### PR TITLE
[Demo app] Add offline label to GitHub Search feature

### DIFF
--- a/demo/sources/GitHubSearchResultsContentOperation.swift
+++ b/demo/sources/GitHubSearchResultsContentOperation.swift
@@ -39,6 +39,16 @@ class GitHubSearchResultsContentOperation: NSObject, HUBContentOperation {
     private var jsonData: Data?
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {
+        // If we're offline, we won't be able to call the GitHub web API, so let the user know by adding a label and exit early
+        guard connectivityState == .online else {
+            let offlineLabelBuilder = viewModelBuilder.builderForOverlayComponentModel(withIdentifier: "offlineLabel")
+            offlineLabelBuilder.componentName = DefaultComponentNames.label
+            offlineLabelBuilder.title = "You're offline.\nGo online to search GitHub."
+            
+            finishAndResetState()
+            return
+        }
+        
         // Exit early in case the user hasn't entered a search string yet (set by `GitHubSearchBarContentOperation`)
         guard let searchString = viewModelBuilder.customData?[GitHubSearchCustomDataKeys.searchString] as? String else {
             finishAndResetState()

--- a/demo/sources/LabelComponent.swift
+++ b/demo/sources/LabelComponent.swift
@@ -40,6 +40,7 @@ class LabelComponent: NSObject, HUBComponent {
     }
 
     func loadView() {
+        label.numberOfLines = 0
         label.font = font
         view = label
     }


### PR DESCRIPTION
This change adds an “You’re offline”-label to the GitHub search feature that shows up if the connectivity state is offline (since we won’t be able to call the GitHub Web API then anyway).

It also makes the LabelComponent in the demo app able to render multiple lines of text.
