### PR TITLE
Fix content offset adjustment error when view is empty

### DIFF
--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -177,12 +177,17 @@ NS_ASSUME_NONNULL_BEGIN
     CGPoint offset = self.collectionView.contentOffset;
     
     NSInteger topmostVisibleIndex = NSNotFound;
+    
     for (NSIndexPath *indexPath in [self.collectionView indexPathsForVisibleItems]) {
         topmostVisibleIndex = MIN(topmostVisibleIndex, indexPath.item);
     }
     
+    if (topmostVisibleIndex == NSNotFound) {
+        topmostVisibleIndex = 0;
+    }
+    
     for (NSIndexPath *indexPath in self.lastViewModelDiff.insertedBodyComponentIndexPaths) {
-        if (indexPath.item <= topmostVisibleIndex) {
+        if (indexPath.item < topmostVisibleIndex) {
             UICollectionViewLayoutAttributes *attributes = self.layoutAttributesByIndexPath[indexPath];
             offset.y += CGRectGetHeight(attributes.frame);
         }

--- a/tests/HUBCollectionViewLayoutTests.m
+++ b/tests/HUBCollectionViewLayoutTests.m
@@ -285,6 +285,33 @@
     XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:proposedOffset].y, proposedOffset.y, 0.001);
 }
 
+- (void)testProposedContentOffsetForInitiallyAddedComponents
+{
+    HUBCollectionViewLayout * const layout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
+                                                                                 componentLayoutManager:self.componentLayoutManager];
+    
+    CGRect const collectionViewFrame = {.origin = CGPointZero, .size = self.collectionViewSize};
+    HUBCollectionViewMock * const collectionView = [[HUBCollectionViewMock alloc] initWithFrame:collectionViewFrame
+                                                                           collectionViewLayout:layout];
+    
+    collectionView.mockedIndexPathsForVisibleItems = @[];
+    
+    id<HUBViewModel> const viewModelA = [self.viewModelBuilder build];
+    [layout computeForCollectionViewSize:collectionViewFrame.size viewModel:viewModelA diff:nil];
+    
+    for (NSUInteger componentIndex = 0; componentIndex < 20; componentIndex++) {
+        NSString * const componentIdentifier = [NSString stringWithFormat:@"%@", @(componentIndex)];
+        [self.viewModelBuilder builderForBodyComponentModelWithIdentifier:componentIdentifier].title = @"Component";
+    }
+    
+    id<HUBViewModel> const viewModelB = [self.viewModelBuilder build];
+    HUBViewModelDiff * const diff = [HUBViewModelDiff diffFromViewModel:viewModelA toViewModel:viewModelB];
+    [layout computeForCollectionViewSize:collectionViewFrame.size viewModel:viewModelB diff:diff];
+    
+    CGPoint const targetContentOffset = [layout targetContentOffsetForProposedContentOffset:CGPointZero];
+    XCTAssertTrue(CGPointEqualToPoint(targetContentOffset, CGPointZero));
+}
+
 - (void)testProposedContentOffsetAfterRecomputing
 {
     for (NSUInteger i = 0; i < 30; i++) {


### PR DESCRIPTION
This patch fixes a bug that would cause the content offset of a view controller to be incorrect after an initial update, where the view goes from being empty to being populated with components.

The problem was that the topmost visible index would end up being `NSNotFound`, which would make the view jump to the bottom.