### PR TITLE
Bump Jazzy config & Podspec to 2.0.1

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -6,7 +6,7 @@ readme: README.md
 documentation: documentation/*.md
 
 module: HubFramework
-module_version: v2.0.0
+module_version: v2.0.1
 
 output: documentation/output
 theme: fullwidth

--- a/HubFramework.podspec
+++ b/HubFramework.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name         = "HubFramework"
-    s.version      = "2.0.0"
+    s.version      = "2.0.1"
     s.summary      = "Spotify's component-driven UI framework for iOS"
 
     s.description  = <<-DESC


### PR DESCRIPTION
Following the release of version `2.0.1`