### PR TITLE
Calculate parent component’s view size up-front when creating children

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -461,7 +461,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 - (HUBComponentWrapper *)componentWrapper:(HUBComponentWrapper *)componentWrapper
                    childComponentForModel:(id<HUBComponentModel>)model
 {
-    CGSize const containerViewSize = HUBComponentLoadViewIfNeeded(componentWrapper).frame.size;
+    CGSize const containerViewSize = [self childComponentContainerViewSizeForParentWrapper:componentWrapper];
     
     HUBComponentWrapper * const childComponentWrapper = [self.childComponentReusePool componentWrapperForModel:model
                                                                                                       delegate:self
@@ -823,6 +823,16 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     
     [wrapper configureViewWithModel:model containerViewSize:containerViewSize];
     self.componentWrappersByModelIdentifier[model.identifier] = wrapper;
+}
+
+- (CGSize)childComponentContainerViewSizeForParentWrapper:(HUBComponentWrapper *)parentWrapper
+{
+    if (parentWrapper.isRootComponent && parentWrapper.model.type == HUBComponentTypeBody) {
+        NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:(NSInteger)parentWrapper.model.index inSection:0];
+        return [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame.size;
+    }
+    
+    return HUBComponentLoadViewIfNeeded(parentWrapper).frame.size;
 }
 
 - (nullable HUBComponentWrapper *)componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1384,12 +1384,13 @@
     XCTAssertTrue(CGSizeEqualToSize(self.component.currentContainerViewSize, self.collectionView.bounds.size));
 }
 
-- (void)testContainerViewSizeForChildComponentsAreParerentComponentsViewSize
+- (void)testContainerViewSizeForChildComponentsAreParentComponentsViewSize
 {
     NSString * const componentNamespace = @"childComponentSelection";
     NSString * const componentName = @"component";
     NSString * const childComponentName = @"componentB";
     HUBComponentMock * const component = [HUBComponentMock new];
+    component.preferredViewSize = CGSizeMake(200, 200);
     HUBComponentMock * const childComponent = [HUBComponentMock new];
 
     HUBComponentFactoryMock * const componentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{
@@ -1416,9 +1417,6 @@
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     [self.collectionView.dataSource collectionView:self.collectionView cellForItemAtIndexPath:indexPath];
 
-    const CGRect expectedParentFrame = CGRectMake(0, 0, 88, 88);
-    component.view.frame = expectedParentFrame;
-
     id<HUBComponentChildDelegate> const childDelegate = component.childDelegate;
 
     id<HUBComponentModel> const childComponentModelA = [component.model childAtIndex:0];
@@ -1426,7 +1424,9 @@
 
     [childDelegate component:component childComponentForModel:childComponentModelA];
 
-    XCTAssertTrue(CGSizeEqualToSize(childComponent.currentContainerViewSize, expectedParentFrame.size));
+    CGSize const expectedContainerViewSize = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame.size;
+    XCTAssertTrue(CGSizeEqualToSize(expectedContainerViewSize, CGSizeMake(200, 200)));
+    XCTAssertTrue(CGSizeEqualToSize(childComponent.currentContainerViewSize, expectedContainerViewSize));
 }
 
 - (void)testCollectionViewNotAddedOnTopOfInitialOverlayComponent


### PR DESCRIPTION
This patch fixes a bug where child components would get a `CGSizeZero` container view size, if created before their parent component was resized by `UICollectionView`. This is done by using layout attributes directly when computing the container view size for root body components.

This lookup is very fast (`O(1)`), since we cache the layout attributes by index path.