### PR TITLE
Add APIs for getting number of body/overlay component builders in a view model builder

### DIFF
--- a/include/HubFramework/HUBViewModelBuilder.h
+++ b/include/HubFramework/HUBViewModelBuilder.h
@@ -41,9 +41,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Whether this builder is currently empty, and does not contain any content
  *
- *  As soon as any header or body component model has been added to this builder, it is no longer considered empty
+ *  As soon as any header, body or overlay component model has been added to this builder, it is no longer considered empty
  */
 @property (nonatomic, readonly) BOOL isEmpty;
+
+/// The number of body component model builders that this builder contains
+@property (nonatomic, readonly) NSUInteger numberOfBodyComponentModelBuilders;
+
+/// The number of overlay component model builders that this builder contains
+@property (nonatomic, readonly) NSUInteger numberOfOverlayComponentModelBuilders;
 
 #pragma mark - Identifier
 
@@ -133,6 +139,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return All the existing body component model builders, in the order that they were created. Note that
  *  any `preferredIndex` set by the component model builders hasn't been resolved at this point, so those
  *  are not taken into account.
+ *
+ *  If you just want to check the current number of body component model builders, it's better to use the
+ *  `numberOfBodyComponentModelBuilders` property, as it's faster.
  */
 - (NSArray<id<HUBComponentModelBuilder>> *)allBodyComponentModelBuilders;
 
@@ -142,6 +151,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return All the existing overlay component model builders, in the order that they were created. Note that
  *  any `preferredIndex` set by the component model builders hasn't been resolved at this point, so those
  *  are not taken into account.
+ *
+ *  If you just want to check the current number of overlay component model builders, it's better to use the
+ *  `numberOfOverlayComponentModelBuilders` property, as it's faster.
  */
 - (NSArray<id<HUBComponentModelBuilder>> *)allOverlayComponentModelBuilders;
 

--- a/sources/HUBViewModelBuilderImplementation.m
+++ b/sources/HUBViewModelBuilderImplementation.m
@@ -80,24 +80,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBViewModelBuilder
 
-- (nullable NSError *)addJSONData:(NSData *)JSONData
+- (BOOL)isEmpty
 {
-    NSError *error;
-    NSObject *JSONObject = [NSJSONSerialization JSONObjectWithData:JSONData options:NSJSONReadingAllowFragments error:&error];
-    
-    if (error != nil || JSONObject == nil) {
-        return error;
+    if (self.headerComponentModelBuilderImplementation != nil) {
+        return NO;
     }
     
-    if ([JSONObject isKindOfClass:[NSDictionary class]]) {
-        [self addDataFromJSONDictionary:(NSDictionary *)JSONObject];
-    } else if ([JSONObject isKindOfClass:[NSArray class]]) {
-        [self addDataFromJSONArray:(NSArray *)JSONObject];
-    } else {
-        return [NSError errorWithDomain:@"spotify.com.hubFramework.invalidJSON" code:0 userInfo:nil];
+    if (self.bodyComponentModelBuilders.count > 0) {
+        return NO;
     }
     
-    return nil;
+    if (self.overlayComponentModelBuilders.count > 0) {
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (NSUInteger)numberOfBodyComponentModelBuilders
+{
+    return self.bodyComponentModelBuilders.count;
+}
+
+- (NSUInteger)numberOfOverlayComponentModelBuilders
+{
+    return self.overlayComponentModelBuilders.count;
 }
 
 - (id<HUBComponentModelBuilder>)headerComponentModelBuilder
@@ -215,23 +222,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - API
 
-- (BOOL)isEmpty
-{
-    if (self.headerComponentModelBuilderImplementation != nil) {
-        return NO;
-    }
-    
-    if (self.bodyComponentModelBuilders.count > 0) {
-        return NO;
-    }
-    
-    if (self.overlayComponentModelBuilders.count > 0) {
-        return NO;
-    }
-    
-    return YES;
-}
-
 - (id<HUBViewModel>)build
 {
     id<HUBComponentModel> const headerComponentModel = [self.headerComponentModelBuilderImplementation buildForIndex:0 parent:nil];
@@ -254,6 +244,26 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - HUBJSONCompatibleBuilder
+
+- (nullable NSError *)addJSONData:(NSData *)JSONData
+{
+    NSError *error;
+    NSObject *JSONObject = [NSJSONSerialization JSONObjectWithData:JSONData options:NSJSONReadingAllowFragments error:&error];
+    
+    if (error != nil || JSONObject == nil) {
+        return error;
+    }
+    
+    if ([JSONObject isKindOfClass:[NSDictionary class]]) {
+        [self addDataFromJSONDictionary:(NSDictionary *)JSONObject];
+    } else if ([JSONObject isKindOfClass:[NSArray class]]) {
+        [self addDataFromJSONArray:(NSArray *)JSONObject];
+    } else {
+        return [NSError errorWithDomain:@"spotify.com.hubFramework.invalidJSON" code:0 userInfo:nil];
+    }
+    
+    return nil;
+}
 
 - (void)addDataFromJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary
 {

--- a/tests/HUBViewModelBuilderTests.m
+++ b/tests/HUBViewModelBuilderTests.m
@@ -98,6 +98,19 @@
     XCTAssertNil(self.builder.headerComponentModelBuilder.title);
 }
 
+- (void)testNumberOfBodyComponentModelBuilders
+{
+    [self.builder builderForBodyComponentModelWithIdentifier:@"A"];
+    [self.builder builderForBodyComponentModelWithIdentifier:@"B"];
+    [self.builder builderForBodyComponentModelWithIdentifier:@"C"];
+    
+    XCTAssertEqual(self.builder.numberOfBodyComponentModelBuilders, (NSUInteger)3);
+    
+    [self.builder removeBuilderForBodyComponentModelWithIdentifier:@"B"];
+    
+    XCTAssertEqual(self.builder.numberOfBodyComponentModelBuilders, (NSUInteger)2);
+}
+
 - (void)testAllBodyComponentModelBuilders
 {
     NSMutableArray * const bodyComponentModelBuilders = [NSMutableArray new];
@@ -107,6 +120,19 @@
     [bodyComponentModelBuilders addObject:[self.builder builderForBodyComponentModelWithIdentifier:@"D"]];
     
     XCTAssertEqualObjects([self.builder allBodyComponentModelBuilders], bodyComponentModelBuilders);
+}
+
+- (void)testNumberOfOverlayComponentModelBuilders
+{
+    [self.builder builderForOverlayComponentModelWithIdentifier:@"A"];
+    [self.builder builderForOverlayComponentModelWithIdentifier:@"B"];
+    [self.builder builderForOverlayComponentModelWithIdentifier:@"C"];
+    
+    XCTAssertEqual(self.builder.numberOfOverlayComponentModelBuilders, (NSUInteger)3);
+    
+    [self.builder removeBuilderForOverlayComponentModelWithIdentifier:@"B"];
+    
+    XCTAssertEqual(self.builder.numberOfOverlayComponentModelBuilders, (NSUInteger)2);
 }
 
 - (void)testAllOverlayComponentModelBuilders


### PR DESCRIPTION
Previously, you could get the number of body or overlay component model builders contained within a view model builder by enumerating them. This was a bit wasteful if all you’re looking for is the count, so these new APIs are more efficient for that use case.

Also do some slight reordering of methods in the implementation to match the way the header is declared.
