### PR TITLE
[Demo app] Clean up GitHub Search code + add comments

### DIFF
--- a/demo/sources/GitHubSearchActivityIndicatorContentOperation.swift
+++ b/demo/sources/GitHubSearchActivityIndicatorContentOperation.swift
@@ -27,15 +27,15 @@ class GitHubSearchActivityIndicatorContentOperation: NSObject, HUBContentOperati
     weak var delegate: HUBContentOperationDelegate?
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {
-        if let searchString = viewModelBuilder.customData?[GitHubSearchCustomDataKeys.searchString] as? String,
-            searchString.characters.count > 0 {
-            if viewModelBuilder.allBodyComponentModelBuilders().count == 1 {
-                if viewModelBuilder.allOverlayComponentModelBuilders().isEmpty {
-                    let activityIndicatorBuilder = viewModelBuilder.builderForOverlayComponentModel(withIdentifier: "activityIndicator")
-                    activityIndicatorBuilder.componentName = DefaultComponentNames.activityIndicator
-                }
-            }
+        // If no search is in progress, there's no need for an activity indicator
+        guard viewModelBuilder.customData?[GitHubSearchCustomDataKeys.searchInProgress] as? Bool == true else {
+            delegate?.contentOperationDidFinish(self)
+            return
         }
+        
+        // Add an activity indicator overlay component
+        let activityIndicatorBuilder = viewModelBuilder.builderForOverlayComponentModel(withIdentifier: "activityIndicator")
+        activityIndicatorBuilder.componentName = DefaultComponentNames.activityIndicator
         
         delegate?.contentOperationDidFinish(self)
     }

--- a/demo/sources/GitHubSearchBarContentOperation.swift
+++ b/demo/sources/GitHubSearchBarContentOperation.swift
@@ -29,10 +29,13 @@ class GitHubSearchBarContentOperation: NSObject, HUBContentOperationActionObserv
     private var searchActionIdentifier: HUBIdentifier { return HUBIdentifier(namespace: "github", name: "search") }
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {
+        // Encode any search string that was passed from the search bar component
+        // (through an action) into the view model builder's custom data
         var viewModelCustomData = viewModelBuilder.customData ?? [:]
         viewModelCustomData[GitHubSearchCustomDataKeys.searchString] = searchString
         viewModelBuilder.customData = viewModelCustomData
         
+        // Add the search bar
         let searchBarBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "searchBar")
         searchBarBuilder.componentName = DefaultComponentNames.searchBar
         searchBarBuilder.customData = [
@@ -52,6 +55,9 @@ class GitHubSearchBarContentOperation: NSObject, HUBContentOperationActionObserv
             return
         }
         
+        // Save the search sting that was entered, and reschedule this operation to fetch new results
+        // See `GitHubSearchResultsContentOperation`, which comes after this one, for the actual fetching
+        // of results.
         self.searchString = searchString
         delegate?.contentOperationRequiresRescheduling(self)
     }

--- a/demo/sources/GitHubSearchCustomDataKeys.swift
+++ b/demo/sources/GitHubSearchCustomDataKeys.swift
@@ -25,4 +25,7 @@ import Foundation
 struct GitHubSearchCustomDataKeys {
     /// Key used to encode a search string into a view model builder's custom data
     static var searchString: String { return "searchString" }
+    /// Key used to encode a Boolean indicating whether a search is currently in
+    /// progess into a view model builder's custom data
+    static var searchInProgress: String { return "searchInProgress" }
 }

