### PR TITLE
Content offset updates for child component

### DIFF
--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -54,7 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param childIndex The index of the child component that is about to appear
  */
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-          childComponent:(HUBComponentWrapper *)childComponent
+          childComponent:(nullable HUBComponentWrapper *)childComponent
+               childView:(UIView *)childComponentView
        willAppearAtIndex:(NSUInteger)childIndex;
 
 /**
@@ -65,7 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param childIndex The index of the child component that disappared
  */
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-          childComponent:(HUBComponentWrapper *)childComponent
+          childComponent:(nullable HUBComponentWrapper *)childComponent
+               childView:(UIView *)childComponentView
      didDisappearAtIndex:(NSUInteger)childIndex;
 
 /**

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param childIndex The index of the child component that is about to appear
  */
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-  childComponentWithView:(UIView *)childComponentView
+          childComponent:(HUBComponentWrapper *)childComponent
        willAppearAtIndex:(NSUInteger)childIndex;
 
 /**
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param childIndex The index of the child component that disappared
  */
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-  childComponentWithView:(UIView *)childComponentView
+          childComponent:(HUBComponentWrapper *)childComponent
      didDisappearAtIndex:(NSUInteger)childIndex;
 
 /**

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Notify the delegate that one of the wrapped component's children is about to appear on the screen
  *
  *  @param componentWrapper The wrapper of the component in which the event occured
+ *  @param childComponent The child component that is about to appear
  *  @param childComponentView The view of the child component that is about to appear
  *  @param childIndex The index of the child component that is about to appear
  */
@@ -62,8 +63,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  Notify the delegate that one of the wrapped component's children disappeared from the screen
  *
  *  @param componentWrapper The wrapper of the component in which the event occured
- *  @param childComponentView The view of the child component that disappared
- *  @param childIndex The index of the child component that disappared
+ *  @param childComponent The child component that disappeared
+ *  @param childComponentView The view of the child component that disappeared
+ *  @param childIndex The index of the child component that disappeared
  */
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
           childComponent:(nullable HUBComponentWrapper *)childComponent

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -228,6 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     for (NSNumber * const childIndex in self.visibleChildViewsByIndex) {
         HUBComponentWrapper * const childComponent = self.childrenByIndex[childIndex];
+        UIView *childView = self.visibleChildViewsByIndex[childIndex];
         
         if (childComponent != nil) {
             [childComponent viewWillAppear];
@@ -235,6 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
         
         [self.delegate componentWrapper:self
                          childComponent:childComponent
+                              childView:childView
                       willAppearAtIndex:childIndex.unsignedIntegerValue];
     }
     
@@ -272,7 +274,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     self.visibleChildViewsByIndex[@(childIndex)] = childView;
-    [self.delegate componentWrapper:self childComponent:childComponent willAppearAtIndex:childIndex];
+    [self.delegate componentWrapper:self
+                     childComponent:childComponent
+                          childView:childView
+                  willAppearAtIndex:childIndex];
 }
 
 - (void)component:(id<HUBComponentWithChildren>)component didStopDisplayingChildAtIndex:(NSUInteger)childIndex view:(UIView *)childView
@@ -283,7 +288,11 @@ NS_ASSUME_NONNULL_BEGIN
     
     HUBComponentWrapper * const childComponent = self.childrenByIndex[@(childIndex)];
     self.visibleChildViewsByIndex[@(childIndex)] = nil;
