### PR TITLE
Power up actions API to support content operations & async, chainable actions

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		8AD151821D9968390008E182 /* HUBURLSessionDataTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBURLSessionDataTaskMock.h; sourceTree = "<group>"; };
 		8AD151831D9968390008E182 /* HUBURLSessionDataTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBURLSessionDataTaskMock.m; sourceTree = "<group>"; };
 		8AD585B51DB4D38700DB7606 /* HUBActionPerformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBActionPerformer.h; sourceTree = "<group>"; };
+		8AD585B91DB4F49600DB7606 /* HUBContentOperationActionPerformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBContentOperationActionPerformer.h; sourceTree = "<group>"; };
 		8AD732011D9AD30100E4B427 /* HUBDefaultConnectivityStateResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBDefaultConnectivityStateResolver.h; sourceTree = "<group>"; };
 		8AD732021D9AD30100E4B427 /* HUBDefaultConnectivityStateResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBDefaultConnectivityStateResolver.m; sourceTree = "<group>"; };
 		8AD7335F1D9BE6F800E4B427 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -742,6 +743,7 @@
 				8A40B12D1CAAA71500EBDDE2 /* HUBContentOperation.h */,
 				8AF82D831D12EEFA00D1B933 /* HUBContentOperationWithInitialContent.h */,
 				8A6525371D815F4C007B1A15 /* HUBContentOperationActionObserver.h */,
+				8AD585B91DB4F49600DB7606 /* HUBContentOperationActionPerformer.h */,
 				8A5D7A471CB7D2DB00B987BA /* HUBContentReloadPolicy.h */,
 				52977AC61DA7D0890064629E /* HUBBlockContentOperationFactory.h */,
 			);

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		8AD151801D9966080008E182 /* HUBURLSessionMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBURLSessionMock.m; sourceTree = "<group>"; };
 		8AD151821D9968390008E182 /* HUBURLSessionDataTaskMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBURLSessionDataTaskMock.h; sourceTree = "<group>"; };
 		8AD151831D9968390008E182 /* HUBURLSessionDataTaskMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBURLSessionDataTaskMock.m; sourceTree = "<group>"; };
+		8AD585B51DB4D38700DB7606 /* HUBActionPerformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBActionPerformer.h; sourceTree = "<group>"; };
 		8AD732011D9AD30100E4B427 /* HUBDefaultConnectivityStateResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBDefaultConnectivityStateResolver.h; sourceTree = "<group>"; };
 		8AD732021D9AD30100E4B427 /* HUBDefaultConnectivityStateResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBDefaultConnectivityStateResolver.m; sourceTree = "<group>"; };
 		8AD7335F1D9BE6F800E4B427 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -526,6 +527,7 @@
 				8A2A72EE1D4B749600141619 /* HUBAction.h */,
 				8A0C356C1D7DB656007C32D9 /* HUBActionFactory.h */,
 				8A2A72ED1D4B744A00141619 /* HUBActionRegistry.h */,
+				8AD585B51DB4D38700DB7606 /* HUBActionPerformer.h */,
 				8A6529F51D82D1C7007B1A15 /* HUBActionHandler.h */,
 				F663FE7C1D10BECE003E19B6 /* HUBActionContext.h */,
 				8A6529F61D82D7BE007B1A15 /* HUBActionTrigger.h */,

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		8A4C28151DB5120400152429 /* HUBComponentGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentGestureRecognizer.h; sourceTree = "<group>"; };
 		8A4C28161DB5120400152429 /* HUBComponentGestureRecognizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentGestureRecognizer.m; sourceTree = "<group>"; };
 		8A4C28191DB6464B00152429 /* HUBComponentWithSelectionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentWithSelectionState.h; sourceTree = "<group>"; };
+		8A4EB8B01DBA47E90004588C /* HUBAsyncAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBAsyncAction.h; sourceTree = "<group>"; };
 		8A58E0E21C5A77C700F41A5C /* HUBJSONPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBJSONPathTests.m; sourceTree = "<group>"; };
 		8A58E1461C5B79A900F41A5C /* HUBMutableJSONPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBMutableJSONPathTests.m; sourceTree = "<group>"; };
 		8A58E1481C5FA62E00F41A5C /* HUBComponentImageDataBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentImageDataBuilderTests.m; sourceTree = "<group>"; };
@@ -526,6 +527,7 @@
 			isa = PBXGroup;
 			children = (
 				8A2A72EE1D4B749600141619 /* HUBAction.h */,
+				8A4EB8B01DBA47E90004588C /* HUBAsyncAction.h */,
 				8A0C356C1D7DB656007C32D9 /* HUBActionFactory.h */,
 				8A2A72ED1D4B744A00141619 /* HUBActionRegistry.h */,
 				8AD585B51DB4D38700DB7606 /* HUBActionPerformer.h */,

--- a/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
+++ b/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		8A27299A1D9546BB00EF43FC /* RootContentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2729991D9546BB00EF43FC /* RootContentOperationFactory.swift */; };
 		8A27299E1D9546ED00EF43FC /* RootContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A27299D1D9546ED00EF43FC /* RootContentOperation.swift */; };
 		8A2729A21D95486A00EF43FC /* URL+ViewURIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2729A11D95486A00EF43FC /* URL+ViewURIs.swift */; };
+		8A374CFF1DBE659E0013E592 /* TodoListActionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A374CFC1DBE659E0013E592 /* TodoListActionFactory.swift */; };
+		8A374D001DBE659E0013E592 /* TodoListAddAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A374CFD1DBE659E0013E592 /* TodoListAddAction.swift */; };
+		8A374D011DBE659E0013E592 /* TodoListContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A374CFE1DBE659E0013E592 /* TodoListContentOperation.swift */; };
 		8A42E0AB1D8C376B004FAC33 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E0A91D8C376B004FAC33 /* AppDelegate.swift */; };
 		8A42E0B21D8C3779004FAC33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8A42E0AE1D8C3779004FAC33 /* Assets.xcassets */; };
 		8A42E0B31D8C3779004FAC33 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A42E0AF1D8C3779004FAC33 /* LaunchScreen.storyboard */; };
