### PR TITLE
Add support for UINavigationItem

### DIFF
--- a/include/HubFramework/HUBViewModel.h
+++ b/include/HubFramework/HUBViewModel.h
@@ -20,9 +20,9 @@
  */
 
 #import "HUBSerializable.h"
-#import <UIKit/UIKit.h>
 
 @protocol HUBComponentModel;
+@class UINavigationItem;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/include/HubFramework/HUBViewModel.h
+++ b/include/HubFramework/HUBViewModel.h
@@ -20,6 +20,7 @@
  */
 
 #import "HUBSerializable.h"
+#import <UIKit/UIKit.h>
 
 @protocol HUBComponentModel;
 
@@ -47,11 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly, nullable) NSString *identifier;
 
 /**
- *  The title that should be displayed in the view's navigation bar
- *
- *  The value of this property will be assigned to the view controller's title property
+ *  The navigation item that the view should use when presented in a `UINavigationController`
  */
-@property (nonatomic, copy, readonly, nullable) NSString *navigationBarTitle;
+@property (nonatomic, copy, readonly, nullable) UINavigationItem *navigationItem;
 
 #pragma mark - Component models
 

--- a/include/HubFramework/HUBViewModelBuilder.h
+++ b/include/HubFramework/HUBViewModelBuilder.h
@@ -20,6 +20,7 @@
  */
 
 #import "HUBJSONCompatibleBuilder.h"
+#import <UIKit/UIKit.h>
 
 @protocol HUBComponentModelBuilder;
 
@@ -68,9 +69,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The title that the view should have in the navigation bar
  *
- *  The value of this property will be assigned to the view controller's title property
+ *  This property is an alias for `navigationItem.title`.
  */
 @property (nonatomic, copy, nullable) NSString *navigationBarTitle;
+
+/**
+ *  The navigation item that the view should use when presented in a `UINavigationController`
+ *
+ *  You can use this navigation item to set what title, bar buttons etc that the view's navigation bar
+ *  should contain. Only relevant when the view's controller is added to a container view controller.
+ */
+@property (nonatomic, strong, readonly) UINavigationItem *navigationItem;
 
 /**
  *  The builder to use to build a model for the view's header component

--- a/include/HubFramework/HUBViewModelBuilder.h
+++ b/include/HubFramework/HUBViewModelBuilder.h
@@ -20,9 +20,9 @@
  */
 
 #import "HUBJSONCompatibleBuilder.h"
-#import <UIKit/UIKit.h>
 
 @protocol HUBComponentModelBuilder;
+@class UINavigationItem;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/sources/HUBAutoEquatable.m
+++ b/sources/HUBAutoEquatable.m
@@ -23,6 +23,8 @@
 
 #import <objc/runtime.h>
 
+#import "HUBUtilities.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef BOOL(^HUBAutoEquatableComparisonBlock)(NSObject *, NSObject *);
@@ -92,14 +94,7 @@ typedef NSMutableDictionary<NSString *, HUBAutoEquatableComparisonBlock> HUBAuto
             }
             
             mutableComparisonMap[propertyName] = ^(NSObject * const objectA, NSObject * const objectB) {
-                NSObject * const valueA = [objectA valueForKey:propertyName];
-                NSObject * const valueB = [objectB valueForKey:propertyName];
-                
-                if (valueA == nil && valueB == nil) {
-                    return YES;
-                }
-                
-                return [valueA isEqual:valueB];
+                return HUBPropertyIsEqual(objectA, objectB, propertyName);
             };
         }
         

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -298,7 +298,8 @@ NS_ASSUME_NONNULL_BEGIN
         self.lastViewModelDiff = [HUBViewModelDiff diffFromViewModel:currentModel toViewModel:viewModel];
     }
     
-    self.title = viewModel.navigationBarTitle;
+    HUBCopyNavigationItemProperties(self.navigationItem, viewModel.navigationItem);
+    
     self.viewModel = viewModel;
     self.viewModelIsInitial = NO;
     self.viewModelHasChangedSinceLastLayoutUpdate = YES;

