### PR TITLE
Demo app: Add carousel component

### DIFF
--- a/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
+++ b/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		8A42E1F71D8C468C004FAC33 /* ComponentLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E1F61D8C468C004FAC33 /* ComponentLayoutManager.swift */; };
 		8A42E1F91D8C476C004FAC33 /* ComponentFallbackHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E1F81D8C476C004FAC33 /* ComponentFallbackHandler.swift */; };
 		8A42E1FB1D8C4CEB004FAC33 /* RowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E1FA1D8C4CEB004FAC33 /* RowComponent.swift */; };
+		8AB850961DBF9DE300AFAFD0 /* CarouselComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB850951DBF9DE300AFAFD0 /* CarouselComponent.swift */; };
 		8ABCCEAA1D9D1AC3005113B5 /* ReallyLongListContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCCEA91D9D1AC3005113B5 /* ReallyLongListContentOperation.swift */; };
 		8ABCCEAC1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCCEAB1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift */; };
 		8AD14FED1D9958A90008E182 /* UIImageView+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD14FEC1D9958A90008E182 /* UIImageView+Animation.swift */; };
@@ -80,6 +81,7 @@
 		8A42E1F61D8C468C004FAC33 /* ComponentLayoutManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentLayoutManager.swift; sourceTree = "<group>"; };
 		8A42E1F81D8C476C004FAC33 /* ComponentFallbackHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentFallbackHandler.swift; sourceTree = "<group>"; };
 		8A42E1FA1D8C4CEB004FAC33 /* RowComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowComponent.swift; sourceTree = "<group>"; };
+		8AB850951DBF9DE300AFAFD0 /* CarouselComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselComponent.swift; sourceTree = "<group>"; };
 		8ABCCEA91D9D1AC3005113B5 /* ReallyLongListContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReallyLongListContentOperation.swift; sourceTree = "<group>"; };
 		8ABCCEAB1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReallyLongListContentOperationFactory.swift; sourceTree = "<group>"; };
 		8AD14FEC1D9958A90008E182 /* UIImageView+Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImageView+Animation.swift"; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				8AD72F561D9AC22600E4B427 /* ImageComponent.swift */,
 				8AD5EDB61D9A7D50004B2CEA /* SearchBarComponent.swift */,
 				8AD5EDC71D9A9C3C004B2CEA /* ActivityIndicatorComponent.swift */,
+				8AB850951DBF9DE300AFAFD0 /* CarouselComponent.swift */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -369,6 +372,7 @@
 				8AD72F571D9AC22600E4B427 /* ImageComponent.swift in Sources */,
 				8A2729A21D95486A00EF43FC /* URL+ViewURIs.swift in Sources */,
 				8A42E1F91D8C476C004FAC33 /* ComponentFallbackHandler.swift in Sources */,
+				8AB850961DBF9DE300AFAFD0 /* CarouselComponent.swift in Sources */,
 				8A374D001DBE659E0013E592 /* TodoListAddAction.swift in Sources */,
 				8ABCCEAC1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift in Sources */,
 				8AD5EDCE1D9AA294004B2CEA /* LabelComponent.swift in Sources */,

