### PR TITLE
Add API to create view controllers without registering features

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		52977ACA1DA7D0B40064629E /* HUBBlockContentOperationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 52977AC91DA7D0B40064629E /* HUBBlockContentOperationFactory.m */; };
 		52E7FC661D9C78700053EECF /* HUBActionFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6525321D802DCD007B1A15 /* HUBActionFactoryMock.m */; };
 		52E7FC671D9C78730053EECF /* HUBActionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6525351D802E3F007B1A15 /* HUBActionMock.m */; };
 		52E7FC681D9C78780053EECF /* HUBGestureRecognizerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A684AD51D95387C00E29513 /* HUBGestureRecognizerMock.m */; };
@@ -146,6 +147,8 @@
 /* Begin PBXFileReference section */
 		2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentFactoryMock.m; sourceTree = "<group>"; };
 		2932EAD3C06CBB869669B382 /* HUBComponentFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactoryMock.h; sourceTree = "<group>"; };
+		52977AC61DA7D0890064629E /* HUBBlockContentOperationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBBlockContentOperationFactory.h; sourceTree = "<group>"; };
+		52977AC91DA7D0B40064629E /* HUBBlockContentOperationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBBlockContentOperationFactory.m; sourceTree = "<group>"; };
 		8A0568F31CBFB073007C296A /* HUBComponentCategories.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentCategories.h; sourceTree = "<group>"; };
 		8A07549E1C21A79200AFAD38 /* libHubFramework.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHubFramework.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A0754AC1C21A7C700AFAD38 /* HUBComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponent.h; sourceTree = "<group>"; };
@@ -760,6 +763,7 @@
 				8AF82D831D12EEFA00D1B933 /* HUBContentOperationWithInitialContent.h */,
 				8A6525371D815F4C007B1A15 /* HUBContentOperationActionObserver.h */,
 				8A5D7A471CB7D2DB00B987BA /* HUBContentReloadPolicy.h */,
+				52977AC61DA7D0890064629E /* HUBBlockContentOperationFactory.h */,
 			);
 			name = Content;
 			sourceTree = "<group>";