--- a/sources/HUBViewModelBuilderImplementation.m
+++ b/sources/HUBViewModelBuilderImplementation.m
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) id<HUBJSONSchema> JSONSchema;
 @property (nonatomic, strong, readonly) HUBComponentDefaults *componentDefaults;
 @property (nonatomic, strong, nullable, readonly) id<HUBIconImageResolver> iconImageResolver;
+@property (nonatomic, strong, nullable) UINavigationItem *navigationItemImplementation;
 @property (nonatomic, strong, nullable) HUBComponentModelBuilderImplementation *headerComponentModelBuilderImplementation;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, HUBComponentModelBuilderImplementation *> *bodyComponentModelBuilders;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, HUBComponentModelBuilderImplementation *> *overlayComponentModelBuilders;
@@ -50,7 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Property synthesization
 
 @synthesize viewIdentifier = _viewIdentifier;
-@synthesize navigationBarTitle = _navigationBarTitle;
 @synthesize extensionURL = _extensionURL;
 @synthesize customData = _customData;
 
@@ -105,6 +105,31 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSUInteger)numberOfOverlayComponentModelBuilders
 {
     return self.overlayComponentModelBuilders.count;
+}
+
+- (nullable NSString *)navigationBarTitle
+{
+    return self.navigationItemImplementation.title;
+}
+
+- (void)setNavigationBarTitle:(nullable NSString *)navigationBarTitle
+{
+    if (navigationBarTitle != nil) {
+        self.navigationItem.title = navigationBarTitle;
+        return;
+    }
+    
+    self.navigationItemImplementation.title = nil;
+}
+
+- (UINavigationItem *)navigationItem
+{
+    if (self.navigationItemImplementation == nil) {
+        self.navigationItemImplementation = [UINavigationItem new];
+    }
+    
+    UINavigationItem * const navigationItem = self.navigationItemImplementation;
+    return navigationItem;
 }
 
 - (id<HUBComponentModelBuilder>)headerComponentModelBuilder
@@ -235,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                                                 parent:nil];
     
     return [[HUBViewModelImplementation alloc] initWithIdentifier:self.viewIdentifier
-                                               navigationBarTitle:self.navigationBarTitle
+                                                   navigationItem:self.navigationItemImplementation
                                              headerComponentModel:headerComponentModel
                                               bodyComponentModels:bodyComponentModels
                                            overlayComponentModels:overlayComponentModels
@@ -339,8 +364,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                                  componentDefaults:self.componentDefaults
                                                                                                  iconImageResolver:self.iconImageResolver];
     
+    if (self.navigationItemImplementation != nil) {
+        HUBCopyNavigationItemProperties(copy.navigationItem, self.navigationItemImplementation);
+    }
+    
     copy.viewIdentifier = self.viewIdentifier;
-    copy.navigationBarTitle = self.navigationBarTitle;
     copy.extensionURL = self.extensionURL;
     copy.customData = self.customData;
     copy.headerComponentModelBuilderImplementation = [self.headerComponentModelBuilderImplementation copy];

--- a/sources/HUBViewModelImplementation.h
+++ b/sources/HUBViewModelImplementation.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Initialize an instance of this class with its possible values
  *
  *  @param identifier The identifier of the view
- *  @param navigationBarTitle The title that the view should have in the navigation bar
+ *  @param navigationItem Any navigation item that should be used for the view's controller
  *  @param headerComponentModel The model for any component that make up the view's header
  *  @param bodyComponentModels The models for the components that make up the view's body
  *  @param overlayComponentModels The models for the components that will be rendered as overlays
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param customData Any custom data that should be associated with the view
  */
 - (instancetype)initWithIdentifier:(nullable NSString *)identifier
-                navigationBarTitle:(nullable NSString *)navigationBarTitle
+                    navigationItem:(nullable UINavigationItem *)navigationItem
               headerComponentModel:(nullable id<HUBComponentModel>)headerComponentModel
                bodyComponentModels:(NSArray<id<HUBComponentModel>> *)bodyComponentModels
             overlayComponentModels:(NSArray<id<HUBComponentModel>> *)overlayComponentModels

