### PR TITLE
Separate UICollectionView update logic

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		DDBCF36E1C68DE2C00693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
 		DDBCF36F1C68DE4900693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
 		DDBCF3701C68DE5000693038 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36B1C68DD2300693038 /* UIKit.framework */; };
+		F64C5C2D1DB82CA30077E619 /* HUBViewModelRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = F64C5C2C1DB82CA30077E619 /* HUBViewModelRenderer.m */; };
 		F66658D91D9925CC0097929F /* HUBViewModelDiff.m in Sources */ = {isa = PBXBuildFile; fileRef = F66658D81D9925CC0097929F /* HUBViewModelDiff.m */; };
 		F6665AA71D9947E00097929F /* HUBViewModelDiffTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6665AA61D9947E00097929F /* HUBViewModelDiffTests.m */; };
 		F6AC23C21DA2863A001B1A6A /* HUBComponentWrapperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F6AC23C11DA2863A001B1A6A /* HUBComponentWrapperTests.m */; };
@@ -395,6 +396,8 @@
 		DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBUtilities.h; sourceTree = "<group>"; };
 		DDBCF36B1C68DD2300693038 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		F64C5C2B1DB82CA30077E619 /* HUBViewModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelRenderer.h; sourceTree = "<group>"; };
+		F64C5C2C1DB82CA30077E619 /* HUBViewModelRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelRenderer.m; sourceTree = "<group>"; };
 		F663FE7C1D10BECE003E19B6 /* HUBActionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBActionContext.h; sourceTree = "<group>"; };
 		F66658D71D9925CC0097929F /* HUBViewModelDiff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelDiff.h; sourceTree = "<group>"; };
 		F66658D81D9925CC0097929F /* HUBViewModelDiff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelDiff.m; sourceTree = "<group>"; };
@@ -1005,6 +1008,8 @@
 			children = (
 				8AF9FA051C5254F5003F3D6C /* HUBViewModelImplementation.h */,
 				8AF9FA061C5254F5003F3D6C /* HUBViewModelImplementation.m */,
+				F64C5C2B1DB82CA30077E619 /* HUBViewModelRenderer.h */,
+				F64C5C2C1DB82CA30077E619 /* HUBViewModelRenderer.m */,
 				8AF5B57D1C64B59E001FF228 /* HUBViewModelLoaderImplementation.h */,
 				8AF5B57E1C64B59E001FF228 /* HUBViewModelLoaderImplementation.m */,
 				8AD064721C68F0820086C081 /* HUBViewModelLoaderFactoryImplementation.h */,
@@ -1127,6 +1132,7 @@
 				52977ACA1DA7D0B40064629E /* HUBBlockContentOperationFactory.m in Sources */,
 				8A6ACAB31D7D893400102EA9 /* HUBActionContextImplementation.m in Sources */,
 				8A786BBE1C5A595900B2AB9E /* HUBJSONPathImplementation.m in Sources */,
+				F64C5C2D1DB82CA30077E619 /* HUBViewModelRenderer.m in Sources */,
 				8AA29C851C4FAA9200E972B7 /* HUBComponentModelImplementation.m in Sources */,
 				8AD14E8A1D994BB40008E182 /* HUBDefaultImageLoaderFactory.m in Sources */,
 				8AD064741C68F0820086C081 /* HUBViewModelLoaderFactoryImplementation.m in Sources */,

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -46,7 +46,7 @@
 #import "HUBActionContextImplementation.h"
 #import "HUBActionRegistry.h"
 #import "HUBActionHandler.h"
-#import "HUBViewModelDiff.h"
+#import "HUBViewModelRenderer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable, readonly) id<HUBContentReloadPolicy> contentReloadPolicy;
 @property (nonatomic, strong, nullable, readonly) id<HUBImageLoader> imageLoader;
 @property (nonatomic, strong, nullable) UICollectionView *collectionView;
+@property (nonatomic, strong, nullable) HUBViewModelRenderer *viewModelRenderer;
 @property (nonatomic, assign) BOOL collectionViewIsScrolling;
 @property (nonatomic, strong, readonly) NSMutableSet<NSString *> *registeredCollectionViewCellReuseIdentifiers;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSURL *, NSMutableArray<HUBComponentImageLoadingContext *> *> *componentImageLoadingContexts;
@@ -73,10 +74,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) HUBComponentUIStateManager *componentUIStateManager;
 @property (nonatomic, strong, readonly) HUBComponentReusePool *childComponentReusePool;
 @property (nonatomic, strong, nullable) id<HUBViewModel> viewModel;
-@property (nonatomic, strong, nullable) HUBViewModelDiff *lastViewModelDiff;
 @property (nonatomic, assign) BOOL viewHasAppeared;
 @property (nonatomic, assign) BOOL viewHasBeenLaidOut;
