### PR TITLE
Fix bug causing nested components to be unelectable

### DIFF
--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -361,7 +361,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
-    return ![touch.view isKindOfClass:[UIButton class]];
+    CGPoint const touchLocation = [touch locationInView:self.view];
+    
+    if (!CGRectContainsPoint(self.view.bounds, touchLocation)) {
+        return NO;
+    }
+    
+    UIView *currentView = touch.view;
+    
+    while (currentView != nil && currentView != self.view) {
+        if ([currentView isKindOfClass:[UIButton class]]) {
+            return NO;
+        }
+        
+        if ([currentView isKindOfClass:[UICollectionViewCell class]]) {
+            return NO;
+        }
+        
+        if ([currentView isKindOfClass:[UITableViewCell class]]) {
+            return NO;
+        }
+        
+        currentView = currentView.superview;
+    }
+    
+    return YES;
 }
 
 #pragma mark - HUBComponentResizeObservingViewDelegate


### PR DESCRIPTION
Since the new selection handling mechanism was introduced, child components have been made unselectable, because the touch recognizer used to perform selection handling was “stealing touches” from nested views.

This has now been fixed by not using selection handling if one of the following view classes were touched:

- UIButton
- UICollectionViewCell
- UITableViewCell

A more rigid implementation of this would be to check the visible child components and hit test them, but since we’re currently also using plain UIViews as child components, we need to go through the view hierarchy.