--- a/demo/sources/GitHubSearchResultsContentOperation.swift
+++ b/demo/sources/GitHubSearchResultsContentOperation.swift
@@ -35,58 +35,75 @@ import HubFramework
  */
 class GitHubSearchResultsContentOperation: NSObject, HUBContentOperation {
     weak var delegate: HUBContentOperationDelegate?
+    private var dataTask: URLSessionDataTask?
     private var jsonData: Data?
-    private var searchString: String?
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {
+        // Exit early in case the user hasn't entered a search string yet (set by `GitHubSearchBarContentOperation`)
         guard let searchString = viewModelBuilder.customData?[GitHubSearchCustomDataKeys.searchString] as? String else {
-            finishWithoutPerforming()
+            finishAndResetState()
             return
         }
 
+        // Also exit if the search string is empty (no need to call the GitHub web API)
         guard searchString.characters.count > 0 else {
-            finishWithoutPerforming()
+            finishAndResetState()
             return
-        }
-
-        if searchString != self.searchString {
-            self.searchString = searchString
-
-            if let requestURL = URL(string: "https://api.github.com/search/repositories?q=" + searchString) {
-                let dataTask = URLSession.shared.dataTask(with: requestURL) { [weak self] data, _, _ in
-                    DispatchQueue.main.async {
-                        guard let strongSelf = self else {
-                            return
-                        }
-                        
-                        if let data = data {
-                            strongSelf.jsonData = data
-                        }
-                        
-                        strongSelf.delegate?.contentOperationRequiresRescheduling(strongSelf)
-                    }
-                }
-                
-                dataTask.resume()
-            }
         }
         
-        if let jsonData = self.jsonData {
+        // If we've already downloaded JSON data, add it to the view and flush our state
+        if let jsonData = jsonData {
             viewModelBuilder.addJSONData(jsonData)
             
-            if viewModelBuilder.allBodyComponentModelBuilders().count == 1 {
+            // If the data didn't contain any components (we only have 1 = the search bar), add a
+            // "No results found" label as an overlay component
+            if viewModelBuilder.numberOfBodyComponentModelBuilders == 1 {
                 let noResultsLabelBuilder = viewModelBuilder.builderForOverlayComponentModel(withIdentifier: "noResultsLabel")
                 noResultsLabelBuilder.componentName = DefaultComponentNames.label
                 noResultsLabelBuilder.title = "No results found"
             }
+            
+            finishAndResetState()
+            return
         }
-
-        self.delegate?.contentOperationDidFinish(self)
+        
+        // Abort any currently running data task (since it's now outdated)
+        dataTask?.cancel()
+        
+        // Make sure we have a valid search string (that can be URL encoded)
+        guard let requestURL = URL(string: "https://api.github.com/search/repositories?q=" + searchString) else {
+            finishAndResetState()
+            return
+        }
+        
+        // Create the data task that'll download JSON and save it for the next execution
+        dataTask = URLSession.shared.dataTask(with: requestURL) { [weak self] data, _, _ in
+            guard let strongSelf = self else {
+                return
+            }
+            
+            guard let jsonData = data else {
+                return
+            }
+            
+            // Once we have data, we'll reschedule our operation to go back to the top and add it to the view
+            strongSelf.jsonData = jsonData
+            strongSelf.delegate?.contentOperationRequiresRescheduling(strongSelf)
+        }
+        
+        // Encode that a search will be performed (will be picked up by `GitHubSearchActivityIndicatorContentOperation`)
+        var customData = viewModelBuilder.customData ?? [:]
+        customData[GitHubSearchCustomDataKeys.searchInProgress] = true
+        viewModelBuilder.customData = customData
+        
+        // Tell our delegate we're done (to enable to UI to be rendered), then start the task
+        delegate?.contentOperationDidFinish(self)
+        dataTask?.resume()
     }
     
-    private func finishWithoutPerforming() {
+    private func finishAndResetState() {
         jsonData = nil
-        searchString = nil
+        dataTask = nil
         delegate?.contentOperationDidFinish(self)
     }
 }


### PR DESCRIPTION
The GitHub Search content operation code was a bit hackily implemented (I blame it on lack of coffee! 😅), and since it’s a bit complicated, it also suffered from not being commented.

Both of these issues have now been fixed, it should now be a lot simpler to follow as it has a more streamlined implementation and comments explaining why we’re doing what we’re doing.
