### PR TITLE
Add configuration of Cocoadocs

### DIFF
--- a/.cocoadocs.yml
+++ b/.cocoadocs.yml
@@ -1,0 +1,9 @@
+highlight-color: '#1db954'
+highlight-dark-color: '#1da74d'
+
+darker-color: '#999999'
+darker-dark-color: '#4c4c4c'
+
+background-color: '#F2F2F2'
+alt-link-color: '#006450'
+warning-color: '#ff6437'


### PR DESCRIPTION
So we get Spotify-y colors. Copied from [SPTDataLoader](https://github.com/spotify/SPTDataLoader/blob/master/.cocoadocs.yml).

@JohnSundell @spotify/objc-dev 