--- a/tests/HUBComponentModelBuilderTests.m
+++ b/tests/HUBComponentModelBuilderTests.m
@@ -406,7 +406,7 @@
     XCTAssertEqualObjects(model.customImageData[customImageIdentifier].placeholderIcon.identifier, customImagePlaceholderIdentifier);
     XCTAssertEqualObjects(model.icon.identifier, iconIdentifier);
     XCTAssertEqualObjects(model.target.URI, targetURL);
-    XCTAssertEqualObjects(model.target.initialViewModel.navigationBarTitle, targetTitle);
+    XCTAssertEqualObjects(model.target.initialViewModel.navigationItem.title, targetTitle);
     XCTAssertEqual(model.target.actionIdentifiers.count, (NSUInteger)1);
     XCTAssertEqualObjects(model.target.actionIdentifiers.firstObject, targetActionIdentifier);
     

--- a/tests/HUBComponentModelTests.m
+++ b/tests/HUBComponentModelTests.m
@@ -77,7 +77,7 @@
         
         NSURL * const targetURI = [NSURL URLWithString:@"spotify:hub:framework"];
         HUBViewModelImplementation * const targetInitialViewModel = [[HUBViewModelImplementation alloc] initWithIdentifier:nil
-                                                                                                        navigationBarTitle:nil
+                                                                                                            navigationItem:nil
                                                                                                       headerComponentModel:nil
                                                                                                        bodyComponentModels:@[]
                                                                                                     overlayComponentModels:@[]

--- a/tests/HUBComponentTargetBuilderTests.m
+++ b/tests/HUBComponentTargetBuilderTests.m
@@ -75,7 +75,7 @@
     id<HUBComponentTarget> const target = [self.builder build];
     
     XCTAssertEqualObjects(target.URI, URI);
-    XCTAssertEqualObjects(target.initialViewModel.navigationBarTitle, initialViewModelNavigationBarTitle);
+    XCTAssertEqualObjects(target.initialViewModel.navigationItem.title, initialViewModelNavigationBarTitle);
     XCTAssertEqualObjects(target.actionIdentifiers, @[actionIdentifier]);
     XCTAssertEqualObjects(target.customData, customData);
     
@@ -83,7 +83,7 @@
     id<HUBComponentTarget> const copiedBuilderTarget = [copiedBuilder build];
     
     XCTAssertEqualObjects(copiedBuilderTarget.URI, URI);
-    XCTAssertEqualObjects(copiedBuilderTarget.initialViewModel.navigationBarTitle, initialViewModelNavigationBarTitle);
+    XCTAssertEqualObjects(copiedBuilderTarget.initialViewModel.navigationItem.title, initialViewModelNavigationBarTitle);
     XCTAssertEqualObjects(copiedBuilderTarget.actionIdentifiers, @[actionIdentifier]);
     XCTAssertEqualObjects(copiedBuilderTarget.customData, customData);
 }