@@ -65,6 +68,9 @@
 		8A2729991D9546BB00EF43FC /* RootContentOperationFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootContentOperationFactory.swift; sourceTree = "<group>"; };
 		8A27299D1D9546ED00EF43FC /* RootContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootContentOperation.swift; sourceTree = "<group>"; };
 		8A2729A11D95486A00EF43FC /* URL+ViewURIs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+ViewURIs.swift"; sourceTree = "<group>"; };
+		8A374CFC1DBE659E0013E592 /* TodoListActionFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoListActionFactory.swift; sourceTree = "<group>"; };
+		8A374CFD1DBE659E0013E592 /* TodoListAddAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoListAddAction.swift; sourceTree = "<group>"; };
+		8A374CFE1DBE659E0013E592 /* TodoListContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoListContentOperation.swift; sourceTree = "<group>"; };
 		8A42E0921D8C36A3004FAC33 /* HubFrameworkDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HubFrameworkDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A42E0A91D8C376B004FAC33 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A42E0AE1D8C3779004FAC33 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -107,6 +113,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8A374CFA1DBE65920013E592 /* Todo list */ = {
+			isa = PBXGroup;
+			children = (
+				8A374CFC1DBE659E0013E592 /* TodoListActionFactory.swift */,
+				8A374CFD1DBE659E0013E592 /* TodoListAddAction.swift */,
+				8A374CFE1DBE659E0013E592 /* TodoListContentOperation.swift */,
+			);
+			name = "Todo list";
+			sourceTree = "<group>";
+		};
 		8A42E0891D8C36A3004FAC33 = {
 			isa = PBXGroup;
 			children = (
@@ -198,6 +214,7 @@
 				8AD5EDB11D9A7CE4004B2CEA /* GitHub Search */,
 				8AD72F4F1D9ABCDD00E4B427 /* Pretty pictures */,
 				8ABCCEA71D9D1AAB005113B5 /* Really long list */,
+				8A374CFA1DBE65920013E592 /* Todo list */,
 			);
 			name = Features;
 			sourceTree = "<group>";
@@ -352,6 +369,7 @@
 				8AD72F571D9AC22600E4B427 /* ImageComponent.swift in Sources */,
 				8A2729A21D95486A00EF43FC /* URL+ViewURIs.swift in Sources */,
 				8A42E1F91D8C476C004FAC33 /* ComponentFallbackHandler.swift in Sources */,
+				8A374D001DBE659E0013E592 /* TodoListAddAction.swift in Sources */,
 				8ABCCEAC1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift in Sources */,
 				8AD5EDCE1D9AA294004B2CEA /* LabelComponent.swift in Sources */,
 				8AD5EDCA1D9A9DBC004B2CEA /* GitHubSearchActivityIndicatorContentOperation.swift in Sources */,
@@ -360,12 +378,14 @@
 				8A42E0AB1D8C376B004FAC33 /* AppDelegate.swift in Sources */,
 				8AD5EDC41D9A92EC004B2CEA /* GitHubSearchCustomDataKeys.swift in Sources */,
 				8A27299E1D9546ED00EF43FC /* RootContentOperation.swift in Sources */,
+				8A374CFF1DBE659E0013E592 /* TodoListActionFactory.swift in Sources */,
 				8ABCCEAA1D9D1AC3005113B5 /* ReallyLongListContentOperation.swift in Sources */,
 				8AD5EDB91D9A7DEC004B2CEA /* DefaultComponentFactory.swift in Sources */,
 				8AD5EDC61D9A9674004B2CEA /* HUBJSONSchemaRegistry+CustomSchemas.swift in Sources */,
 				8AD5EDC81D9A9C3C004B2CEA /* ActivityIndicatorComponent.swift in Sources */,
 				8AD72F551D9AC18100E4B427 /* PrettyPicturesContentOperationFactory.swift in Sources */,
 				8AD5EDC21D9A90F7004B2CEA /* GitHubSearchResultsContentOperation.swift in Sources */,
+				8A374D011DBE659E0013E592 /* TodoListContentOperation.swift in Sources */,
 				8AD14FED1D9958A90008E182 /* UIImageView+Animation.swift in Sources */,
 				8A42E1F71D8C468C004FAC33 /* ComponentLayoutManager.swift in Sources */,
 				8AD72F531D9ABDB100E4B427 /* PrettyPicturesContentOperation.swift in Sources */,

--- a/demo/sources/AppDelegate.swift
+++ b/demo/sources/AppDelegate.swift
@@ -43,6 +43,7 @@ import HubFramework
         registerGitHubSearchFeature()
         registerPrettyPicturesFeature()
         registerReallyLongListFeature()
+        registerTodoListFeature()
         
         return true
     }
@@ -120,6 +121,25 @@ import HubFramework
             actionHandler: nil,
             viewControllerScrollHandler: nil
         )
+    }
+    
+    private func registerTodoListFeature() {
+        let contentOperationFactory = HUBBlockContentOperationFactory() { _ in
+            return [TodoListContentOperation()]
+        }
+        
+        hubManager.featureRegistry.registerFeature(
+            withIdentifier: "todoList",
+            viewURIPredicate: HUBViewURIPredicate(viewURI: .todoListViewURI),
+            title: "Todo List",
+            contentOperationFactories: [contentOperationFactory],
+            contentReloadPolicy: nil,
+            customJSONSchemaIdentifier: nil,
+            actionHandler: nil,
+            viewControllerScrollHandler: nil
+        )
+        
+        hubManager.actionRegistry.register(TodoListActionFactory(), forNamespace: TodoListActionFactory.namespace)
     }
     
     // MARK: - Opening view URIs

