### PR TITLE
Fix an issue demo app build fails by removing Library Search Paths

### DIFF
--- a/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
+++ b/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
@@ -493,7 +493,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/**";
+				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.HubFrameworkDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = ../;
@@ -508,7 +508,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/resources/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/**";
+				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.HubFrameworkDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_INCLUDE_PATHS = ../;


### PR DESCRIPTION
Hi Spotify team and @JohnSundell! I cloned the repo and tried to build and run the demo app on iOS simulator, but I got the following error. The project under DerivedData is not related to the HubFramework demo project at all:
```
Dependency Analysis Error

Check dependencies
Argument list too long: recursive header expansion failed at /Users/keitaito/Library/Developer/Xcode/DerivedData/test-rbenv-03132016-axujngqvejimbiehvegvqqlckgub/Index/Debug/iphonesimulator9.2-x86_64/test-rbenv-03132016.xcindex.
```

To fix the error, I changed project settings. I removed a path from "Library Search Paths" under "Search Paths" section in "Build Settings". 
```
$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData (with recursive option)
```
This path is displayed as like this:
```
/Users/keitaito/LibraryDeveloper/Xcode/DerivedData/**
```

And, now I can build and run the demo app :)

Does this issue happen with only me? And, I'm not 100% sure if this fix is the right solution. Is it possible for you to review this PR? Please let me know if you know something with this issue. Thank you!

My Environment: Xcode Version 8.0 (8A218a). Used iOS simulator "iPhone 7 Plus". I ran unit tests for HubFramework with this fix, and all tests succeeded (though I didn't change anything in HubFramework).

Reference: http://stackoverflow.com/questions/3490629/error-argument-list-too-longrecursive-header-expansion-failed-at-application