### PR TITLE
[WIP] Registering passing a feature model

### DIFF
--- a/include/HubFramework/HUBFeatureRegistry.h
+++ b/include/HubFramework/HUBFeatureRegistry.h
@@ -26,6 +26,7 @@
 @protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
 @class HUBViewURIPredicate;
+@class HUBFeatureRegistration;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -70,6 +71,17 @@ NS_ASSUME_NONNULL_BEGIN
            customJSONSchemaIdentifier:(nullable NSString *)customJSONSchemaIdentifier
                         actionHandler:(nullable id<HUBActionHandler>)actionHandler
           viewControllerScrollHandler:(nullable id<HUBViewControllerScrollHandler>)viewControllerScrollHandler;
+
+
+/**
+ * Register a feature with the Hub Framework
+ *
+ * @param feature to be registered.
+ *
+ *  Registering a feature with the same identifier as one that is already registered is considered a severe error and will
+ *  trigger an assert.
+ */
+- (void)registerFeature:(HUBFeatureRegistration *)feature;
 
 /**
  *  Unregister a feature from the Hub Framework

--- a/sources/HUBFeatureRegistryImplementation.m
+++ b/sources/HUBFeatureRegistryImplementation.m
@@ -99,6 +99,18 @@ NS_ASSUME_NONNULL_BEGIN
     [self.registrationIdentifierOrder addObject:registration.featureIdentifier];
 }
 
+- (void)registerFeature:(HUBFeatureRegistration *)feature
+{
+    [self registerFeatureWithIdentifier:feature.featureIdentifier
+                       viewURIPredicate:feature.viewURIPredicate
+                                  title:feature.featureTitle
+              contentOperationFactories:feature.contentOperationFactories
+                    contentReloadPolicy:feature.contentReloadPolicy
+             customJSONSchemaIdentifier:feature.customJSONSchemaIdentifier
+                          actionHandler:feature.actionHandler
+            viewControllerScrollHandler:feature.viewControllerScrollHandler];
+}
+
 - (void)unregisterFeatureWithIdentifier:(NSString *)featureIdentifier
 {
     HUBFeatureRegistration * const registration = self.registrationsByIdentifier[featureIdentifier];


### PR DESCRIPTION
### What?
I started using the Framework and I noticed that the way features are registered is calling the method passing all the parameters and internally *(after some checks)* the feature is registered and the model `HUBFeatureRegistration` created. I have a few ideas that I'd like to discuss with you first and get your point of view regarding them:

- The name `HUBFeatureRegistration` sounds like it's represents a registration in the registry. However it doesn't contain any registration information. How does it sound renaming it to just `HUBFeature`?
- Then the `HUBFeatureRegistry` could include a method for registering these features:
```objc
- (void)register:(HUBFeature *)feature;
```

I've only added the extra method but I'll wait for your answer before continuing with these ideas.