--- a/demo/sources/RootContentOperation.swift
+++ b/demo/sources/RootContentOperation.swift
@@ -48,6 +48,11 @@ class RootContentOperation: NSObject, HUBContentOperation {
         reallyLongListRowBuilder.subtitle = "A feature that renders 10,000 rows"
         reallyLongListRowBuilder.targetBuilder.uri = .reallyLongListViewURI
         
+        let todoListRowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "todoList")
+        todoListRowBuilder.title = "Todo list"
+        todoListRowBuilder.subtitle = "A feature for adding todo items to a list"
+        todoListRowBuilder.targetBuilder.uri = .todoListViewURI
+        
         delegate?.contentOperationDidFinish(self)
     }
 }

--- a/demo/sources/SearchBarComponent.swift
+++ b/demo/sources/SearchBarComponent.swift
@@ -42,7 +42,7 @@ class SearchBarComponent: NSObject, HUBComponentActionPerformer, UISearchBarDele
     static let debounceInterval = 0.3
 
     var view: UIView?
-    var actionDelegate: HUBComponentActionDelegate?
+    weak var actionPerformer: HUBActionPerformer?
 
     var debounceTimer: Timer?
     
@@ -95,7 +95,7 @@ class SearchBarComponent: NSObject, HUBComponentActionPerformer, UISearchBarDele
         debounceTimer?.invalidate()
         self.debounceTimer = Timer.scheduledTimer(withTimeInterval: SearchBarComponent.debounceInterval, repeats: false) { (_) in
             let customData = [SearchBarComponentCustomDataKeys.text: searchText]
-            self.actionDelegate?.component(self, performActionWith: actionIdentifier, customData: customData)
+            self.actionPerformer?.performAction(withIdentifier: actionIdentifier, customData: customData)
         }
     }
     

--- a/demo/sources/TodoListActionFactory.swift
+++ b/demo/sources/TodoListActionFactory.swift
@@ -1,0 +1,24 @@
+import Foundation
+import HubFramework
+
+/// Action names used by `TodoListActionFactory`
+struct TodoListActionNames {
+    /// The name of an action to display an alert to add a todo item
+    static var add: String { return "add" }
+    /// The name of an action that gets performed once a todo item has been added
+    static var addCompleted: String { return "add-completed" }
+}
+
+/// Action factory used by the "Todo list" feature
+class TodoListActionFactory: NSObject, HUBActionFactory {
+    /// The namespace that this action factory is registered for with `HUBActionRegistry`
+    static var namespace: String { return "namespace" }
+    
+    func createAction(forName name: String) -> HUBAction? {
+        if (name == TodoListActionNames.add) {
+            return TodoListAddAction()
+        }
+        
+        return nil
+    }
+}

--- a/demo/sources/TodoListActionFactory.swift
+++ b/demo/sources/TodoListActionFactory.swift
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 import Foundation
 import HubFramework
 

--- a/demo/sources/TodoListAddAction.swift
+++ b/demo/sources/TodoListAddAction.swift
@@ -1,0 +1,37 @@
+import Foundation
+import HubFramework
+
+/// Action custom data keys used by `TodoListAddAction`
+struct TodoListAddActionCustomDataKeys {
+    /// The title of the item to add to a todo list
+    static var itemTitle: String { return "item" }
+}
+
+/// Action that presents an alert to add a todo list item
+class TodoListAddAction: NSObject, HUBAsyncAction {
+    weak var delegate: HUBAsyncActionDelegate?
+    
+    func perform(with context: HUBActionContext) -> Bool {
+        let alertController = UIAlertController(title: "Add an item", message: nil, preferredStyle: .alert)
+        alertController.addTextField(configurationHandler: nil)
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            alertController.dismiss(animated: true, completion: nil)
+            self.delegate?.actionDidFinish(self, chainToActionWithIdentifier: nil, customData: nil)
+        }
+        
+        let doneAction = UIAlertAction(title: "Add", style: .default) { _ in
+            let nextActionIdentifier = HUBIdentifier(namespace: TodoListActionFactory.namespace, name: TodoListActionNames.addCompleted)
+            let nextActionCustomData = [TodoListAddActionCustomDataKeys.itemTitle: alertController.textFields!.first!.text]
+            self.delegate?.actionDidFinish(self, chainToActionWithIdentifier: nextActionIdentifier, customData: nextActionCustomData)
+        }
+        
+        alertController.addAction(cancelAction)
+        alertController.addAction(doneAction)
+        
+        context.viewController.present(alertController, animated: true, completion: nil)
+        
+        return true
+    }
+}
+

--- a/demo/sources/TodoListAddAction.swift
+++ b/demo/sources/TodoListAddAction.swift
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 import Foundation
 import HubFramework
 

--- a/demo/sources/TodoListContentOperation.swift
+++ b/demo/sources/TodoListContentOperation.swift
@@ -1,0 +1,39 @@
+import Foundation
+import HubFramework
+
+/// Content operation used by the "Todo list" feature
+class TodoListContentOperation: NSObject, HUBContentOperationActionPerformer, HUBContentOperationActionObserver {
+    weak var delegate: HUBContentOperationDelegate?
+    weak var actionPerformer: HUBActionPerformer?
+    
+    private var items = [String]()
+
+    func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {
+        viewModelBuilder.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(handleAddButton))
+        
+        items.enumerated().forEach { index, item in
+            let itemRowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "item-\(index)")
+            itemRowBuilder.title = item
+        }
+        
+        delegate?.contentOperationDidFinish(self)
+    }
+    
+    func actionPerformed(with context: HUBActionContext, viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState) {
+        guard context.customActionIdentifier == HUBIdentifier(namespace: TodoListActionFactory.namespace, name: TodoListActionNames.addCompleted) else {
+            return
+        }
+        
+        guard let itemTitle = context.customData?[TodoListAddActionCustomDataKeys.itemTitle] as? String else {
+            return
+        }
+        
+        items.append(itemTitle)
+        delegate?.contentOperationRequiresRescheduling(self)
+    }
+    
+    @objc private func handleAddButton() {
+        let actionIdentifier = HUBIdentifier(namespace: TodoListActionFactory.namespace, name: TodoListActionNames.add)
+        actionPerformer?.performAction(withIdentifier: actionIdentifier, customData: nil)
+    }
+}

