### PR TITLE
View controller: Un-rename visible component views API & improve docs

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -137,8 +137,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  The views of the body components that are currently visible on screen, keyed by their index path
  *
  *  The index paths used for keys contains the indexes for the components' views, starting from the root. For example,
- *  a root body component at index 4 will have an index path with just the index 4, while the 3rd child of that component
- *  will have an index path with the indexes 4 and 2.
+ *  a root body component at index 4 will have an index path with just the index 4, while the child at index 2 of that
+ *  component will have an index path with the indexes 4 and 2.
  */
 @property (nonatomic, strong, readonly) NSDictionary<NSIndexPath *, UIView *> *visibleBodyComponentViews;
 

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -133,8 +133,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) id<HUBViewModel> viewModel;
 
-/// The views of the root body components that are currently visible on screen, keyed by their index paths
-@property (nonatomic, strong, readonly) NSDictionary<NSIndexPath *, UIView *> *visibleBodyComponentViewIndexPaths;
+/**
+ *  The views of the body components that are currently visible on screen, keyed by their index path
+ *
+ *  The index paths used for keys contains the indexes for the components' views, starting from the root. For example,
+ *  a root body component at index 4 will have an index path with just the index 4, while the 3rd child of that component
+ *  will have an index path with the indexes 4 and 2.
+ */
+@property (nonatomic, strong, readonly) NSDictionary<NSIndexPath *, UIView *> *visibleBodyComponentViews;
 
 /**
  *  Return the frame used to render a body component at a given index

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -194,8 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     // Since we're traversing from this model through the parents, we will record the indices in reverse order.
     // Capture them in a mutable array for easy reversal.
-    NSMutableArray<NSNumber *> *reversedIndices = [NSMutableArray array];
-    [reversedIndices addObject:@(self.index)];
+    NSMutableArray<NSNumber *> * const reversedIndices = [NSMutableArray arrayWithObject:@(self.index)];
 
     id<HUBComponentModel> parent = self.parent;
     while (parent != nil) {
@@ -203,13 +202,11 @@ NS_ASSUME_NONNULL_BEGIN
         parent = parent.parent;
     }
 
-    NSIndexPath *indexPath = nil;
+    NSIndexPath *indexPath = [NSIndexPath indexPathWithIndex:reversedIndices.lastObject.unsignedIntegerValue];
+    [reversedIndices removeLastObject];
+    
     for  (NSNumber *index in reversedIndices.reverseObjectEnumerator) {
-        if (indexPath == nil) {
-            indexPath = [NSIndexPath indexPathWithIndex:index.unsignedIntegerValue];
-        } else {
-            indexPath = [indexPath indexPathByAddingIndex:index.unsignedIntegerValue];
-        }
+        indexPath = [indexPath indexPathByAddingIndex:index.unsignedIntegerValue];
     }
 
     return indexPath;

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -245,18 +245,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBViewController
 
-- (NSDictionary<NSIndexPath *, UIView *> *)visibleBodyComponentViewIndexPaths
+- (NSDictionary<NSIndexPath *, UIView *> *)visibleBodyComponentViews
 {
     NSMutableDictionary<NSIndexPath *, UIView *> * const visibleViewIndexPaths = [NSMutableDictionary new];
-    NSMutableArray<HUBComponentWrapper *> *visibleComponents = [NSMutableArray array];
+    NSMutableArray<HUBComponentWrapper *> * const visibleComponents = [NSMutableArray array];
 
     for (HUBComponentCollectionViewCell * const cell in self.collectionView.visibleCells) {
         HUBComponentWrapper * const wrapper = [self componentWrapperFromCell:cell];
         [self addComponentWrapper:wrapper toArray:visibleComponents];
     }
 
-    for (HUBComponentWrapper *visibleComponent in visibleComponents) {
-        NSIndexPath *indexPath = visibleComponent.model.indexPath;
+    for (HUBComponentWrapper * const visibleComponent in visibleComponents) {
+        NSIndexPath * const indexPath = visibleComponent.model.indexPath;
         visibleViewIndexPaths[indexPath] = HUBComponentLoadViewIfNeeded(visibleComponent);
     }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1709,7 +1709,7 @@
     
     self.collectionView.mockedVisibleCells = @[cellA, cellB, cellC];
     
-    NSDictionary<NSIndexPath *, UIView *> * const visibleViews = self.viewController.visibleBodyComponentViewIndexPaths;
+    NSDictionary<NSIndexPath *, UIView *> * const visibleViews = self.viewController.visibleBodyComponentViews;
     XCTAssertEqual(visibleViews.count, (NSUInteger)3);
     XCTAssertEqual(visibleViews[[NSIndexPath indexPathWithIndex:0]], componentA.view);
     XCTAssertEqual(visibleViews[[NSIndexPath indexPathWithIndex:1]], componentB.view);


### PR DESCRIPTION
This change changes the name of the API used to retrieve the currently visible body component views back to the name that was used before https://github.com/spotify/HubFramework/pull/84. We don’t need to change the name of the API because the key type was changed.

This change also adds a bit more thorough documentation for the API, explaining what the API user can expect from the index paths used as keys.