@@ -809,6 +813,7 @@
 		8A7B48E91CD77C5800130C25 /* Content */ = {
 			isa = PBXGroup;
 			children = (
+				52977AC91DA7D0B40064629E /* HUBBlockContentOperationFactory.m */,
 				8A7B48EA1CD77C8200130C25 /* HUBContentOperationWrapper.h */,
 				8A7B48EB1CD77C8200130C25 /* HUBContentOperationWrapper.m */,
 			);
@@ -1120,6 +1125,7 @@
 				8A684ACC1D95331400E29513 /* UIView+HUBTouchForwardingTarget.m in Sources */,
 				8A8808A01C21AD0900ADB737 /* HUBComponentRegistryImplementation.m in Sources */,
 				8AA29C881C4FAB6200E972B7 /* HUBComponentImageDataImplementation.m in Sources */,
+				52977ACA1DA7D0B40064629E /* HUBBlockContentOperationFactory.m in Sources */,
 				8A6ACAB31D7D893400102EA9 /* HUBActionContextImplementation.m in Sources */,
 				8A786BBE1C5A595900B2AB9E /* HUBJSONPathImplementation.m in Sources */,
 				8AA29C851C4FAA9200E972B7 /* HUBComponentModelImplementation.m in Sources */,

--- a/include/HubFramework/HUBBlockContentOperationFactory.h
+++ b/include/HubFramework/HUBBlockContentOperationFactory.h
@@ -1,0 +1,26 @@
+#import "HUBContentOperationFactory.h"
+#import "HUBHeaderMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  A concrete content opereation factory implementation that uses a block
+ *
+ *  You can use this content operation factory in case you want to implement a simple factory that
+ *  doesn't need any injected dependencies or complex logic. For more advanced use cases, see the
+ *  `HUBContentOperationFactory` protocol, that you can implement in a custom object.
+ */
+@interface HUBBlockContentOperationFactory : NSObject  <HUBContentOperationFactory>
+
+/**
+ *  Initialize an instance of this class with a block that creates content operations
+ *
+ *  @param block The block used to create content operations. The input parameter of the block will
+ *         be the view URI that content operations should be created for. This block will be copied
+ *         and called every time this factory is asked to create content operations.
+ */
+- (instancetype)initWithBlock:(NSArray<id<HUBContentOperation>> *(^)(NSURL *))block HUB_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBBlockContentOperationFactory.h
+++ b/include/HubFramework/HUBBlockContentOperationFactory.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBContentOperationFactory.h"
 #import "HUBHeaderMacros.h"
 

--- a/include/HubFramework/HUBBlockContentOperationFactory.h
+++ b/include/HubFramework/HUBBlockContentOperationFactory.h
@@ -24,6 +24,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Type of block used by `HUBBlockContentOperationFactory` to create content operations
+typedef NSArray<id<HUBContentOperation>> * _Nonnull (^HUBContentOperationFactoryBlock)(NSURL *);
+
 /**
  *  A concrete content opereation factory implementation that uses a block
  *
@@ -40,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  *         be the view URI that content operations should be created for. This block will be copied
  *         and called every time this factory is asked to create content operations.
  */
-- (instancetype)initWithBlock:(NSArray<id<HUBContentOperation>> *(^)(NSURL *))block HUB_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBlock:(HUBContentOperationFactoryBlock)block HUB_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/include/HubFramework/HUBViewControllerFactory.h
+++ b/include/HubFramework/HUBViewControllerFactory.h
@@ -22,6 +22,7 @@
 #import <UIKIt/UIKit.h>
 
 @protocol HUBViewController;
+@protocol HUBContentOperation;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,16 +47,36 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)canCreateViewControllerForViewURI:(NSURL *)viewURI;
 
 /**
- *  Create a view controller for a certain view URI
+ *  Create a view controller for a certain pre-registered view URI
  *
- *  @param viewURI The view URI to create a view controller for
+ *  @param viewURI The view URI to create a view controller for. The URI should match a feature that
+ *         was previously registered with `HUBFeatureRegistry`.
  *
  *  @return A Hub Framework-powered view controller used for rendering content provided by a feature’s
  *  content operations, using a User Interface consisting of `HUBComponent` views. If a view controller
  *  could not be created for the supplied viewURI (because a feature registration could not be resolved
  *  for it), this method returns `nil`.
+ *
+ *  To be able to create a view controller without creating a feature, you can use the other view controller
+ *  creation method available on this protocol.
  */
 - (nullable UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI;
+
+/**
+ *  Create a view controller without a feature registration
+ *
+ *  @param viewURI The URI of the view controller to create. This view URI will not be looked up in the
+ *         Hub Framework's feature registry, it will simply be assigned to the view controller.
+ *  @param contentOperations The content operations to use to load the content for the view controller.
+ *  @param featureIdentifier The identifier of the feature that the view controller will belong to. Will
+ *         be made available to content operations as part of `HUBFeatureInfo`.
+ *  @param featureTitle The title of the feature that the view controller will belong to. Used for its
+ *         default title, and also made available to contnet operations as part of `HUBFeatureInfo`.
+ */
+- (UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
+                                                      contentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
+                                                      featureIdentifier:(NSString *)featureIdentifier
+                                                           featureTitle:(NSString *)featureTitle;
 
 @end
 

--- a/sources/HUBBlockContentOperationFactory.m
+++ b/sources/HUBBlockContentOperationFactory.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBBlockContentOperationFactory ()
 
-@property (nonatomic, copy) NSArray<id<HUBContentOperation>> *(^block)(NSURL *);
+@property (nonatomic, copy, readonly) HUBContentOperationFactoryBlock block;
 
 @end
 
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Initializer
 
-- (instancetype)initWithBlock:(NSArray<id<HUBContentOperation>> *(^)(NSURL *))block
+- (instancetype)initWithBlock:(HUBContentOperationFactoryBlock)block
 {
     NSParameterAssert(block != nil);
     

--- a/sources/HUBBlockContentOperationFactory.m
+++ b/sources/HUBBlockContentOperationFactory.m
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBBlockContentOperationFactory.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sources/HUBBlockContentOperationFactory.m
+++ b/sources/HUBBlockContentOperationFactory.m
@@ -1,0 +1,37 @@
+#import "HUBBlockContentOperationFactory.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBBlockContentOperationFactory ()
+
+@property (nonatomic, copy) NSArray<id<HUBContentOperation>> *(^block)(NSURL *);
+
+@end
+
+@implementation HUBBlockContentOperationFactory
+
+#pragma mark - Initializer
+
+- (instancetype)initWithBlock:(NSArray<id<HUBContentOperation>> *(^)(NSURL *))block
+{
+    NSParameterAssert(block != nil);
+    
+    self = [super init];
+    
+    if (self != nil) {
+        _block = [block copy];
+    }
+    
+    return self;
+}
+
+#pragma mark - HUBContentOperationFactory
+
+- (NSArray<id<HUBContentOperation>> *)createContentOperationsForViewURI:(NSURL *)viewURI
+{
+    return self.block(viewURI);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBViewControllerFactoryImplementation.m
+++ b/sources/HUBViewControllerFactoryImplementation.m
@@ -32,6 +32,8 @@
 #import "HUBViewControllerDefaultScrollHandler.h"
 #import "HUBActionHandlerWrapper.h"
 #import "HUBViewModelLoaderImplementation.h"
+#import "HUBViewURIPredicate.h"
+#import "HUBBlockContentOperationFactory.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -97,6 +99,33 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
     }
     
+    return [self createViewControllerForViewURI:viewURI featureRegistration:featureRegistration];
+}
+
+- (UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
+                                                      contentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
+                                                      featureIdentifier:(NSString *)featureIdentifier
+                                                           featureTitle:(NSString *)featureTitle
+{
+    HUBViewURIPredicate * const viewURIPredicate = [HUBViewURIPredicate predicateWithViewURI:viewURI];
+    id<HUBContentOperationFactory> const contentOperationFactory = [[HUBBlockContentOperationFactory alloc] initWithBlock:^NSArray<id<HUBContentOperation>> *(NSURL *_) {
+        return contentOperations;
+    }];
+    
+    HUBFeatureRegistration * const featureRegistration = [[HUBFeatureRegistration alloc] initWithFeatureIdentifier:featureIdentifier
+                                                                                                             title:featureTitle
+                                                                                                  viewURIPredicate:viewURIPredicate
+                                                                                         contentOperationFactories:@[contentOperationFactory]
+                                                                                               contentReloadPolicy:nil customJSONSchemaIdentifier:nil actionHandler:nil viewControllerScrollHandler:nil];
+    
+    return [self createViewControllerForViewURI:viewURI featureRegistration:featureRegistration];
+}
+
+#pragma mark - Private utilities
+
+- (UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
+                                                    featureRegistration:(HUBFeatureRegistration *)featureRegistration
+{
     HUBViewModelLoaderImplementation * const viewModelLoader = [self.viewModelLoaderFactory createViewModelLoaderForViewURI:viewURI
                                                                                                         featureRegistration:featureRegistration];
     

--- a/tests/HUBViewControllerFactoryTests.m
+++ b/tests/HUBViewControllerFactoryTests.m
@@ -103,6 +103,30 @@
     XCTAssertNil([self.manager.viewControllerFactory createViewControllerForViewURI:viewURI]);
 }
 
+- (void)testCreatingViewControllerWithoutFeatureRegistration
+{
+    NSURL * const viewURI = [NSURL URLWithString:@"spotify:hub:framework"];
+    HUBContentOperationMock * const contentOperation = [HUBContentOperationMock new];
+    
+    __block BOOL contentOperationCalled = NO;
+    
+    contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        contentOperationCalled = YES;
+        return YES;
+    };
+    
+    UIViewController<HUBViewController> * const viewController = [self.manager.viewControllerFactory createViewControllerForViewURI:viewURI
+                                                                                                                  contentOperations:@[contentOperation]
+                                                                                                                  featureIdentifier:@"identifier"
+                                                                                                                       featureTitle:@"Title"];
+    
+    [viewController viewWillAppear:NO];
+    
+    XCTAssertTrue(contentOperationCalled);
+    XCTAssertEqualObjects(viewController.featureIdentifier, @"identifier");
+    XCTAssertEqualObjects(viewController.navigationItem.title, @"Title");
+}
+
 - (void)testDefaultContentReloadPolicyUsedIfFeatureDidNotSupplyOne
 {
     NSURL * const viewURI = [NSURL URLWithString:@"spotify:hub:framework"];


### PR DESCRIPTION
This change adds a new way to create view controllers, without having to pre-register a feature with the framework. The use case for this is to more easily be able to create view controller, which decreases the learning curve to get into using the framework.

It also will make it easier to use the Hub Framework for playgrounds.

To make this happen, another convenience API is introduced to be able to create content operation factories using a concrete class that takes a block. Again, this reduces the barrier of entry for creating content operations, and the need for boilerplate.