### PR TITLE
Add basic indexPath support to the component model.

### DIFF
--- a/include/HubFramework/HUBComponentModel.h
+++ b/include/HubFramework/HUBComponentModel.h
@@ -229,6 +229,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable, readonly) NSArray<id<HUBComponentModel>> *children;
 
 /**
+ *  The index path of this component in the `HUBComponentModel` hierarchy.
+ */
+@property (nonatomic, strong, readonly) NSIndexPath *indexPath;
+
+/**
  *  Return a child component model for a given index, or `nil` if an invalid index was supplied
  *
  *  @param childIndex The index to return a child component model for

--- a/include/HubFramework/HUBComponentModel.h
+++ b/include/HubFramework/HUBComponentModel.h
@@ -230,6 +230,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The index path of this component in the `HUBComponentModel` hierarchy.
+ *
+ *  @discussion This is a computed property so shouldn't be accessed multiple times in the same block.
  */
 @property (nonatomic, strong, readonly) NSIndexPath *indexPath;
 

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -133,8 +133,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) id<HUBViewModel> viewModel;
 
-/// The views of the root body components that are currently visible on screen, keyed by their index
-@property (nonatomic, strong, readonly) NSDictionary<NSNumber *, UIView *> *visibleBodyComponentViews;
+/// The views of the root body components that are currently visible on screen, keyed by their index paths
+@property (nonatomic, strong, readonly) NSDictionary<NSIndexPath *, UIView *> *visibleBodyComponentViewIndexPaths;
 
 /**
  *  Return the frame used to render a body component at a given index

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -190,6 +190,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBComponentModel
 
+- (NSIndexPath *)indexPath
+{
+    // Since we're traversing from this model through the parents, we will record the indices in reverse order.
+    // Capture them in a mutable array for easy reversal.
+    NSMutableArray<NSNumber *> *reversedIndexPath = [NSMutableArray array];
+    [reversedIndexPath addObject:@(self.index)];
+
+    id<HUBComponentModel> parent = self.parent;
+    while (parent) {
+        [reversedIndexPath addObject:@(parent.index)];
+        parent = parent.parent;
+    }
+
+    NSIndexPath *indexPath = nil;
+    for  (NSNumber *index in reversedIndexPath.reverseObjectEnumerator) {
+        if (indexPath == nil) {
+            indexPath = [NSIndexPath indexPathWithIndex:index.unsignedIntegerValue];
+        } else {
+            indexPath = [indexPath indexPathByAddingIndex:index.unsignedIntegerValue];
+        }
+    }
+
+    return indexPath;
+}
+
 - (nullable id<HUBComponentModel>)childAtIndex:(NSUInteger)childIndex
 {
     if (childIndex >= self.children.count) {

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -194,17 +194,17 @@ NS_ASSUME_NONNULL_BEGIN
 {
     // Since we're traversing from this model through the parents, we will record the indices in reverse order.
     // Capture them in a mutable array for easy reversal.
-    NSMutableArray<NSNumber *> *reversedIndexPath = [NSMutableArray array];
-    [reversedIndexPath addObject:@(self.index)];
+    NSMutableArray<NSNumber *> *reversedIndices = [NSMutableArray array];
+    [reversedIndices addObject:@(self.index)];
 
     id<HUBComponentModel> parent = self.parent;
-    while (parent) {
-        [reversedIndexPath addObject:@(parent.index)];
+    while (parent != nil) {
+        [reversedIndices addObject:@(parent.index)];
         parent = parent.parent;
     }
 
     NSIndexPath *indexPath = nil;
-    for  (NSNumber *index in reversedIndexPath.reverseObjectEnumerator) {
+    for  (NSNumber *index in reversedIndices.reverseObjectEnumerator) {
         if (indexPath == nil) {
             indexPath = [NSIndexPath indexPathWithIndex:index.unsignedIntegerValue];
         } else {

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -158,6 +158,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)saveComponentUIState;
 
+/**
+ *  Returns an array of all child component wrappers that are currently being displayed.
+ *
+ *  @discussion Only direct descendents will be returned. Visible children of children won't be returned.
+ */
+- (NSArray<HUBComponentWrapper *> *)visibleChildren;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -137,6 +137,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether the wrapped component's view has appeared since the model was last changed
 @property (nonatomic, readonly) BOOL viewHasAppearedSinceLastModelChange;
 
