### PR TITLE
performBatchUpdates crash fix

### DIFF
--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -213,6 +213,38 @@
     XCTAssertEqualObjects(self.viewModelFromDelegateMethod.navigationItem.title, viewModelNavBarTitleB);
 }
 
+- (void)testThatComponentsAreLoadedIfViewWasLaidOutBeforeItAppeared
+{
+    // the content loading is async and is triggered on `viewWillAppear:`
+    // so it is likely that the loading will finish after the `viewDidAppear:` was called
+    __weak __typeof(self.viewController) weakViewController = self.viewController;
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [weakViewController viewDidAppear:YES];
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"one"].title = @"One";
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"two"].title = @"Two";
+        return YES;
+    };
+
+    [self.viewController loadView];
+    [self.viewController viewDidLoad];
+    self.viewController.view.frame = CGRectMake(0, 0, 320, 400);
+    [self.viewController viewDidLayoutSubviews];
+
+    [self.viewController viewWillAppear:YES];
+
+    XCTAssertEqual([self.collectionView.dataSource collectionView:self.collectionView numberOfItemsInSection:0], 2);
+
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"one"].title = @"One";
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"two"].title = @"Two";
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"three"].title = @"Three";
+        return YES;
+    };
+
+    [self.contentOperation.delegate contentOperationRequiresRescheduling:self.contentOperation];
+    XCTAssertEqual([self.collectionView.dataSource collectionView:self.collectionView numberOfItemsInSection:0], 3);
+}
+
 - (void)testDelegateNotifiedOfViewModelUpdateError
 {
     NSError * const error = [NSError errorWithDomain:@"hubFramework" code:4 userInfo:nil];


### PR DESCRIPTION
Attempts to fix a crash that would occur if the initial UICollectionView load was done with a batch update.

@nataliq, @JohnSundell 