--- a/tests/HUBInitialViewModelRegistryTests.m
+++ b/tests/HUBInitialViewModelRegistryTests.m
@@ -41,7 +41,7 @@
 - (void)testRegisteringRetrievingAndRemovingInitialViewModel
 {
     id<HUBViewModel> const viewModel = [[HUBViewModelImplementation alloc] initWithIdentifier:@"id"
-                                                                           navigationBarTitle:nil
+                                                                               navigationItem:nil
                                                                          headerComponentModel:nil
                                                                           bodyComponentModels:@[]
                                                                        overlayComponentModels:@[]

--- a/tests/HUBJSONSchemaRegistryTests.m
+++ b/tests/HUBJSONSchemaRegistryTests.m
@@ -96,8 +96,8 @@
     id<HUBViewModel> const originalViewModel = [originalSchema viewModelFromJSONDictionary:dictionary];
     id<HUBViewModel> const copiedViewModel = [copiedSchema viewModelFromJSONDictionary:dictionary];
     
-    XCTAssertEqual(originalViewModel.navigationBarTitle, title);
-    XCTAssertEqual(originalViewModel.navigationBarTitle, copiedViewModel.navigationBarTitle);
+    XCTAssertEqual(originalViewModel.navigationItem.title, title);
+    XCTAssertEqual(originalViewModel.navigationItem.title, copiedViewModel.navigationItem.title);
 }
 
 - (void)testCopyingUknownSchemaReturningNil

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -200,7 +200,7 @@
     
     [self simulateViewControllerLayoutCycle];
     
-    XCTAssertEqualObjects(self.viewModelFromDelegateMethod.navigationBarTitle, viewModelNavBarTitleA);
+    XCTAssertEqualObjects(self.viewModelFromDelegateMethod.navigationItem.title, viewModelNavBarTitleA);
     
     self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> builder) {
         builder.navigationBarTitle = viewModelNavBarTitleB;
@@ -210,7 +210,7 @@
     self.contentReloadPolicy.shouldReload = YES;
     [self.viewController viewWillAppear:YES];
     
-    XCTAssertEqualObjects(self.viewModelFromDelegateMethod.navigationBarTitle, viewModelNavBarTitleB);
+    XCTAssertEqualObjects(self.viewModelFromDelegateMethod.navigationItem.title, viewModelNavBarTitleB);
 }
 
 - (void)testDelegateNotifiedOfViewModelUpdateError
@@ -1624,16 +1624,20 @@
     XCTAssertEqual(self.contentOperation.actionContext, actionContext);
 }
 
-- (void)testAssigningTitle
+- (void)testAssigningNavigationItemProperties
 {
+    UIBarButtonItem * const rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:[UIView new]];
+    
     self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
         viewModelBuilder.navigationBarTitle = @"Nav bar title";
+        viewModelBuilder.navigationItem.rightBarButtonItem = rightBarButtonItem;
         return YES;
     };
     
     [self simulateViewControllerLayoutCycle];
     
-    XCTAssertEqualObjects(self.viewController.title, @"Nav bar title");
+    XCTAssertEqualObjects(self.viewController.navigationItem.title, @"Nav bar title");
+    XCTAssertEqualObjects(self.viewController.navigationItem.rightBarButtonItem, rightBarButtonItem);
 }
 
 - (void)testAdaptingOverlayComponentCenterPointToKeyboard

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -60,8 +60,10 @@
 
 - (id<HUBViewModel>)createViewModelWithIdentifier:(NSString *)identifier components:(NSArray<id<HUBComponentModel>> *)components
 {
+    UINavigationItem * const navigationItem = [[UINavigationItem alloc] initWithTitle:@"Title"];
+    
     return [[HUBViewModelImplementation alloc] initWithIdentifier:identifier
-                                               navigationBarTitle:@"Title"
+                                                   navigationItem:navigationItem
                                              headerComponentModel:nil
                                               bodyComponentModels:components
                                            overlayComponentModels:@[]

--- a/tests/HUBViewModelLoaderTests.m
+++ b/tests/HUBViewModelLoaderTests.m
@@ -90,11 +90,11 @@
                           connectivityState:HUBConnectivityStateOnline
                            initialViewModel:nil];
     
-    XCTAssertEqualObjects(self.loader.initialViewModel.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.loader.initialViewModel.navigationItem.title, @"A title");
     
     // The initial view model should now be cached, so accessing it shouldn't increment the request count
-    XCTAssertEqualObjects(self.loader.initialViewModel.navigationBarTitle, @"A title");
-    XCTAssertEqualObjects(self.loader.initialViewModel.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.loader.initialViewModel.navigationItem.title, @"A title");
+    XCTAssertEqualObjects(self.loader.initialViewModel.navigationItem.title, @"A title");
     
     XCTAssertEqual(numberOfInitialViewModelRequests, (NSUInteger)1);
 }
@@ -124,7 +124,7 @@
                           connectivityState:HUBConnectivityStateOnline
                            initialViewModel:initialViewModel];
     
-    XCTAssertEqualObjects(self.loader.initialViewModel.navigationBarTitle, @"Pre-computed title");
+    XCTAssertEqualObjects(self.loader.initialViewModel.navigationItem.title, @"Pre-computed title");
     XCTAssertFalse(contentOperationCalled);
 }
 