--- a/demo/sources/TodoListContentOperation.swift
+++ b/demo/sources/TodoListContentOperation.swift
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 import Foundation
 import HubFramework
 

--- a/demo/sources/URL+ViewURIs.swift
+++ b/demo/sources/URL+ViewURIs.swift
@@ -41,6 +41,11 @@ extension URL {
     static var reallyLongListViewURI: URL {
         return URL(viewURI: "reallylonglist")
     }
+    
+    /// The view URI used for the "Todo list" feature
+    static var todoListViewURI: URL {
+        return URL(viewURI: "todoList")
+    }
 }
 
 private extension URL {

--- a/include/HubFramework/HUBAction.h
+++ b/include/HubFramework/HUBAction.h
@@ -19,7 +19,6 @@
  *  under the License.
  */
 
-
 #import <Foundation/Foundation.h>
 
 @protocol HUBActionContext;

--- a/include/HubFramework/HUBActionContext.h
+++ b/include/HubFramework/HUBActionContext.h
@@ -62,8 +62,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// The view model of the view that the action is being performed in
 @property (nonatomic, strong, readonly) id<HUBViewModel> viewModel;
 
-/// The model of the component that the action is being performed for
-@property (nonatomic, strong, readonly) id<HUBComponentModel> componentModel;
+/// The model of any component that the action is being performed for (nil if performed by a content operation)
+@property (nonatomic, strong, readonly, nullable) id<HUBComponentModel> componentModel;
 
 /// The view controller that the action is being performed in
 @property (nonatomic, strong, readonly) UIViewController *viewController;

--- a/include/HubFramework/HUBActionPerformer.h
+++ b/include/HubFramework/HUBActionPerformer.h
@@ -1,0 +1,41 @@
+#import <Foundation/Foundation.h>
+
+@class HUBIdentifier;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  Protocol defining the public API of an object that performs Hub Framework actions
+ *
+ *  You use this API to manually perform actions from either a component (conforming to
+ *  `HUBComponentActionPerformer`) or content operation (conforming to
+ *  `HUBContentOperationActionPerformer`).
+ *
+ *  Actions are used to define custom behavior and/or to communicate between the parts
+ *  that make up a Hub Framework-powered view.
+ *
+ *  You don't conform to this protocol yourself. Instead, the Hub Framework will assign
+ *  an object conforming to this protocol to the `actionPerformer` property of either a
+ *  component or content operation.
+ */
+@protocol HUBActionPerformer <NSObject>
+
+/**
+ *  Perform an action with a given identifier, optionally passing custom data as well
+ *
+ *  @param identifier The identifier of the action to perform. Will be resolved to a
+ *         `HUBAction` if matching a `HUBActionFactory` registered with `HUBActionRegistry`
+ *         for the given identifier's namespace part.
+ *  @param customData Any custom data to send to the action. Will be available on the
+ *         `HUBActionContext` passed to the action when performed.
+ *
+ *  @return A boolean indicating whether the action was successfully performed or not.
+ *          `NO` will be returned if either no action could be created for the given
+ *          identifier, or if the resolved action returned `NO` when being performed.
+ */
+- (BOOL)performActionWithIdentifier:(HUBIdentifier *)identifier
+                         customData:(nullable NSDictionary<NSString *, id> *)customData NS_SWIFT_NAME(performAction(withIdentifier:customData:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBActionPerformer.h
+++ b/include/HubFramework/HUBActionPerformer.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import <Foundation/Foundation.h>
 
 @class HUBIdentifier;

--- a/include/HubFramework/HUBActionTrigger.h
+++ b/include/HubFramework/HUBActionTrigger.h
@@ -27,5 +27,7 @@ typedef NS_ENUM(NSUInteger, HUBActionTrigger) {
     /// The action was triggered by that a component was selected
     HUBActionTriggerSelection,
     /// The action was triggered manually by a component
-    HUBActionTriggerComponent
+    HUBActionTriggerComponent,
+    /// The action was triggered manually by a content operation
+    HUBActionTriggerContentOperation
 };

--- a/include/HubFramework/HUBActionTrigger.h
+++ b/include/HubFramework/HUBActionTrigger.h
@@ -19,7 +19,6 @@
  *  under the License.
  */
 
-
 #import <Foundation/Foundation.h>
 
 /// Enum describing various reasons that can cause an action to be triggered
@@ -29,5 +28,7 @@ typedef NS_ENUM(NSUInteger, HUBActionTrigger) {
     /// The action was triggered manually by a component
     HUBActionTriggerComponent,
     /// The action was triggered manually by a content operation
-    HUBActionTriggerContentOperation
+    HUBActionTriggerContentOperation,
+    /// The action was triggered as a chained action
+    HUBActionTriggerChained
 };

--- a/include/HubFramework/HUBAsyncAction.h
+++ b/include/HubFramework/HUBAsyncAction.h
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBAction.h"
+
+@protocol HUBAsyncAction;
+@class HUBIdentifier;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Delegate protocol used by `HUBAsyncAction` types to notify the Hub Framework when they finish
+@protocol HUBAsyncActionDelegate <NSObject>
+
+/**
+ *  Notify the Hub Framework that an asynchronous action finished
+ *
+ *  @param action The action that was finished
+ *  @param nextActionIdentifier The identifier of any action to chain this action to. Any action
+ *         matching this identifier will immediately be invoked, optionally with the given custom data.
+ *  @param nextActionCustomData Any custom data to pass to the next action that this one chains to
+ *
+ *  Call this method whenever an asynchronous action finished doing its work, to enable the Hub Framework
+ *  to release it from memory. You can also (optionally) at this point chain the action that was finished
+ *  to another, by supplying an action identifier and any custom data. This enables you to create chains
+ *  of logic from actions.
+ */
+- (void)actionDidFinish:(id<HUBAsyncAction>)action
+        chainToActionWithIdentifier:(nullable HUBIdentifier *)nextActionIdentifier
+        customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData NS_SWIFT_NAME(actionDidFinish(_:chainToActionWithIdentifier:customData:));
+
+@end
+
+/**
+ *  Extended action protocol used to define actions that are asynchronous
+ *
+ *  Asynchronous actions enable you to perform work even after the main `performWithContext:`
+ *  method has returned. Once you're done performing an async action, call its delegate. The
+ *  Hub Framework will automatically retain any performed asynchronous actions until they have
+ *  been completed.
+ */
+@protocol HUBAsyncAction <HUBAction>
+
+/**
+ *  The action's delegate
+ *
+ *  The Hub Framework will assign an object to this property, so just \@synthesize it, and use
+ *  the delegate to notify the framework when your action has completed and can safely be released.
+ */
+@property (nonatomic, weak, nullable) id<HUBAsyncActionDelegate> delegate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBComponentActionPerformer.h
+++ b/include/HubFramework/HUBComponentActionPerformer.h
@@ -21,35 +21,9 @@
 
 #import "HUBComponent.h"
 
-@protocol HUBComponentActionPerformer;
-@class HUBIdentifier;
+@protocol HUBActionPerformer;
 
 NS_ASSUME_NONNULL_BEGIN
-
-/**
- *  Delegate protocol used to perform Hub Framework actions from a component
- *
- *  You don't implement this protocol yourself. Instead, you \@synthesize your component's `actionDelegate` property,
- *  and may choose to use this API to perform actions from your component implementation.
- */
-@protocol HUBComponentActionDelegate <NSObject>
-
-/**
- *  Perform an action with a given identifier from a component
- *
- *  @param component The component that wants the action to be performed
- *  @param identifier The identifier of the action to perform
- *  @param customData Any custom data that should be passed to the action
- *
- *  @return A boolean indicating whether the action was successfully performed. For example, `NO` will be returned
- *          if no actions could be found for the given identifier, or if that action in turn returned `NO` as its
- *          outcome when being performed.
- */
-- (BOOL)component:(id<HUBComponentActionPerformer>)component
-        performActionWithIdentifier:(HUBIdentifier *)identifier
-        customData:(nullable NSDictionary<NSString *, id> *)customData;
-
-@end
 
 /**
  *  Extended Hub component protocol that adds the ability to perform actions
@@ -65,12 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol HUBComponentActionPerformer <HUBComponent>
 
 /**
- *  The object that acts as a delegate for performing actions on behalf of the component
+ *  An object that can be used to perform actions on behalf of this component
  *
  *  Don't assign any custom objects to this property. Instead, just \@sythensize it, so that the Hub Framework can
  *  assign an internal object to this property, to enable you to perform actions from the component.
  */
-@property (nonatomic, weak, nullable) id<HUBComponentActionDelegate> actionDelegate;
+@property (nonatomic, weak, nullable) id<HUBActionPerformer> actionPerformer;
 
 @end
 

--- a/include/HubFramework/HUBContentOperationActionPerformer.h
+++ b/include/HubFramework/HUBContentOperationActionPerformer.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBContentOperation.h"
 
 @protocol HUBActionPerformer;

--- a/include/HubFramework/HUBContentOperationActionPerformer.h
+++ b/include/HubFramework/HUBContentOperationActionPerformer.h
@@ -1,0 +1,29 @@
+#import "HUBContentOperation.h"
+
+@protocol HUBActionPerformer;
+
+/**
+ *  Extended content operation protocol that adds the ability to perform actions
+ *
+ *  Use this protocol whenever you want one of your content operations to be able to perform
+ *  actions. Actions can be used to perform small, atomic tasks and provide a lightweight way
+ *  to extend the Hub Framework with additional functionality.
+ *
+ *  For more information about actions, see `HUBAction`, as well as the "Action programming
+ *  guide" available at https://spotify.github.io/HubFramework/action-programming-guide.html.
+ *
+ *  For more information about content operations, see `HUBContentOperation`.
+ */
+@protocol HUBContentOperationActionPerformer <HUBContentOperation>
+
+/**
+ *  An object that can be used to perform actions on behalf of this content operation
+ *
+ *  Don't assign any custom objects to this property. Instead, just \@sythensize it, so that
+ *  the Hub Framework can assign an internal object to this property, to enable you to perform
+ *  actions from the content operation.
+ */
+@property (nonatomic, weak, nullable) id<HUBActionPerformer> actionPerformer;
+
+@end
+

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -92,6 +92,7 @@
 
 // Actions
 #import "HUBAction.h"
+#import "HUBAsyncAction.h"
 #import "HUBActionFactory.h"
 #import "HUBActionRegistry.h"
 #import "HUBActionPerformer.h"

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -43,6 +43,7 @@
 #import "HUBContentOperation.h"
 #import "HUBContentOperationWithInitialContent.h"
 #import "HUBContentOperationActionObserver.h"
+#import "HUBContentOperationActionPerformer.h"
 #import "HUBContentReloadPolicy.h"
 #import "HUBBlockContentOperationFactory.h"
 

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -93,6 +93,7 @@
 #import "HUBAction.h"
 #import "HUBActionFactory.h"
 #import "HUBActionRegistry.h"
+#import "HUBActionPerformer.h"
 #import "HUBActionHandler.h"
 #import "HUBActionContext.h"
 #import "HUBActionTrigger.h"

--- a/sources/HUBActionContextImplementation.h
+++ b/sources/HUBActionContextImplementation.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param customData Any custom data that should be passed to the action
  *  @param viewURI The URI of the view that the action is for
  *  @param viewModel The model of the view that the action is for
- *  @param componentModel The model of the component that the action is for
+ *  @param componentModel The model of any component that the action is for
  *  @param viewController The view controller presenting the view that the action is for
  */
 - (instancetype)initWithTrigger:(HUBActionTrigger)trigger
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
                      customData:(nullable NSDictionary<NSString *, id> *)customData
                         viewURI:(NSURL *)viewURI
                       viewModel:(id<HUBViewModel>)viewModel
-                 componentModel:(id<HUBComponentModel>)componentModel
+                 componentModel:(nullable id<HUBComponentModel>)componentModel
                  viewController:(UIViewController *)viewController HUB_DESIGNATED_INITIALIZER;
 
 @end

--- a/sources/HUBActionContextImplementation.m
+++ b/sources/HUBActionContextImplementation.m
@@ -38,12 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
                      customData:(nullable NSDictionary<NSString *, id> *)customData
                         viewURI:(NSURL *)viewURI
                       viewModel:(id<HUBViewModel>)viewModel
-                 componentModel:(id<HUBComponentModel>)componentModel
+                 componentModel:(nullable id<HUBComponentModel>)componentModel
                  viewController:(UIViewController *)viewController
 {
     NSParameterAssert(viewURI != nil);
     NSParameterAssert(viewModel != nil);
-    NSParameterAssert(componentModel != nil);
     NSParameterAssert(viewController != nil);
 
     self = [super init];

--- a/sources/HUBActionHandlerWrapper.h
+++ b/sources/HUBActionHandlerWrapper.h
@@ -22,14 +22,35 @@
 #import "HUBActionHandler.h"
 #import "HUBHeaderMacros.h"
 
+@class HUBActionHandlerWrapper;
+@class HUBIdentifier;
 @class HUBActionRegistryImplementation;
 @class HUBInitialViewModelRegistry;
 @class HUBViewModelLoaderImplementation;
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Delegate protocol for `HUBActionHandlerWrapper`
+@protocol HUBActionHandlerWrapperDelegate <NSObject>
+
+/**
+ *  Provide an action context for an action handler
+ *
+ *  @param actionHandler The handler to provide an action context for
+ *  @param actionIdentifier The identifier of the action to return a context for
+ *  @param customData Any custom data to include in the returned action context
+ */
+- (id<HUBActionContext>)actionHandler:(HUBActionHandlerWrapper *)actionHandler
+                        provideContextForActionWithIdentifier:(HUBIdentifier *)actionIdentifier
+                        customData:(nullable NSDictionary<NSString *, id> *)customData;
+
+@end
+
 /// Class handling actions for a Hub Framework powered-view, while wrapping any user-specified action handler
 @interface HUBActionHandlerWrapper : NSObject <HUBActionHandler>
+
+/// The action handler's delegate. See `HUBActionHandlerWrapperDelegate` for more information.
+@property (nonatomic, weak, nullable) id<HUBActionHandlerWrapperDelegate> delegate;
 
 /**
  *  Initialize an instance of this class

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -384,8 +384,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     return YES;
 }
-#pragma mark - HUBActionPerformer
 
+#pragma mark - HUBActionPerformer
 
 - (BOOL)performActionWithIdentifier:(HUBIdentifier *)identifier customData:(nullable NSDictionary<NSString *, id> *)customData
 {

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -30,12 +30,13 @@
 #import "HUBComponentModel.h"
 #import "HUBComponentUIStateManager.h"
 #import "HUBComponentResizeObservingView.h"
+#import "HUBActionPerformer.h"
 #import "HUBComponentGestureRecognizer.h"
 #import "HUBUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface HUBComponentWrapper () <HUBComponentChildDelegate, HUBComponentActionDelegate, HUBComponentResizeObservingViewDelegate, UIGestureRecognizerDelegate>
+@interface HUBComponentWrapper () <HUBComponentChildDelegate, HUBComponentResizeObservingViewDelegate, HUBActionPerformer, UIGestureRecognizerDelegate>
 
 @property (nonatomic, strong, readwrite) id<HUBComponentModel> model;
 @property (nonatomic, assign) BOOL viewHasAppearedSinceLastModelChange;
@@ -80,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         if ([_component conformsToProtocol:@protocol(HUBComponentActionPerformer)]) {
-            ((id<HUBComponentActionPerformer>)_component).actionDelegate = self;
+            ((id<HUBComponentActionPerformer>)_component).actionPerformer = self;
         }
     }
     
@@ -342,15 +343,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self.delegate componentWrapper:self childSelectedAtIndex:childIndex];
 }
 
-#pragma mark - HUBComponentActionDelegate
+#pragma mark - HUBComponentResizeObservingViewDelegate
 
-- (BOOL)component:(id<HUBComponentActionPerformer>)component performActionWithIdentifier:(HUBIdentifier *)identifier customData:(nullable NSDictionary<NSString *, id> *)customData
+- (void)resizeObservingViewDidResize:(HUBComponentResizeObservingView *)view
 {
-    if (self.component != component) {
-        return NO;
-    }
-    
-    return [self.delegate componentWrapper:self performActionWithIdentifier:identifier customData:customData];
+    [(id<HUBComponentViewObserver>)self.component viewDidResize];
 }
 
 #pragma mark - UIGestureRecognizerDelegate
@@ -360,11 +357,11 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
 }
 
-#pragma mark - HUBComponentResizeObservingViewDelegate
+#pragma mark - HUBActionPerformer
 
-- (void)resizeObservingViewDidResize:(HUBComponentResizeObservingView *)view
+- (BOOL)performActionWithIdentifier:(HUBIdentifier *)identifier customData:(nullable NSDictionary<NSString *, id> *)customData
 {
-    [(id<HUBComponentViewObserver>)self.component viewDidResize];
+    return [self.delegate componentWrapper:self performActionWithIdentifier:identifier customData:customData];
 }
 
 #pragma mark - Gesture recognizer handling

--- a/sources/HUBViewControllerImplementation.h
+++ b/sources/HUBViewControllerImplementation.h
@@ -25,13 +25,13 @@
 @protocol HUBImageLoader;
 @protocol HUBContentReloadPolicy;
 @protocol HUBComponentLayoutManager;
-@protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
 @class HUBViewModelLoaderImplementation;
 @class HUBCollectionViewFactory;
 @class HUBComponentRegistryImplementation;
 @class HUBInitialViewModelRegistry;
 @class HUBActionRegistryImplementation;
+@class HUBActionHandlerWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
-                  actionHandler:(id<HUBActionHandler>)actionHandler
+                  actionHandler:(HUBActionHandlerWrapper *)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader HUB_DESIGNATED_INITIALIZER;
 

--- a/sources/HUBViewControllerImplementation.h
+++ b/sources/HUBViewControllerImplementation.h
@@ -22,12 +22,12 @@
 #import "HUBViewController.h"
 #import "HUBHeaderMacros.h"
 
-@protocol HUBViewModelLoader;
 @protocol HUBImageLoader;
 @protocol HUBContentReloadPolicy;
 @protocol HUBComponentLayoutManager;
 @protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
+@class HUBViewModelLoaderImplementation;
 @class HUBCollectionViewFactory;
 @class HUBComponentRegistryImplementation;
 @class HUBInitialViewModelRegistry;
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithViewURI:(NSURL *)viewURI
               featureIdentifier:(NSString *)featureIdentifier
-                viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
+                viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager

--- a/sources/HUBViewModelLoaderImplementation.h
+++ b/sources/HUBViewModelLoaderImplementation.h
@@ -29,12 +29,16 @@
 @protocol HUBConnectivityStateResolver;
 @protocol HUBIconImageResolver;
 @protocol HUBActionContext;
+@protocol HUBActionPerformer;
 @class HUBComponentDefaults;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Concrete implementation of the `HUBViewModelLoader` API
 @interface HUBViewModelLoaderImplementation : NSObject <HUBViewModelLoader>
+
+/// Any object that performs actions on behalf of this view model loader
+@property (nonatomic, weak, nullable) id<HUBActionPerformer> actionPerformer;
 
 /**
  *  Initialize an instance of this class with its required dependencies & values

--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -25,6 +25,8 @@
 #import "HUBConnectivityStateResolver.h"
 #import "HUBContentOperationWithInitialContent.h"
 #import "HUBContentOperationActionObserver.h"
+#import "HUBContentOperationActionPerformer.h"
+#import "HUBActionPerformer.h"
 #import "HUBContentReloadPolicy.h"
 #import "HUBJSONSchema.h"
 #import "HUBViewModelBuilderImplementation.h"
@@ -121,6 +123,21 @@ NS_ASSUME_NONNULL_BEGIN
                                                                              viewURI:self.viewURI
                                                                          featureInfo:self.featureInfo
                                                                    connectivityState:self.connectivityState];
+    }
+}
+
+#pragma mark - Accessor overrides
+
+- (void)setActionPerformer:(nullable id<HUBActionPerformer>)actionPerformer
+{
+    _actionPerformer = actionPerformer;
+    
+    for (id<HUBContentOperation> const operation in self.contentOperations) {
+        if (![operation conformsToProtocol:@protocol(HUBContentOperationActionPerformer)]) {
+            continue;
+        }
+        
+        ((id<HUBContentOperationActionPerformer>)operation).actionPerformer = actionPerformer;
     }
 }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -55,6 +55,7 @@
 #import "HUBActionContext.h"
 #import "HUBActionFactoryMock.h"
 #import "HUBActionMock.h"
+#import "HUBActionPerformer.h"
 #import "HUBViewControllerScrollHandlerMock.h"
 #import "HUBComponentCollectionViewCell.h"
 #import "HUBUtilities.h"
@@ -1823,9 +1824,8 @@
     
     NSDictionary * const customActionData = @{@"custom": @"data"};
     
-    BOOL const actionOutcome = [self.component.actionDelegate component:self.component
-                                            performActionWithIdentifier:actionIdentifier
-                                                             customData:customActionData];
+    BOOL const actionOutcome = [self.component.actionPerformer performActionWithIdentifier:actionIdentifier
+                                                                                customData:customActionData];
     
     XCTAssertTrue(actionOutcome);
     XCTAssertEqualObjects(actionContext.componentModel.identifier, @"A");

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1835,6 +1835,30 @@
     XCTAssertEqual(self.contentOperation.actionContext, actionContext);
 }
 
+- (void)testPerformingActionFromContentOperation
+{
+    __block id<HUBActionContext> actionContext = nil;
+    
+    self.actionHandler.block = ^(id<HUBActionContext> context) {
+        actionContext = context;
+        return YES;
+    };
+    
+    [self simulateViewControllerLayoutCycle];
+    
+    HUBIdentifier * const actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"contentOperation" name:@"action"];
+    NSDictionary * const customActionData = @{@"custom": @"data"};
+    BOOL const actionOutcome = [self.contentOperation.actionPerformer performActionWithIdentifier:actionIdentifier
+                                                                                       customData:customActionData];
+    
+    XCTAssertTrue(actionOutcome);
+    XCTAssertNil(actionContext.componentModel);
+    XCTAssertEqualObjects(actionContext.customData, customActionData);
+    XCTAssertEqual(actionContext.trigger, HUBActionTriggerContentOperation);
+    XCTAssertEqualObjects(self.actionHandler.contexts, @[actionContext]);
+    XCTAssertEqual(self.contentOperation.actionContext, actionContext);
+}
+
 - (void)testAssigningNavigationItemProperties
 {
     UIBarButtonItem * const rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:[UIView new]];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1859,6 +1859,56 @@
     XCTAssertEqual(self.contentOperation.actionContext, actionContext);
 }
 
+- (void)testPerformingAsyncAction
+{
+    HUBActionMock *action = [[HUBActionMock alloc] initWithBlock:^(id<HUBActionContext> context) {
+        return YES;
+    }];
+    action.isAsync = YES;
+    
+    HUBActionFactoryMock *actionFactory = [[HUBActionFactoryMock alloc] initWithActions:@{@"name": action}];
+    [self.actionRegistry registerActionFactory:actionFactory forNamespace:@"namespace"];
+    
+    __weak HUBActionMock *actionWeakRef = action;
+    
+    [self simulateViewControllerLayoutCycle];
+    
+    HUBIdentifier * const actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];
+    BOOL const actionOutcome = [self.contentOperation.actionPerformer performActionWithIdentifier:actionIdentifier
+                                                                                       customData:nil];
+    
+    // Here we unregister the action factory, to release our mocked reference to the action
+    // We also nil out our local reference, to be able to assert that the Hub Framework is retaining it
+    [self.actionRegistry unregisterActionFactoryForNamespace:@"namespace"];
+    actionFactory = nil;
+    action = nil;
+    
+    XCTAssertTrue(actionOutcome);
+    XCTAssertNotNil(actionWeakRef);
+    
+    // Capture action strongly again, to avoid compiler error
+    action = actionWeakRef;
+    
+    __block id<HUBActionContext> chainedActionContext = nil;
+    
+    self.actionHandler.block = ^(id<HUBActionContext> context) {
+        chainedActionContext = context;
+        return YES;
+    };
+    
+    HUBIdentifier * const chainedActionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"chained" name:@"action"];
+    NSDictionary * const chainedActionCustomData = @{@"custom": @"data"};
+    [action.delegate actionDidFinish:action chainToActionWithIdentifier:chainedActionIdentifier customData:chainedActionCustomData];
+    
+    // Action should now be fully released, since we are done with it
+    action = nil;
+    XCTAssertNil(actionWeakRef);
+    
+    XCTAssertNotNil(chainedActionContext);
+    XCTAssertEqualObjects(chainedActionContext.customActionIdentifier, chainedActionIdentifier);
+    XCTAssertEqualObjects(chainedActionContext.customData, chainedActionCustomData);
+}
+
 - (void)testAssigningNavigationItemProperties
 {
     UIBarButtonItem * const rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:[UIView new]];

--- a/tests/mocks/HUBActionMock.h
+++ b/tests/mocks/HUBActionMock.h
@@ -19,16 +19,19 @@
  *  under the License.
  */
 
-#import "HUBAction.h"
+#import "HUBAsyncAction.h"
 #import "HUBHeaderMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Mocked action, for use in unit tests only
-@interface HUBActionMock : NSObject <HUBAction>
+@interface HUBActionMock : NSObject <HUBAsyncAction>
 
 /// Any block to run when the action is performed
 @property (nonatomic, copy, nullable) BOOL(^block)(id<HUBActionContext>);
+
+/// Whether this action should act like it's asynchronous or not
+@property (nonatomic, assign) BOOL isAsync;
 
 /**
  *  Initialize an instance of this class

--- a/tests/mocks/HUBActionMock.m
+++ b/tests/mocks/HUBActionMock.m
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBActionMock
 
+@synthesize delegate = _delegate;
+
 #pragma mark - Initializer
 
 - (instancetype)initWithBlock:(BOOL(^_Nullable)(id<HUBActionContext>))block
@@ -43,6 +45,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)performWithContext:(id<HUBActionContext>)context
 {
     return self.block != nil ? self.block(context) : NO;
+}
+
+#pragma mark - NSObject
+
+- (BOOL)conformsToProtocol:(Protocol *)protocol
+{
+    if (protocol == @protocol(HUBAsyncAction)) {
+        return self.isAsync;
+    }
+    
+    return [super conformsToProtocol:protocol];
 }
 
 @end

--- a/tests/mocks/HUBComponentMock.m
+++ b/tests/mocks/HUBComponentMock.m
@@ -41,7 +41,7 @@
 
 @synthesize view = _view;
 @synthesize childDelegate = _childDelegate;
-@synthesize actionDelegate = _actionDelegate;
+@synthesize actionPerformer = _actionPerformer;
 
 - (instancetype)init
 {

--- a/tests/mocks/HUBContentOperationMock.h
+++ b/tests/mocks/HUBContentOperationMock.h
@@ -21,11 +21,16 @@
 
 #import "HUBContentOperationWithInitialContent.h"
 #import "HUBContentOperationActionObserver.h"
+#import "HUBContentOperationActionPerformer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Mocked content operation, for use in tests only
-@interface HUBContentOperationMock : NSObject <HUBContentOperationWithInitialContent, HUBContentOperationActionObserver>
+@interface HUBContentOperationMock : NSObject <
+    HUBContentOperationWithInitialContent,
+    HUBContentOperationActionObserver,
+    HUBContentOperationActionPerformer
+>
 
 /// A block that gets called whenever the content operation is asked to add initial content to a view model builder.
 @property (nonatomic, copy, nullable) void(^initialContentLoadingBlock)(id<HUBViewModelBuilder> builder);

--- a/tests/mocks/HUBContentOperationMock.m
+++ b/tests/mocks/HUBContentOperationMock.m
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation HUBContentOperationMock
 
 @synthesize delegate = _delegate;
+@synthesize actionPerformer = _actionPerformer;
 
 #pragma mark - HUBContentOperation
 


### PR DESCRIPTION
This PR makes some significant upgrades to the Action API.

- Enable content operations to **perform** actions. They were previously able to **observe** actions, but now they can also perform them.
- Enable actions to be async (through the new `HUBAsyncAction` protocol). Async actions are retained until they have completed.
- Enable action chaining. Actions can now hand over to another one, and also supply a new set of custom data. This enables the construction of really nice user flows using actions, and enables API users to easily extend the framework.

To demonstrate these new capabilities, a "Todo list" feature has been added to the demo app, that enables the user to add new items to a todo list through an alert dialog (all controlled using async actions).

The Action Programming guide, as well as the Xcode templates, will be updated in a subsequent PR.

![simulator screen shot 24 oct 2016 19 26 02](https://cloud.githubusercontent.com/assets/2466701/19656312/c296f438-9a1f-11e6-92ab-ad090c0d8425.png)
![simulator screen shot 24 oct 2016 19 26 11](https://cloud.githubusercontent.com/assets/2466701/19656317/c5746866-9a1f-11e6-9be1-3d55c41bc665.png)