--- a/demo/sources/CarouselComponent.swift
+++ b/demo/sources/CarouselComponent.swift
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+import HubFramework
+
+/**
+ *  A component that renders an array of child components as a horizontally scrollable carousel
+ *
+ *  The carousel uses the `children` property of a `HUBComponentModel` to determine what items
+ *  it should contain. It makes the assumption that the children are all rendered using the same
+ *  component, to simplify its layout calculations.
+ */
+class CarouselComponent: NSObject, HUBComponentWithChildren, HUBComponentWithRestorableUIState, HUBComponentViewObserver, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    var view: UIView?
+    var childDelegate: HUBComponentChildDelegate?
+    
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: CarouselComponent.makeCollectionViewLayout())
+    private var model: HUBComponentModel?
+    private var itemSize: CGSize?
+    private var cellReuseIdentifier: String { return "cell" }
+    
+    // MARK: - HUBComponent
+
+    var layoutTraits: Set<HUBComponentLayoutTrait> {
+        return [.fullWidth]
+    }
+
+    func loadView() {
+        collectionView.register(HUBComponentCollectionViewCell.self, forCellWithReuseIdentifier: cellReuseIdentifier)
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.backgroundColor = .white
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
+        
+        view = collectionView
+    }
+
+    func preferredViewSize(forDisplaying model: HUBComponentModel, containerViewSize: CGSize) -> CGSize {
+        let itemSize = calculateItemSize(forModel: model, containerViewSize: containerViewSize)
+        return CGSize(width: containerViewSize.width, height: itemSize.height)
+    }
+
+    func prepareViewForReuse() {
+        itemSize = nil
+    }
+
+    func configureView(with model: HUBComponentModel, containerViewSize: CGSize) {
+        self.model = model
+        itemSize = calculateItemSize(forModel: model, containerViewSize: containerViewSize)
+        collectionView.reloadData()
+    }
+    
+    // MARK: - HUBComponentWithRestorableUIState
+    
+    func currentUIState() -> Any? {
+        return collectionView.contentOffset
+    }
+    
+    func restoreUIState(_ state: Any) {
+        guard let contentOffset = state as? CGPoint else {
+            return
+        }
+        
+        collectionView.contentOffset = contentOffset
+    }
+    
+    // MARK: - HUBComponentViewObserver
+    
+    func viewWillAppear() {
+        // No-op
+    }
+    
+    func viewDidResize() {
+        itemSize = nil
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
+    
+    // MARK: - UICollectionViewDataSource
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return model?.children?.count ?? 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as! HUBComponentCollectionViewCell
+        
+        if let childModel = model?.child(at: UInt(indexPath.item)) {
+            cell.component = childDelegate?.component(self, childComponentFor: childModel)
+        } else {
+            cell.component = nil
+        }
+        
+        return cell
+    }
+    
+    // MARK: - UICollectionViewDelegateFlowLayout
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        let horizontalMargin = ComponentLayoutManager.margin
+        return UIEdgeInsets(top: 0, left: horizontalMargin, bottom: 0, right: horizontalMargin)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if let existingItemSize = itemSize {
+            return existingItemSize
+        }
+        
+        guard let model = self.model else {
+            return .zero
+        }
+        
+        let newItemSize = calculateItemSize(forModel: model, containerViewSize: collectionView.frame.size)
+        itemSize = newItemSize
+        return newItemSize
+    }
+    
+    // MARK: - UICollectionViewDelegate
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        childDelegate?.component(self, willDisplayChildAt: UInt(indexPath.item), view: cell)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        childDelegate?.component(self, didStopDisplayingChildAt: UInt(indexPath.item), view: cell)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        childDelegate?.component(self, childSelectedAt: UInt(indexPath.item))
+    }
+    
+    // MARK: - Private utilities
+    
+    private static func makeCollectionViewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        return layout
+    }
+    
+    private func calculateItemSize(forModel model: HUBComponentModel, containerViewSize: CGSize) -> CGSize {
+        guard let firstChildModel = model.child(at: 0) else {
+            return .zero
+        }
+        
+        guard let firstChild = childDelegate?.component(self, childComponentFor: firstChildModel) else {
+            return .zero
+        }
+        
+        return firstChild.preferredViewSize(forDisplaying: firstChildModel, containerViewSize: containerViewSize)
+    }
+}