-    [self.delegate componentWrapper:self childComponent:childComponent didDisappearAtIndex:childIndex];
+
+    [self.delegate componentWrapper:self
+                     childComponent:childComponent
+                          childView:childView
+                didDisappearAtIndex:childIndex];
 }
 
 - (void)component:(id<HUBComponentWithChildren>)component childSelectedAtIndex:(NSUInteger)childIndex

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -227,7 +227,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     for (NSNumber * const childIndex in self.visibleChildViewsByIndex) {
-        UIView * const childView = self.visibleChildViewsByIndex[childIndex];
         HUBComponentWrapper * const childComponent = self.childrenByIndex[childIndex];
         
         if (childComponent != nil) {
@@ -235,7 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         [self.delegate componentWrapper:self
-                 childComponentWithView:childView
+                         childComponent:childComponent
                       willAppearAtIndex:childIndex.unsignedIntegerValue];
     }
     
@@ -273,7 +272,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     self.visibleChildViewsByIndex[@(childIndex)] = childView;
-    [self.delegate componentWrapper:self childComponentWithView:childView willAppearAtIndex:childIndex];
+    [self.delegate componentWrapper:self childComponent:childComponent willAppearAtIndex:childIndex];
 }
 
 - (void)component:(id<HUBComponentWithChildren>)component didStopDisplayingChildAtIndex:(NSUInteger)childIndex view:(UIView *)childView
@@ -282,8 +281,9 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
     
+    HUBComponentWrapper * const childComponent = self.childrenByIndex[@(childIndex)];
     self.visibleChildViewsByIndex[@(childIndex)] = nil;
-    [self.delegate componentWrapper:self childComponentWithView:childView didDisappearAtIndex:childIndex];
+    [self.delegate componentWrapper:self childComponent:childComponent didDisappearAtIndex:childIndex];
 }
 
 - (void)component:(id<HUBComponentWithChildren>)component childSelectedAtIndex:(NSUInteger)childIndex

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -369,7 +369,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-          childComponent:(HUBComponentWrapper *)childComponent
+          childComponent:(nullable HUBComponentWrapper *)childComponent
+               childView:(UIView *)childView
        willAppearAtIndex:(NSUInteger)childIndex
 {
     id<HUBComponentModel> const componentModel = componentWrapper.model;
@@ -380,7 +381,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     id<HUBComponentModel> const childComponentModel = componentModel.children[childIndex];
     [self loadImagesForComponentWrapper:componentWrapper childIndex:@(childIndex)];
-    [self.delegate viewController:self componentWithModel:childComponentModel willAppearInView:childComponent.view];
+    [self.delegate viewController:self componentWithModel:childComponentModel willAppearInView:childView];
 
     if (childComponent.isContentOffsetObserver) {
         [self.contentOffsetObservingComponentWrappers addObject:childComponent];
@@ -388,7 +389,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-          childComponent:(HUBComponentWrapper *)childComponent
+          childComponent:(nullable HUBComponentWrapper *)childComponent
+               childView:(UIView *)childView
      didDisappearAtIndex:(NSUInteger)childIndex
 {
     id<HUBComponentModel> const componentModel = componentWrapper.model;
@@ -398,7 +400,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     id<HUBComponentModel> const childComponentModel = componentModel.children[childIndex];
-    [self.delegate viewController:self componentWithModel:childComponentModel didDisappearFromView:childComponent.view];
+    [self.delegate viewController:self componentWithModel:childComponentModel didDisappearFromView:childView];
 
     if (childComponent.isContentOffsetObserver) {
         [self.contentOffsetObservingComponentWrappers removeObject:childComponent];

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -369,7 +369,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-  childComponentWithView:(UIView *)childComponentView
+          childComponent:(HUBComponentWrapper *)childComponent
        willAppearAtIndex:(NSUInteger)childIndex
 {
     id<HUBComponentModel> const componentModel = componentWrapper.model;
@@ -377,14 +377,18 @@ NS_ASSUME_NONNULL_BEGIN
     if (childIndex >= componentModel.children.count) {
         return;
     }
-    
+
     id<HUBComponentModel> const childComponentModel = componentModel.children[childIndex];
     [self loadImagesForComponentWrapper:componentWrapper childIndex:@(childIndex)];
-    [self.delegate viewController:self componentWithModel:childComponentModel willAppearInView:childComponentView];
+    [self.delegate viewController:self componentWithModel:childComponentModel willAppearInView:childComponent.view];
+
+    if (childComponent.isContentOffsetObserver) {
+        [self.contentOffsetObservingComponentWrappers addObject:childComponent];
+    }
 }
 
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
-  childComponentWithView:(UIView *)childComponentView
+          childComponent:(HUBComponentWrapper *)childComponent
      didDisappearAtIndex:(NSUInteger)childIndex
 {
     id<HUBComponentModel> const componentModel = componentWrapper.model;
@@ -392,9 +396,14 @@ NS_ASSUME_NONNULL_BEGIN
     if (childIndex >= componentModel.children.count) {
         return;
     }
-    
+
     id<HUBComponentModel> const childComponentModel = componentModel.children[childIndex];
-    [self.delegate viewController:self componentWithModel:childComponentModel didDisappearFromView:childComponentView];
+    [self.delegate viewController:self componentWithModel:childComponentModel didDisappearFromView:childComponent.view];
+
+    if (childComponent.isContentOffsetObserver) {
+        [self.contentOffsetObservingComponentWrappers removeObject:childComponent];
+    }
+    
 }
 
 - (void)componentWrapper:(HUBComponentWrapper *)componentWrapper
@@ -463,11 +472,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     [self loadImagesForComponentWrapper:componentWrapper
                              childIndex:nil];
-    
-    if (componentWrapper.isContentOffsetObserver) {
-        [self.contentOffsetObservingComponentWrappers addObject:componentWrapper];
-    }
-    
+
     return cell;
 }
 
@@ -485,6 +490,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
     [self collectionViewCellWillAppear:(HUBComponentCollectionViewCell *)cell
               ignorePreviousAppearance:self.collectionViewIsScrolling];
+    
+    HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
+    if (componentWrapper.isContentOffsetObserver) {
+        [self.contentOffsetObservingComponentWrappers addObject:componentWrapper];
+    }
 }
 
 - (void)collectionView:(UICollectionView *)collectionView
@@ -493,6 +503,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
     id<HUBComponentModel> const componentModel = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell].model;
     [self.delegate viewController:self componentWithModel:componentModel didDisappearFromView:cell];
+    
+    HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
+    if (componentWrapper.isContentOffsetObserver) {
+        [self.contentOffsetObservingComponentWrappers removeObject:componentWrapper];
+    }
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/tests/HUBComponentWrapperTests.m
+++ b/tests/HUBComponentWrapperTests.m
@@ -127,11 +127,11 @@
                                                    parent:nil];
 }
 
-- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponentWithView:(UIView *)childComponentView willAppearAtIndex:(NSUInteger)childIndex
+- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponent:(HUBComponentWrapper *)childComponent willAppearAtIndex:(NSUInteger)childIndex
 {
 }
 
-- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponentWithView:(UIView *)childComponentView didDisappearAtIndex:(NSUInteger)childIndex
+- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponent:(HUBComponentWrapper *)childComponent didDisappearAtIndex:(NSUInteger)childIndex
 {
 }
 

--- a/tests/HUBComponentWrapperTests.m
+++ b/tests/HUBComponentWrapperTests.m
@@ -127,11 +127,11 @@
                                                    parent:nil];
 }
 
-- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponent:(HUBComponentWrapper *)childComponent willAppearAtIndex:(NSUInteger)childIndex
+- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponent:(HUBComponentWrapper *)childComponent childView:(UIView *)childView willAppearAtIndex:(NSUInteger)childIndex
 {
 }
 
-- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponent:(HUBComponentWrapper *)childComponent didDisappearAtIndex:(NSUInteger)childIndex
+- (void)componentWrapper:(HUBComponentWrapper *)componentWrapper childComponent:(HUBComponentWrapper *)childComponent childView:(UIView *)childView didDisappearAtIndex:(NSUInteger)childIndex
 {
 }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1451,8 +1451,10 @@
 
     id<HUBComponentModel> const childComponentModel = children.firstObject;
 