@@ -143,7 +143,7 @@
     [self.loader loadViewModel];
     [contentOperation.delegate contentOperationDidFinish:contentOperation];
     
-    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationItem.title, @"A title");
     XCTAssertNil(self.errorFromFailureDelegateMethod);
 }
 
@@ -194,7 +194,7 @@
     XCTAssertEqualObjects(contentOperationB.previousContentOperationError, error);
     [contentOperationB.delegate contentOperationDidFinish:contentOperationB];
     
-    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationItem.title, @"A title");
     XCTAssertNil(self.errorFromFailureDelegateMethod);
 }
 
@@ -250,19 +250,19 @@
     
     [contentOperationDelegate contentOperationDidFinish:contentOperation];
     
-    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationItem.title, @"A title");
     XCTAssertNil(self.errorFromFailureDelegateMethod);
     
     viewModelBuilder.navigationBarTitle = @"Another title";
     [contentOperationDelegate contentOperationDidFinish:contentOperation];
     
-    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationItem.title, @"A title");
     XCTAssertNil(self.errorFromFailureDelegateMethod);
 
     NSError * const error = [NSError errorWithDomain:@"domain" code:7 userInfo:nil];
     [contentOperationDelegate contentOperation:contentOperation didFailWithError:error];
     
-    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationBarTitle, @"A title");
+    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationItem.title, @"A title");
     XCTAssertNil(self.errorFromFailureDelegateMethod);
 }
 
@@ -635,8 +635,8 @@
     
     [self.loader loadViewModel];
     
-    XCTAssertNotNil(self.viewModelFromSuccessDelegateMethod.navigationBarTitle);
-    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationBarTitle,
+    XCTAssertNotNil(self.viewModelFromSuccessDelegateMethod.navigationItem.title);
+    XCTAssertEqualObjects(self.viewModelFromSuccessDelegateMethod.navigationItem.title,
                           self.featureInfo.title);
 }
 

--- a/tests/HUBViewModelTests.m
+++ b/tests/HUBViewModelTests.m
@@ -59,10 +59,11 @@
                                                                         parent:nil];
         };
         
+        UINavigationItem * const navigationItem = [[UINavigationItem alloc] initWithTitle:@"title"];
         NSURL * const extensionURL = [NSURL URLWithString:@"https://spotify.com/viewmodelextension"];
         
         return [[HUBViewModelImplementation alloc] initWithIdentifier:@"identifier"
-                                                   navigationBarTitle:@"title"
+                                                       navigationItem:navigationItem
                                                  headerComponentModel:createComponentModel()
                                                   bodyComponentModels:@[createComponentModel()]
                                                overlayComponentModels:@[createComponentModel()]
@@ -101,10 +102,11 @@
         };
         
         NSString * const title = [NSUUID UUID].UUIDString;
+        UINavigationItem * const navigationItem = [[UINavigationItem alloc] initWithTitle:title];
         NSURL * const extensionURL = [NSURL URLWithString:@"https://spotify.com/viewmodelextension"];
         
         return [[HUBViewModelImplementation alloc] initWithIdentifier:@"identifier"
-                                                   navigationBarTitle:title
+                                                       navigationItem:navigationItem
                                                  headerComponentModel:createComponentModel()
                                                   bodyComponentModels:@[createComponentModel()]
                                                overlayComponentModels:@[createComponentModel()]


### PR DESCRIPTION
This change adds support for setting a `UINavigationItem` on a `HUBViewModel`, which will then be used when its `HUBViewController` is added to a navigation controller.

This is done by replacing `navigationBarTitle` with `navigationItem` on `HUBViewModel` (since you can now just use the navigation item’s title). No backwards compatibility is added here, since the use cases for using a `HUBViewModel` directly are very small.

However, on the builder (`HUBViewModelBuilder`) backwards compatibility is achieved by letting `navigationBarTitle` be an alias for `navigationItem.title`.

Some equality checking code is extracted from `HUBAutoEquatable` into `HUBUtilities` to avoid code duplication.