### PR TITLE
Fix max target content offset after updates

### DIFF
--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -208,7 +208,7 @@ NS_ASSUME_NONNULL_BEGIN
     CGFloat const minContentOffset = -self.collectionView.contentInset.top;
     offset.y = MAX(minContentOffset, offset.y);
     // ...or beyond the bottom.
-    CGFloat maxContentOffset = MAX(self.contentSize.height - CGRectGetHeight(self.collectionView.frame), minContentOffset);
+    CGFloat maxContentOffset = MAX(self.contentSize.height + self.collectionView.contentInset.bottom - CGRectGetHeight(self.collectionView.frame), minContentOffset);
     offset.y = MIN(maxContentOffset, offset.y);
     
     self.previousLayoutAttributesByIndexPath = nil;

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -183,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     for (NSIndexPath *indexPath in self.lastViewModelDiff.insertedBodyComponentIndexPaths) {
         if (indexPath.item <= topmostVisibleIndex) {
-            UICollectionViewLayoutAttributes *attributes = self.previousLayoutAttributesByIndexPath[indexPath];
+            UICollectionViewLayoutAttributes *attributes = self.layoutAttributesByIndexPath[indexPath];
             offset.y += CGRectGetHeight(attributes.frame);
         }
     }
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (NSIndexPath *indexPath in self.lastViewModelDiff.reloadedBodyComponentIndexPaths) {
         if (indexPath.item < topmostVisibleIndex) {
             UICollectionViewLayoutAttributes *oldAttributes = self.previousLayoutAttributesByIndexPath[indexPath];
-            UICollectionViewLayoutAttributes *newAttributes = self.previousLayoutAttributesByIndexPath[indexPath];
+            UICollectionViewLayoutAttributes *newAttributes = self.layoutAttributesByIndexPath[indexPath];
             CGFloat heightDifference = CGRectGetHeight(oldAttributes.frame) - CGRectGetHeight(newAttributes.frame);
             offset.y += heightDifference;
         }


### PR DESCRIPTION
Fixes an issue where the collection view layout wouldn't take the bottom content inset into account when determining the proper offset after updates.

@spotify/objc-dev 