-    [component.childDelegate component:component childComponentForModel:childComponentModel];
-    [component.childDelegate component:component willDisplayChildAtIndex:0 view:childComponent.view];
+    UIView *childView = childComponent.view;
+    id<HUBComponentChildDelegate> childDelegate = component.childDelegate;
+    [childDelegate component:component childComponentForModel:childComponentModel];
+    [childDelegate component:component willDisplayChildAtIndex:0 view:childView];
 
     const CGPoint expectedContentOffset = CGPointMake(99, 77);
     [self.viewController scrollToContentOffset:expectedContentOffset animated:NO];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1335,7 +1335,7 @@
     XCTAssertEqualObjects(self.viewController.view.subviews, expectedSubviews);
 }
 
-- (void)testSetScrollOffsetForwrdsOffsetToCollectionView
+- (void)testSetScrollOffsetForwardsOffsetToCollectionView
 {
     [self simulateViewControllerLayoutCycle];
     const CGPoint expectedContentOffset = CGPointMake(99, 77);
@@ -1415,6 +1415,50 @@
     XCTAssertEqual(self.component.numberOfContentOffsetChanges, (NSUInteger)2);
 }
 
+- (void)testChildComponentNotifiedOfContentOffsetChange
+{
+    NSString * const componentNamespace = @"childComponentSelection";
+    NSString * const componentName = @"component";
+    NSString * const childComponentName = @"componentB";
+    HUBComponentMock * const component = [HUBComponentMock new];
+    HUBComponentMock * const childComponent = [HUBComponentMock new];
+    childComponent.isContentOffsetObserver = YES;
+
+    HUBComponentFactoryMock * const componentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{
+        componentName: component,
+        childComponentName: childComponent
+    }];
+    [self.componentRegistry registerComponentFactory:componentFactory forNamespace:componentNamespace];
+
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        id<HUBComponentModelBuilder> const componentModelBuilder = [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"component"];
+        componentModelBuilder.componentNamespace = componentNamespace;
+        componentModelBuilder.componentName = componentName;
+
+        id<HUBComponentModelBuilder> const childComponentModelBuilder = [componentModelBuilder builderForChildWithIdentifier:@"child"];
+        childComponentModelBuilder.componentNamespace = componentNamespace;
+        childComponentModelBuilder.componentName = childComponentName;
+
+        return YES;
+    };
+    
+    [self simulateViewControllerLayoutCycle];
+    NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+    [self.collectionView.dataSource collectionView:self.collectionView cellForItemAtIndexPath:indexPath];
+
+    id<HUBComponentModel> const componentModel = self.viewModelFromDelegateMethod.bodyComponentModels[0];
+    NSArray<id<HUBComponentModel>> * const children = componentModel.children;
+
+    id<HUBComponentModel> const childComponentModel = children.firstObject;
+
+    [component.childDelegate component:component childComponentForModel:childComponentModel];
+    [component.childDelegate component:component willDisplayChildAtIndex:0 view:childComponent.view];
+
+    const CGPoint expectedContentOffset = CGPointMake(99, 77);
+    [self.viewController scrollToContentOffset:expectedContentOffset animated:NO];
+    XCTAssertEqual(childComponent.numberOfContentOffsetChanges, (NSUInteger)1);
+}
+
 - (void)testCollectionViewCreatedInLoadView
 {
     XCTAssertEqual(self.viewController.view.subviews[0], self.collectionView);
@@ -1438,7 +1482,7 @@
 - (void)testCorrectContentRectSentToScrollHandler
 {
     [self simulateViewControllerLayoutCycle];
-    
+
     self.collectionView.frame = CGRectMake(0, 0, 320, 480);
     self.collectionView.contentOffset = CGPointMake(0, 200);
     self.collectionView.contentSize = CGSizeMake(320, 1600);


### PR DESCRIPTION
Adds the possibility of child components listening for content offset updates via the `HUBComponentContentOffsetObserver` protocol.

Also changes slightly how the list of eligible components are maintained for base-level components as well, adding and removing them in the `willDisplayCell:` & `didEndDisplayingCell:` callbacks.

Resolves https://github.com/spotify/HubFramework/issues/19

@spotify/objc-dev 