### PR TITLE
Component wrapper: fix gesture recognizer stealing button touches

### DIFF
--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -359,6 +359,15 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    if ([touch.view isKindOfClass:[UIButton class]]) {
+        return NO;
+    }
+    
+    return YES;
+}
+
 #pragma mark - HUBComponentResizeObservingViewDelegate
 
 - (void)resizeObservingViewDidResize:(HUBComponentResizeObservingView *)view

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -361,11 +361,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
-    if ([touch.view isKindOfClass:[UIButton class]]) {
-        return NO;
-    }
-    
-    return YES;
+    return ![touch.view isKindOfClass:[UIButton class]];
 }
 
 #pragma mark - HUBComponentResizeObservingViewDelegate


### PR DESCRIPTION
The gesture recognizer used to handle component highlighting and selection prevents buttons inside the component from receiving touches. This PR fixes the issue by not forwarding button touches to the gesture recognizer.