### PR TITLE
Fix `ignoredAutoEquatablePropertyNames` not compiling for device

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		9996E9691C6A42E000231D22 /* HUBComponentFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactory.h; sourceTree = "<group>"; };
 		DD13758E1C68C76000AD3499 /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
 		DD13758F1C68C76000AD3499 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
+		DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBKeyPath.h; sourceTree = "<group>"; };
 		DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBUtilities.h; sourceTree = "<group>"; };
 		DDBCF36B1C68DD2300693038 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -495,10 +496,11 @@
 		8A2061101CCA1971008C34E3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */,
-				8ACB2A791C6A2F7C000741D7 /* HUBIdentifier.m */,
 				8ADA48551D784C1400C27F21 /* HUBAutoEquatable.h */,
 				8ADA48561D784C1400C27F21 /* HUBAutoEquatable.m */,
+				8ACB2A791C6A2F7C000741D7 /* HUBIdentifier.m */,
+				DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */,
+				DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -506,9 +508,9 @@
 		8A2061111CCA1992008C34E3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				8A5D7A5A1CB806E200B987BA /* HUBHeaderMacros.h */,
 				8AF21C9D1C6D044700960A06 /* HUBIdentifier.h */,
 				8A0E4B801CB69CD80019DE71 /* HUBSerializable.h */,
-				8A5D7A5A1CB806E200B987BA /* HUBHeaderMacros.h */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -28,6 +28,7 @@
 #import "HUBViewModel.h"
 #import "HUBUtilities.h"
 #import "HUBIcon.h"
+#import "HUBKeyPath.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -64,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSSet<NSString *> *)ignoredAutoEquatablePropertyNames
 {
-    return [NSSet setWithObjects:NSStringFromSelector(@selector(parent)), NSStringFromSelector(@selector(index)), nil];
+    return [NSSet setWithObjects:HUBKeyPath((id<HUBComponentModel>)nil, parent), HUBKeyPath((id<HUBComponentModel>)nil, index), nil];
 }
 
 #pragma mark - Initializer

--- a/sources/HUBKeyPath.h
+++ b/sources/HUBKeyPath.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+/**
+ *  Returns a key-path string that has been validated at compile-time.
+ *
+ *  ```objc
+ *  HUBKeyPath(self.object, property) => @"property"
+ *  HUBKeyPath(self, object.property) => @"object.property"
+ *  ```
+ *
+ *  In a class method (such as `keyPathsForValuesAffectingvalueForKey:`) you can cast `nil` to a instance pointer
+ *  `HUBKeyPath((MyClass *)nil, property) => @"property"`
+ */
+#ifndef HUBKeyPath
+    #define HUBKeyPath(object, property) ((void)(NO && ((void)(object).property, NO)), @#property)
+#endif


### PR DESCRIPTION
The `index` selector reference was ambiguous and the build would fail. This change resolves that by introducing a typed and compile time checked key-path to string macro.

@spotify/objc-dev 