### PR TITLE
Umbrella header: Add HUBBlockContentOperationFactory

### DIFF
--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -44,6 +44,7 @@
 #import "HUBContentOperationWithInitialContent.h"
 #import "HUBContentOperationActionObserver.h"
 #import "HUBContentReloadPolicy.h"
+#import "HUBBlockContentOperationFactory.h"
 
 // View
 #import "HUBViewModel.h"


### PR DESCRIPTION
Missed to add it to the umbrella header when it was introduced.