### PR TITLE
Simplify the generation of the index path.

### DIFF
--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -192,24 +192,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSIndexPath *)indexPath
 {
-    // Since we're traversing from this model through the parents, we will record the indices in reverse order.
-    // Capture them in a mutable array for easy reversal.
-    NSMutableArray<NSNumber *> *reversedIndices = [NSMutableArray array];
-    [reversedIndices addObject:@(self.index)];
+    NSMutableArray<NSNumber *> *indices = [NSMutableArray array];
+    [indices addObject:@(self.index)];
 
     id<HUBComponentModel> parent = self.parent;
     while (parent != nil) {
-        [reversedIndices addObject:@(parent.index)];
+        // At the next index at the start of the array as we're traversing up the hierarchy.
+        [indices insertObject:@(parent.index) atIndex:0];
         parent = parent.parent;
     }
 
-    NSIndexPath *indexPath = nil;
-    for  (NSNumber *index in reversedIndices.reverseObjectEnumerator) {
-        if (indexPath == nil) {
-            indexPath = [NSIndexPath indexPathWithIndex:index.unsignedIntegerValue];
-        } else {
-            indexPath = [indexPath indexPathByAddingIndex:index.unsignedIntegerValue];
-        }
+    NSIndexPath *indexPath = [NSIndexPath indexPathWithIndex:indices.firstObject.unsignedIntegerValue];
+    for (NSUInteger i = 1; i < indices.count; i++) {
+        indexPath = [indexPath indexPathByAddingIndex:indices[i].unsignedIntegerValue];
     }
 
     return indexPath;

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -192,8 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSIndexPath *)indexPath
 {
-    NSMutableArray<NSNumber *> * const indices = [NSMutableArray array];
-    [indices addObject:@(self.index)];
+    NSMutableArray<NSNumber *> * const indices = [NSMutableArray arrayWithObject:@(self.index)];
 
     id<HUBComponentModel> parent = self.parent;
     while (parent != nil) {

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -197,7 +197,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     id<HUBComponentModel> parent = self.parent;
     while (parent != nil) {
-        // At the next index at the start of the array as we're traversing up the hierarchy.
+        // Add the next index at the start of the array as we're traversing up the hierarchy.
         [indices insertObject:@(parent.index) atIndex:0];
         parent = parent.parent;
     }


### PR DESCRIPTION
Instead of storing the indices in reverse order, then iterating in reverse, store them in the order they'll be accessed in.

Also gets around a static analyser warning, which claims we could return `nil` from the method (which wasn't strictly true).