-@property (nonatomic) BOOL viewModelIsInitial;
 @property (nonatomic) BOOL viewModelHasChangedSinceLastLayoutUpdate;
 @property (nonatomic) CGFloat visibleKeyboardHeight;
 
@@ -123,7 +122,6 @@ NS_ASSUME_NONNULL_BEGIN
     _actionHandler = actionHandler;
     _scrollHandler = scrollHandler;
     _imageLoader = imageLoader;
-    _viewModelIsInitial = YES;
     _registeredCollectionViewCellReuseIdentifiers = [NSMutableSet new];
     _componentImageLoadingContexts = [NSMutableDictionary new];
     _contentOffsetObservingComponentWrappers = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
@@ -210,9 +208,12 @@ NS_ASSUME_NONNULL_BEGIN
     
     self.viewHasBeenLaidOut = YES;
 
-    if (self.viewModel != nil) {
-        id<HUBViewModel> const viewModel = self.viewModel;
-        [self reloadCollectionViewWithViewModel:viewModel animated:NO];
+    if (self.viewModel != nil && self.viewModelHasChangedSinceLastLayoutUpdate) {
+        if (!CGRectEqualToRect(self.collectionView.frame, self.view.bounds)) {
+            self.collectionView.frame = self.view.bounds;
+            id<HUBViewModel> const viewModel = self.viewModel;
+            [self reloadCollectionViewWithViewModel:viewModel animated:NO];
+        }
     }
 }
 
@@ -292,16 +293,10 @@ NS_ASSUME_NONNULL_BEGIN
     
     id<HUBViewControllerDelegate> const delegate = self.delegate;
     [delegate viewController:self willUpdateWithViewModel:viewModel];
-
-    if (self.viewModel != nil && !self.viewModelIsInitial) {
-        id<HUBViewModel> const currentModel = self.viewModel;
-        self.lastViewModelDiff = [HUBViewModelDiff diffFromViewModel:currentModel toViewModel:viewModel];
-    }
     
     HUBCopyNavigationItemProperties(self.navigationItem, viewModel.navigationItem);
     
     self.viewModel = viewModel;
-    self.viewModelIsInitial = NO;
     self.viewModelHasChangedSinceLastLayoutUpdate = YES;
     [self.view setNeedsLayout];
     
@@ -606,67 +601,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)reloadCollectionViewWithViewModel:(id<HUBViewModel>)viewModel animated:(BOOL)animated
 {
-    if (!self.viewModelHasChangedSinceLastLayoutUpdate) {
-        if (CGRectEqualToRect(self.collectionView.frame, self.view.bounds)) {
-            return;
-        }
-    }
-    
-    self.collectionView.frame = self.view.bounds;
-    
-    [self saveStatesForVisibleComponents];
-    
     if (![self.collectionView.collectionViewLayout isKindOfClass:[HUBCollectionViewLayout class]]) {
         self.collectionView.collectionViewLayout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
                                                                                        componentLayoutManager:self.componentLayoutManager];
     }
