### PR TITLE
Set the viewModel after performing batch updates

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -630,6 +630,14 @@ NS_ASSUME_NONNULL_BEGIN
         [self.collectionView reloadData];
         
         [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
+
+        if (self.viewHasAppeared) {
+            /* Forcing a re-layout as the reloadData-call doesn't trigger the numberOfItemsInSection:-calls
+             by itself, and batch update calls don't play well without having an initial item count. */
+            [self.collectionView setNeedsLayout];
+            [self.collectionView layoutIfNeeded];
+        }
+        
         self.lastViewModelDiff = nil;
     } else {
         void (^updateBlock)() = ^{

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<HUBViewControllerDelegate> const delegate = self.delegate;
     [delegate viewController:self willUpdateWithViewModel:viewModel];
 
-    if (self.viewModel != nil) {
+    if (self.viewModel != nil && !self.viewModelIsInitial) {
         id<HUBViewModel> const currentModel = self.viewModel;
         self.lastViewModelDiff = [HUBViewModelDiff diffFromViewModel:currentModel toViewModel:viewModel];
     }

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -299,15 +299,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     HUBCopyNavigationItemProperties(self.navigationItem, viewModel.navigationItem);
-
+    
+    self.viewModel = viewModel;
     self.viewModelIsInitial = NO;
     self.viewModelHasChangedSinceLastLayoutUpdate = YES;
     [self.view setNeedsLayout];
     
     if (self.viewHasBeenLaidOut) {
         [self reloadCollectionViewWithViewModel:viewModel animated:NO];
-    } else {
-        self.viewModel = viewModel;
     }
     
     [delegate viewControllerDidUpdate:self];
@@ -628,7 +627,6 @@ NS_ASSUME_NONNULL_BEGIN
      causes an assertion inside a private UICollectionView method. If no diff exists, fall back to
      a complete reload. */
     if (!self.viewHasAppeared || self.lastViewModelDiff == nil) {
-        self.viewModel = viewModel;
         [self.collectionView reloadData];
         
         [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
@@ -643,7 +641,6 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.collectionView reloadItemsAtIndexPaths:lastDiff.reloadedBodyComponentIndexPaths];
                 
                 [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
-                self.viewModel = viewModel;
             } completion:^(BOOL finished) {
                 self.lastViewModelDiff = nil;
             }];

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -299,14 +299,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     HUBCopyNavigationItemProperties(self.navigationItem, viewModel.navigationItem);
-    
-    self.viewModel = viewModel;
+
     self.viewModelIsInitial = NO;
     self.viewModelHasChangedSinceLastLayoutUpdate = YES;
     [self.view setNeedsLayout];
     
     if (self.viewHasBeenLaidOut) {
         [self reloadCollectionViewWithViewModel:viewModel animated:NO];
+    } else {
+        self.viewModel = viewModel;
     }
     
     [delegate viewControllerDidUpdate:self];
@@ -627,6 +628,7 @@ NS_ASSUME_NONNULL_BEGIN
      causes an assertion inside a private UICollectionView method. If no diff exists, fall back to
      a complete reload. */
     if (!self.viewHasAppeared || self.lastViewModelDiff == nil) {
+        self.viewModel = viewModel;
         [self.collectionView reloadData];
         
         [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
@@ -641,6 +643,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.collectionView reloadItemsAtIndexPaths:lastDiff.reloadedBodyComponentIndexPaths];
                 
                 [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
+                self.viewModel = viewModel;
             } completion:^(BOOL finished) {
                 self.lastViewModelDiff = nil;
             }];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -210,6 +210,30 @@
     XCTAssertEqual([self.collectionView.dataSource collectionView:self.collectionView numberOfItemsInSection:0], 2);
 }
 
+- (void)testUpdatingComponentsWithBatchUpdateDoesntCrash
+{
+    __weak __typeof(self.viewController) weakViewController = self.viewController;
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [weakViewController viewDidAppear:YES];
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"one"].title = @"One";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    id<UICollectionViewDataSource> dataSource = self.collectionView.dataSource;
+    XCTAssertEqual([dataSource collectionView:self.collectionView numberOfItemsInSection:0], 1);
+
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"one"].title = @"One";
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"two"].title = @"Two";
+        return YES;
+    };
+
+    [self.contentOperation.delegate contentOperationRequiresRescheduling:self.contentOperation];
+    XCTAssertEqual([dataSource collectionView:self.collectionView numberOfItemsInSection:0], 2);
+}
+
 - (void)testDelegateNotifiedOfUpdatedViewModel
 {
     NSString * const viewModelNavBarTitleA = @"View model A";

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -188,6 +188,28 @@
     XCTAssertTrue(contentLoaded);
 }
 
+- (void)testThatComponentsAreLoadedIfViewWasLaidOutBeforeItAppeared
+{
+    // the content loading is async and is triggered on `viewWillAppear:`
+    // so it is likely that the loading will finish after the `viewDidAppear:` was called
+    __weak __typeof(self.viewController) weakViewController = self.viewController;
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [weakViewController viewDidAppear:YES];
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"one"].title = @"One";
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"two"].title = @"Two";
+        return YES;
+    };
+
+    [self.viewController loadView];
+    [self.viewController viewDidLoad];
+    self.viewController.view.frame = CGRectMake(0, 0, 320, 400);
+    [self.viewController viewDidLayoutSubviews];
+
+    [self.viewController viewWillAppear:YES];
+
+    XCTAssertEqual([self.collectionView.dataSource collectionView:self.collectionView numberOfItemsInSection:0], 2);
+}
+
 - (void)testDelegateNotifiedOfUpdatedViewModel
 {
     NSString * const viewModelNavBarTitleA = @"View model A";


### PR DESCRIPTION
UICollectionView’s `performBatchUpdates:` method checks the number of items in the collection view before performing the update block and after that. It expects the following: 
```The number of items contained in an existing section after the update must be equal to the number of items contained in that section before the update, plus or minus the number of items inserted or deleted from that section and plus or minus the number of items moved into or out of that section.```
If we update the view model before performing the batch updates `collectionView:numberOfItemsInSection:` will return the updated count even before the actual update and it will fail after that with uncaught exception `'NSInternalInconsistencyException', reason: 'Invalid update’`. 
For example we have 0 items initially and we add 2, before the block we will have 2 items and we will add 2 from the “lastViewModelDiff” so at the end the collection view will expect to have 4 items but it will have only 2.