--- a/demo/sources/DefaultComponentFactory.swift
+++ b/demo/sources/DefaultComponentFactory.swift
@@ -31,7 +31,8 @@ class DefaultComponentFactory: NSObject, HUBComponentFactory {
         DefaultComponentNames.label: { LabelComponent() },
         DefaultComponentNames.image: { ImageComponent() },
         DefaultComponentNames.searchBar: { SearchBarComponent() },
-        DefaultComponentNames.activityIndicator: { ActivityIndicatorComponent() }
+        DefaultComponentNames.activityIndicator: { ActivityIndicatorComponent() },
+        DefaultComponentNames.carousel: { CarouselComponent() }
     ]
     
     func createComponent(forName name: String) -> HUBComponent? {

--- a/demo/sources/DefaultComponentNames.swift
+++ b/demo/sources/DefaultComponentNames.swift
@@ -33,4 +33,6 @@ struct DefaultComponentNames {
     static var searchBar: String { return "searchBar" }
     /// An activity indicator component - maps to `ActivityIndicatorComponent`
     static var activityIndicator: String { return "activityIndicator" }
+    /// A carousel component - maps to `CarouselComponent`
+    static var carousel: String { return "carousel" }
 }

--- a/demo/sources/PrettyPicturesContentOperation.swift
+++ b/demo/sources/PrettyPicturesContentOperation.swift
@@ -34,10 +34,21 @@ class PrettyPicturesContentOperation: NSObject, HUBContentOperation {
             "zurich"
         ]
         
+        let carouselBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "carousel")
+        carouselBuilder.componentName = DefaultComponentNames.carousel
+        
+        for identifier in pictureIdentifiers {
+            let pictureBuilder = carouselBuilder.builderForChild(withIdentifier: "carousel-picture-" + identifier)
+            pictureBuilder.componentName = DefaultComponentNames.image
+            pictureBuilder.mainImageURL = imageURL(forPictureIdentifier: identifier)
+            pictureBuilder.targetBuilder.uri = targetURI(forPictureIdentifier: identifier)
+        }
+        
         for (index, identifier) in pictureIdentifiers.enumerated() {
             let pictureBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "picture-" + identifier)
             pictureBuilder.componentName = DefaultComponentNames.image
-            pictureBuilder.mainImageURL = URL(string: "https://spotify.github.io/HubFramework/resources/getting-started-\(identifier).jpg")
+            pictureBuilder.mainImageURL = imageURL(forPictureIdentifier: identifier)
+            pictureBuilder.targetBuilder.uri = targetURI(forPictureIdentifier: identifier)
             
             if index < 2 {
                 pictureBuilder.customData = [ImageComponentCustomDataKeys.fullWidth: true]
@@ -45,5 +56,13 @@ class PrettyPicturesContentOperation: NSObject, HUBContentOperation {
         }
         
         delegate?.contentOperationDidFinish(self)
+    }
+    
+    private func imageURL(forPictureIdentifier identifier: String) -> URL {
+        return URL(string: "https://spotify.github.io/HubFramework/resources/getting-started-\(identifier).jpg")!
+    }
+    
+    private func targetURI(forPictureIdentifier identifier: String) -> URL {
+        return URL(string: "https://en.wikipedia.org/wiki/" + identifier)!
     }
 }

--- a/demo/sources/RootContentOperation.swift
+++ b/demo/sources/RootContentOperation.swift
@@ -40,7 +40,7 @@ class RootContentOperation: NSObject, HUBContentOperation {
         
         let prettyPicturesRowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "prettyPictures")
         prettyPicturesRowBuilder.title = "Pretty pictures"
-        prettyPicturesRowBuilder.subtitle = "A feature that displays a grid of pictures"
+        prettyPicturesRowBuilder.subtitle = "A feature that displays a carousel & grid of pictures"
         prettyPicturesRowBuilder.targetBuilder.uri = .prettyPicturesViewURI
         
         let reallyLongListRowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "reallyLongList")


### PR DESCRIPTION
This change adds a carousel component to the demo app, partly for demonstration purposes - but also to enable us to cheaply perform UI tests and manual verification for a component with children (the demo app previously didn’t have any components with children).

The “Pretty pictures” feature of the demo app is also updated to display a carousel on the top, as well as adding tappable links to the pictures that it displays.

![simulator screen shot 25 oct 2016 17 39 24](https://cloud.githubusercontent.com/assets/2466701/19692915/fe220cd0-9ad9-11e6-9564-13e1748235bd.png)