### PR TITLE
Support nested touchable views inside a UI[Table/Collection]ViewCell

### DIFF
--- a/sources/HUBComponentCellWrapperView.m
+++ b/sources/HUBComponentCellWrapperView.m
@@ -36,6 +36,22 @@
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
 {
+    UIView * const viewAtPoint = [self.componentView hitTest:point withEvent:event];
+    
+    if (viewAtPoint == self.componentView) {
+        return NO;
+    }
+    
+    if ([self.componentView isKindOfClass:[UICollectionViewCell class]]) {
+        UICollectionViewCell * const cell = (UICollectionViewCell *)self.componentView;
+        return viewAtPoint != cell.contentView;
+    }
+    
+    if ([self.componentView isKindOfClass:[UITableViewCell class]]) {
+        UITableViewCell * const cell = (UITableViewCell *)self.componentView;
+        return viewAtPoint != cell.contentView;
+    }
+    
     return NO;
 }
 


### PR DESCRIPTION
Because of the ways UIKit handles touches in `UITableViewCell` and `UICollectionViewCell`, and we want to support using “orphaned” cells as component views - we need to employ some custom touch handling.

It turns out though, that the custom touch handling wasn’t taking nested touchable views (such as a `UIButton` inside a cell) into account. This has now been fixed, by making sure we only do custom handling when the content view of a cell was touched.