### PR TITLE
Send component's view instead of a collection view cell in HUBViewControllerDelegate.

### DIFF
--- a/sources/HUBUtilities.h
+++ b/sources/HUBUtilities.h
@@ -55,7 +55,7 @@ static inline BOOL HUBPropertyIsEqual(NSObject * _Nullable objectA, NSObject * _
  *
  *  This function asserts that a view has been loaded after -loadView was sent to the component.
  */
-static inline UIView *HUBComponentLoadViewIfNeeded(id<HUBComponent> _Nullable component) {
+static inline UIView *HUBComponentLoadViewIfNeeded(id<HUBComponent> component) {
     if (component.view == nil) {
         [component loadView];
     }

--- a/sources/HUBUtilities.h
+++ b/sources/HUBUtilities.h
@@ -55,7 +55,7 @@ static inline BOOL HUBPropertyIsEqual(NSObject * _Nullable objectA, NSObject * _
  *
  *  This function asserts that a view has been loaded after -loadView was sent to the component.
  */
-static inline UIView *HUBComponentLoadViewIfNeeded(id<HUBComponent> component) {
+static inline UIView *HUBComponentLoadViewIfNeeded(id<HUBComponent> _Nullable component) {
     if (component.view == nil) {
         [component loadView];
     }

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -963,7 +963,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
     
     [self componentWrapperWillAppear:wrapper];
-    [self.delegate viewController:self componentWithModel:wrapper.model willAppearInView:cell];
+
+    UIView * const component = HUBComponentLoadViewIfNeeded(cell.component);
+    [self.delegate viewController:self componentWithModel:wrapper.model willAppearInView:component];
 }
 
 - (void)headerAndOverlayComponentViewsWillAppear

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -964,8 +964,13 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     
     [self componentWrapperWillAppear:wrapper];
 
-    UIView * const component = HUBComponentLoadViewIfNeeded(cell.component);
-    [self.delegate viewController:self componentWithModel:wrapper.model willAppearInView:component];
+    id<HUBComponent> component = cell.component;
+    if (component == nil) {
+        return;
+    }
+
+    UIView * const componentView = HUBComponentLoadViewIfNeeded(component);
+    [self.delegate viewController:self componentWithModel:wrapper.model willAppearInView:componentView];
 }
 
 - (void)headerAndOverlayComponentViewsWillAppear

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -56,6 +56,7 @@
 #import "HUBActionFactoryMock.h"
 #import "HUBActionMock.h"
 #import "HUBViewControllerScrollHandlerMock.h"
+#import "HUBComponentCollectionViewCell.h"
 
 @interface HUBViewControllerTests : XCTestCase <HUBViewControllerDelegate>
 
@@ -1863,6 +1864,7 @@
       willAppearInView:(UIView *)componentView
 {
     XCTAssertEqual(viewController, self.viewController);
+    XCTAssertFalse([componentView isKindOfClass:[HUBComponentCollectionViewCell class]]);
     [self.componentModelsFromAppearanceDelegateMethod addObject:componentModel];
 }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -57,6 +57,7 @@
 #import "HUBActionMock.h"
 #import "HUBViewControllerScrollHandlerMock.h"
 #import "HUBComponentCollectionViewCell.h"
+#import "HUBUtilities.h"
 
 @interface HUBViewControllerTests : XCTestCase <HUBViewControllerDelegate>
 
@@ -82,6 +83,7 @@
 @property (nonatomic, strong) NSMutableArray<id<HUBComponentModel>> *componentModelsFromAppearanceDelegateMethod;
 @property (nonatomic, strong) NSMutableArray<id<HUBComponentModel>> *componentModelsFromDisapperanceDelegateMethod;
 @property (nonatomic, strong) NSMutableArray<id<HUBComponentModel>> *componentModelsFromSelectionDelegateMethod;
+@property (nonatomic, strong) NSMutableArray<UIView *> *componentViewsFromApperanceDelegateMethod;
 @property (nonatomic, assign) BOOL didReceiveViewControllerDidFinishRendering;
 
 
@@ -171,6 +173,7 @@
     self.componentModelsFromAppearanceDelegateMethod = [NSMutableArray new];
     self.componentModelsFromDisapperanceDelegateMethod = [NSMutableArray new];
     self.componentModelsFromSelectionDelegateMethod = [NSMutableArray new];
+    self.componentViewsFromApperanceDelegateMethod = [NSMutableArray new];
 }
 
 #pragma mark - Tests
@@ -1076,7 +1079,8 @@
     XCTAssertEqual(self.component.numberOfAppearances, (NSUInteger)1);
     XCTAssertEqual(self.componentModelsFromAppearanceDelegateMethod.count, (NSUInteger)1);
     XCTAssertEqualObjects(self.componentModelsFromAppearanceDelegateMethod[0].title, @"title");
-    
+    XCTAssertEqualObjects(self.componentViewsFromApperanceDelegateMethod, @[self.component.view]);
+
     self.collectionView.mockedIndexPathsForVisibleItems = @[indexPath];
     [self.viewController viewWillAppear:NO];
     
@@ -1520,7 +1524,7 @@
 
     id<HUBComponentModel> const childComponentModel = children.firstObject;
 
-    UIView *childView = childComponent.view;
+    UIView *childView = HUBComponentLoadViewIfNeeded(childComponent);
     id<HUBComponentChildDelegate> childDelegate = component.childDelegate;
     [childDelegate component:component childComponentForModel:childComponentModel];
     [childDelegate component:component willDisplayChildAtIndex:0 view:childView];
@@ -1865,6 +1869,8 @@
 {
     XCTAssertEqual(viewController, self.viewController);
     XCTAssertFalse([componentView isKindOfClass:[HUBComponentCollectionViewCell class]]);
+
+    [self.componentViewsFromApperanceDelegateMethod addObject:componentView];
     [self.componentModelsFromAppearanceDelegateMethod addObject:componentModel];
 }
 


### PR DESCRIPTION
Solves https://github.com/spotify/HubFramework/issues/82

Send unwrapped `HUBComponentCollectionViewCell` as the view parameter when calling methods on `HUBViewControllerDelegate`.