+/// Returns an array of all direct child component wrappers that are currently being displayed.
+@property (nonatomic, readonly) NSArray<HUBComponentWrapper *> *visibleChildren;
+
 /**
  *  Initialize an instance of this class with a component to wrap and its identifier
  *
@@ -157,13 +160,6 @@ NS_ASSUME_NONNULL_BEGIN
  * is prepared for reuse.
  */
 - (void)saveComponentUIState;
-
-/**
- *  Returns an array of all child component wrappers that are currently being displayed.
- *
- *  @discussion Only direct descendents will be returned. Visible children of children won't be returned.
- */
-- (NSArray<HUBComponentWrapper *> *)visibleChildren;
 
 @end
 

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -112,9 +112,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<HUBComponentWrapper *> *)visibleChildren
 {
     NSMutableArray<HUBComponentWrapper *> *visibleChildren = [NSMutableArray array];
-    for (NSNumber *visibleViewID in self.visibleChildViewsByIndex) {
-        HUBComponentWrapper *childComponentWrapper = self.childrenByIndex[visibleViewID];
-        if (childComponentWrapper) {
+    for (NSNumber *visibleViewIndex in self.visibleChildViewsByIndex) {
+        HUBComponentWrapper *childComponentWrapper = self.childrenByIndex[visibleViewIndex];
+        if (childComponentWrapper != nil) {
             [visibleChildren addObject:childComponentWrapper];
         }
     }

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -109,6 +109,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (NSArray<HUBComponentWrapper *> *)visibleChildren
+{
+    NSMutableArray<HUBComponentWrapper *> *visibleChildren = [NSMutableArray array];
+    for (NSNumber *visibleViewID in self.visibleChildViewsByIndex) {
+        HUBComponentWrapper *childComponentWrapper = self.childrenByIndex[visibleViewID];
+        if (childComponentWrapper) {
+            [visibleChildren addObject:childComponentWrapper];
+        }
+    }
+    return [visibleChildren copy];
+}
+
 #pragma mark - Property overrides
 
 - (BOOL)handlesImages

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -262,7 +262,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addComponentWrapper:(HUBComponentWrapper *)componentWrapper toArray:(NSMutableArray<HUBComponentWrapper *> *)array
 {
     [array addObject:componentWrapper];
-    for (HUBComponentWrapper *childComponentWrapper in [componentWrapper visibleChildren]) {
+    for (HUBComponentWrapper *childComponentWrapper in componentWrapper.visibleChildren) {
         [self addComponentWrapper:childComponentWrapper toArray:array];
     }
 }

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -241,16 +241,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBViewController
 
-- (NSDictionary<NSNumber *, UIView *> *)visibleBodyComponentViews
+- (NSDictionary<NSIndexPath *, UIView *> *)visibleBodyComponentViewIndexPaths
 {
-    NSMutableDictionary<NSNumber *, UIView *> * const visibleViews = [NSMutableDictionary new];
-    
+    NSMutableDictionary<NSIndexPath *, UIView *> * const visibleViewIndexPaths = [NSMutableDictionary new];
+    NSMutableArray<HUBComponentWrapper *> *visibleComponents = [NSMutableArray array];
+
     for (HUBComponentCollectionViewCell * const cell in self.collectionView.visibleCells) {
         HUBComponentWrapper * const wrapper = [self componentWrapperFromCell:cell];
-        visibleViews[@(wrapper.model.index)] = HUBComponentLoadViewIfNeeded(wrapper);
+        [self addComponentWrapper:wrapper toArray:visibleComponents];
     }
-    
-    return [visibleViews copy];
+
+    for (HUBComponentWrapper *visibleComponent in visibleComponents) {
+        NSIndexPath *indexPath = visibleComponent.model.indexPath;
+        visibleViewIndexPaths[indexPath] = HUBComponentLoadViewIfNeeded(visibleComponent);
+    }
+
+    return [visibleViewIndexPaths copy];
+}
+
+- (void)addComponentWrapper:(HUBComponentWrapper *)componentWrapper toArray:(NSMutableArray<HUBComponentWrapper *> *)array
+{
+    [array addObject:componentWrapper];
+    for (HUBComponentWrapper *childComponentWrapper in [componentWrapper visibleChildren]) {
+        [self addComponentWrapper:childComponentWrapper toArray:array];
+    }
 }
 
 - (CGRect)frameForBodyComponentAtIndex:(NSUInteger)index

--- a/tests/HUBComponentModelTests.m
+++ b/tests/HUBComponentModelTests.m
@@ -159,9 +159,36 @@
     XCTAssertNil([parent childWithIdentifier:@"noChild"]);
 }
 
+- (void)testIndexPaths
+{
+    HUBComponentModelImplementation * const parent = [self createComponentModelWithIdentifier:@"parent" index:0];
+    HUBComponentModelImplementation * const childA = [self createComponentModelWithIdentifier:@"childA" index:0 parent:parent];
+    HUBComponentModelImplementation * const childB = [self createComponentModelWithIdentifier:@"childB" index:1 parent:parent];
+    HUBComponentModelImplementation * const grandchild = [self createComponentModelWithIdentifier:@"grandchild" index:0 parent:childB];
+
+    parent.children = @[childA, childB];
+    childB.children = @[grandchild];
+
+    XCTAssertEqual(parent.indexPath, [NSIndexPath indexPathWithIndex:0]);
+
+    NSUInteger childAIndexPathArray[] = {0,0};
+    XCTAssertEqual(childA.indexPath, [NSIndexPath indexPathWithIndexes:childAIndexPathArray length:2]);
+
+    NSUInteger childBIndexPathArray[] = {0,1};
+    XCTAssertEqual(childB.indexPath, [NSIndexPath indexPathWithIndexes:childBIndexPathArray length:2]);
+
+    NSUInteger grandchildIndexPathArray[] = {0,1,0};
+    XCTAssertEqual(grandchild.indexPath, [NSIndexPath indexPathWithIndexes:grandchildIndexPathArray length:3]);
+}
+
 #pragma mark - Utilities
 
 - (HUBComponentModelImplementation *)createComponentModelWithIdentifier:(NSString *)identifier index:(NSUInteger)index
+{
+    return [self createComponentModelWithIdentifier:identifier index:index parent:nil];
+}
+
+- (HUBComponentModelImplementation *)createComponentModelWithIdentifier:(NSString *)identifier index:(NSUInteger)index parent:(nullable HUBComponentModelImplementation *)parent
 {
     HUBIdentifier * const componentIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];
     HUBComponentTargetImplementation * const target = [[HUBComponentTargetImplementation alloc] initWithURI:nil
@@ -187,7 +214,7 @@
                                                               metadata:nil
                                                            loggingData:nil
                                                             customData:nil
-                                                                parent:nil];
+                                                                parent:parent];
 }
 
 @end

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1703,11 +1703,11 @@
     
     self.collectionView.mockedVisibleCells = @[cellA, cellB, cellC];
     
-    NSDictionary<NSNumber *, UIView *> * const visibleViews = self.viewController.visibleBodyComponentViews;
+    NSDictionary<NSIndexPath *, UIView *> * const visibleViews = self.viewController.visibleBodyComponentViewIndexPaths;
     XCTAssertEqual(visibleViews.count, (NSUInteger)3);
-    XCTAssertEqual(visibleViews[@0], componentA.view);
-    XCTAssertEqual(visibleViews[@1], componentB.view);
-    XCTAssertEqual(visibleViews[@2], componentC.view);
+    XCTAssertEqual(visibleViews[[NSIndexPath indexPathWithIndex:0]], componentA.view);
+    XCTAssertEqual(visibleViews[[NSIndexPath indexPathWithIndex:1]], componentB.view);
+    XCTAssertEqual(visibleViews[[NSIndexPath indexPathWithIndex:2]], componentC.view);
 }
 
 - (void)testContentOperationNotifiedOfSelectionAction


### PR DESCRIPTION
This PR:

- Allows a component model to return an `NSIndexPath` representing where it sits in the component hierarchy,
- Updates the `HUBViewController` to return the index paths of all visible body components, not just the top level body components.