### PR TITLE
Notify header component of content offset change when it appears

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -862,24 +862,28 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
     
-    [wrapper viewWillAppear];
+    [self componentWrapperWillAppear:wrapper];
     [self.delegate viewController:self componentWithModel:wrapper.model willAppearInView:cell];
-    
-    if (wrapper.isContentOffsetObserver) {
-        [wrapper updateViewForChangedContentOffset:self.collectionView.contentOffset];
-    }
 }
 
 - (void)headerAndOverlayComponentViewsWillAppear
 {
-    [self.headerComponentWrapper viewWillAppear];
+    if (self.headerComponentWrapper != nil) {
+        HUBComponentWrapper * const headerComponentWrapper = self.headerComponentWrapper;
+        [self componentWrapperWillAppear:headerComponentWrapper];
+    }
     
     for (HUBComponentWrapper * const overlayComponentWrapper in self.overlayComponentWrappers) {
-        [overlayComponentWrapper viewWillAppear];
-        
-        if (overlayComponentWrapper.isContentOffsetObserver) {
-            [overlayComponentWrapper updateViewForChangedContentOffset:self.collectionView.contentOffset];
-        }
+        [self componentWrapperWillAppear:overlayComponentWrapper];
+    }
+}
+
+- (void)componentWrapperWillAppear:(HUBComponentWrapper *)componentWrapper
+{
+    [componentWrapper viewWillAppear];
+    
+    if (componentWrapper.isContentOffsetObserver) {
+        [componentWrapper updateViewForChangedContentOffset:self.collectionView.contentOffset];
     }
 }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1444,6 +1444,22 @@
     XCTAssertEqual(self.component.numberOfContentOffsetChanges, (NSUInteger)3);
 }
 
+- (void)testHeaderComponentNotifiedOfContentOffsetChange
+{
+    self.component.isContentOffsetObserver = YES;
+    
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        viewModelBuilder.headerComponentModelBuilder.title = @"Header";
+        return YES;
+    };
+    
+    [self simulateViewControllerLayoutCycle];
+    XCTAssertEqual(self.component.numberOfContentOffsetChanges, (NSUInteger)1);
+    
+    [self.viewController scrollToContentOffset:CGPointMake(0, 100) animated:NO];
+    XCTAssertEqual(self.component.numberOfContentOffsetChanges, (NSUInteger)2);
+}
+
 - (void)testOverlayComponentNotifiedOfContentOffsetChange
 {
     self.component.isContentOffsetObserver = YES;


### PR DESCRIPTION
This patch fixes a bug where header components wouldn’t be notified of a content offset change when they appear. Body & overlay components already had this intended behavior.

The fix is to merge the “component will appear” logic into a single method, to make sure that all components are treated the same in this regard.