-    
-    HUBCollectionViewLayout * const layout = (HUBCollectionViewLayout *)self.collectionView.collectionViewLayout;
-    
-    /* Performing batch updates inbetween viewDidLoad and viewDidAppear is seemingly not allowed, as it
-     causes an assertion inside a private UICollectionView method. If no diff exists, fall back to
-     a complete reload. */
-    if (!self.viewHasAppeared || self.lastViewModelDiff == nil) {
-        [self.collectionView reloadData];
-        
-        [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
 
-        if (self.viewHasAppeared) {
-            /* Forcing a re-layout as the reloadData-call doesn't trigger the numberOfItemsInSection:-calls
-             by itself, and batch update calls don't play well without having an initial item count. */
-            [self.collectionView setNeedsLayout];
-            [self.collectionView layoutIfNeeded];
-        }
-        
-        self.lastViewModelDiff = nil;
-    } else {
-        void (^updateBlock)() = ^{
-            [self.collectionView performBatchUpdates:^{
-                HUBViewModelDiff * const lastDiff = self.lastViewModelDiff;
-                
-                [self.collectionView insertItemsAtIndexPaths:lastDiff.insertedBodyComponentIndexPaths];
-                [self.collectionView deleteItemsAtIndexPaths:lastDiff.deletedBodyComponentIndexPaths];
-                [self.collectionView reloadItemsAtIndexPaths:lastDiff.reloadedBodyComponentIndexPaths];
-                
-                [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:self.lastViewModelDiff];
-            } completion:^(BOOL finished) {
-                self.lastViewModelDiff = nil;
-            }];
-        };
-        
-        if (animated) {
-            updateBlock();
-        } else {
-            [UIView performWithoutAnimation:updateBlock];
-        }
+    if (self.viewModelRenderer == nil) {
+        UICollectionView * const nonnullCollectionView = self.collectionView;
+        self.viewModelRenderer = [[HUBViewModelRenderer alloc] initWithCollectionView:nonnullCollectionView];
     }
+
+    [self saveStatesForVisibleComponents];
+
+    [self.viewModelRenderer renderViewModel:viewModel
+                          usingBatchUpdates:self.viewHasAppeared
+                                   animated:animated
+                                 completion:^{
+        [self.delegate viewControllerDidFinishRendering:self];
+    }];
     
     [self configureHeaderComponent];
     [self configureOverlayComponents];
     [self headerAndOverlayComponentViewsWillAppear];
     
     self.viewModelHasChangedSinceLastLayoutUpdate = NO;
-    [self.delegate viewControllerDidFinishRendering:self];
 }
 
 - (void)saveStatesForVisibleComponents

--- a/sources/HUBViewModelRenderer.h
+++ b/sources/HUBViewModelRenderer.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "HUBViewModel.h"
+#import "HUBHeaderMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A class used to render view models in a collection view.
+ */
+@interface HUBViewModelRenderer : NSObject
+
+/**
+ * Initializes a @c HUBViewModelRenderer with a provided collection view.
+ *
+ * @param collectionView The collection view to use for rendering.
+ */
+- (instancetype)initWithCollectionView:(UICollectionView *)collectionView HUB_DESIGNATED_INITIALIZER;
+
+/** 
+ * Renders the provided view model in the collection view.
+ * 
+ * @param viewModel The view model to render.
+ * @param usingBatchUpdates @c YES if the renderer should render using batch updates, @c NO otherwise.
+ * @param animated @c YES if the renderer should render with animations, @c NO otherwise.
+ * @param completionBlock The block to be called once the rendering is completed.
+ */
+- (void)renderViewModel:(id<HUBViewModel>)viewModel
+      usingBatchUpdates:(BOOL)usingBatchUpdates
+               animated:(BOOL)animated
+             completion:(void(^)())completionBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBViewModelRenderer.h"
+#import "HUBViewModelDiff.h"
+#import "HUBCollectionViewLayout.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBViewModelRenderer ()
+
+@property (nonatomic, strong, readonly) UICollectionView *collectionView;
+@property (nonatomic, strong) id<HUBViewModel> lastRenderedViewModel;
+
+@end
+
+@implementation HUBViewModelRenderer
+
+- (instancetype)initWithCollectionView:(UICollectionView *)collectionView
+{
+    self = [super init];
+    if (self) {
+        _collectionView = collectionView;
+    }
+    return self;
+}
+
+- (void)renderViewModel:(id<HUBViewModel>)viewModel
+      usingBatchUpdates:(BOOL)usingBatchUpdates
+               animated:(BOOL)animated
+             completion:(void (^)())completionBlock
+{
+    HUBViewModelDiff *diff;
+    if (self.lastRenderedViewModel != nil) {
+        diff = [HUBViewModelDiff diffFromViewModel:self.lastRenderedViewModel toViewModel:viewModel];
+    }
+
+    HUBCollectionViewLayout * const layout = (HUBCollectionViewLayout *)self.collectionView.collectionViewLayout;
+
+    if (!usingBatchUpdates || diff == nil) {
+        [self.collectionView reloadData];
+        
+        [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:diff];
+
+        /* Forcing a re-layout as the reloadData-call doesn't trigger the numberOfItemsInSection:-calls
+         by itself, and batch update calls don't play well without having an initial item count. */
+        [self.collectionView setNeedsLayout];
+        [self.collectionView layoutIfNeeded];
+        completionBlock();
+    } else {
+        void (^updateBlock)() = ^{
+            [self.collectionView performBatchUpdates:^{
+                [self.collectionView insertItemsAtIndexPaths:diff.insertedBodyComponentIndexPaths];
+                [self.collectionView deleteItemsAtIndexPaths:diff.deletedBodyComponentIndexPaths];
+                [self.collectionView reloadItemsAtIndexPaths:diff.reloadedBodyComponentIndexPaths];
+                
+                [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:diff];
+            } completion:^(BOOL finished) {
+                completionBlock();
+            }];
+        };
+        
+        if (animated) {
+            updateBlock();
+        } else {
+            [UIView performWithoutAnimation:updateBlock];
+        }
+    }
+
+    self.lastRenderedViewModel = viewModel;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Separates the UICollectionView update logic into a separate class – the HUBViewModelRenderer. Also moves the diffing of view models to right before the reload in order to avoid unpredictable behaviour caused by multiple updates happening inbetween a UICollectionView reload.

@spotify/objc-dev, @JohnSundell 