### PR TITLE
Diff updated indexes using old view model

### DIFF
--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -200,15 +200,6 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
     
-    for (NSIndexPath *indexPath in self.lastViewModelDiff.reloadedBodyComponentIndexPaths) {
-        if (indexPath.item < topmostVisibleIndex) {
-            UICollectionViewLayoutAttributes *oldAttributes = self.previousLayoutAttributesByIndexPath[indexPath];
-            UICollectionViewLayoutAttributes *newAttributes = self.layoutAttributesByIndexPath[indexPath];
-            CGFloat heightDifference = CGRectGetHeight(oldAttributes.frame) - CGRectGetHeight(newAttributes.frame);
-            offset.y += heightDifference;
-        }
-    }
-    
     // Making sure the content offset doesn't go through the roof.
     CGFloat const minContentOffset = -self.collectionView.contentInset.top;
     offset.y = MAX(minContentOffset, offset.y);

--- a/sources/HUBViewModelDiff.m
+++ b/sources/HUBViewModelDiff.m
@@ -93,10 +93,16 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
         }
     }
 
+    NSMutableIndexSet *reloads = [NSMutableIndexSet indexSet];
+
     // Finding the longest common subsequence
     NSMutableIndexSet *commonIndexSet = [NSMutableIndexSet indexSet];
     for (NSUInteger i = 0, j = 0 ; i < fromViewModelCount && j < toViewModelCount; ) {
         if ([firstIdentifiers[i] isEqualToString:secondIdentifiers[j]]) {
+            if (![fromViewModel.bodyComponentModels[i] isEqual:toViewModel.bodyComponentModels[j]]) {
+                [reloads addIndex:i];
+            }
+
             [commonIndexSet addIndex:i];
             i++;
             j++;
@@ -111,7 +117,6 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
     
     NSMutableIndexSet *insertions = [NSMutableIndexSet indexSet];
     NSMutableIndexSet *deletions = [NSMutableIndexSet indexSet];
-    NSMutableIndexSet *reloads = [NSMutableIndexSet indexSet];
 
     // Comparing the first model indices to the common indices to find deletions
     for (NSUInteger i = 0; i < fromViewModelCount; i++) {
@@ -127,9 +132,6 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
     for (NSUInteger i = 0, j = 0; i < commonObjects.count || j < toViewModelCount; ) {
         if (i < commonObjects.count && j < toViewModelCount &&
             [commonObjects[i].identifier isEqualToString:secondIdentifiers[j]]) {
-            if (![commonObjects[i] isEqual:toViewModel.bodyComponentModels[j]]) {
-                [reloads addIndex:j];
-            }
             i++;
             j++;
         } else {

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -190,21 +190,21 @@
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
 }
 
-- (void)testInsertionOfComponentModelAtStartWithDataChanges
+- (void)testInsertionOfSingleComponentModelAtStartWithDataChanges
 {
     NSArray<id<HUBComponentModel>> *firstComponents = @[
-                                                        [self createComponentModelWithIdentifier:@"component-1" customData:nil],
-                                                        [self createComponentModelWithIdentifier:@"component-2" customData:nil],
-                                                        [self createComponentModelWithIdentifier:@"component-3" customData:nil]
-                                                        ];
+        [self createComponentModelWithIdentifier:@"component-1" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-2" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-3" customData:nil]
+    ];
     id<HUBViewModel> firstViewModel = [self createViewModelWithIdentifier:@"Test"
                                                                components:firstComponents];
     NSArray<id<HUBComponentModel>> *secondComponents = @[
-                                                         [self createComponentModelWithIdentifier:@"component-0" customData:nil],
-                                                         [self createComponentModelWithIdentifier:@"component-1" customData:@{@"test": @1}],
-                                                         [self createComponentModelWithIdentifier:@"component-2" customData:@{@"test": @1}],
-                                                         [self createComponentModelWithIdentifier:@"component-3" customData:@{@"test": @1}]
-                                                         ];
+        [self createComponentModelWithIdentifier:@"component-0" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-1" customData:@{@"test": @1}],
+        [self createComponentModelWithIdentifier:@"component-2" customData:@{@"test": @1}],
+        [self createComponentModelWithIdentifier:@"component-3" customData:@{@"test": @1}]
+    ];
     id<HUBViewModel> secondViewModel = [self createViewModelWithIdentifier:@"Test"
                                                                 components:secondComponents];
 
@@ -218,22 +218,22 @@
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:2 inSection:0]]);
 }
 
-- (void)testInsertionOfComponentModelsAtStartWithDataChanges
+- (void)testInsertionOfMultipleComponentModelsAtStartWithDataChanges
 {
     NSArray<id<HUBComponentModel>> *firstComponents = @[
-                                                        [self createComponentModelWithIdentifier:@"component-1" customData:nil],
-                                                        [self createComponentModelWithIdentifier:@"component-2" customData:nil],
-                                                        [self createComponentModelWithIdentifier:@"component-3" customData:nil]
-                                                        ];
+        [self createComponentModelWithIdentifier:@"component-1" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-2" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-3" customData:nil]
+    ];
     id<HUBViewModel> firstViewModel = [self createViewModelWithIdentifier:@"Test"
                                                                components:firstComponents];
     NSArray<id<HUBComponentModel>> *secondComponents = @[
-                                                         [self createComponentModelWithIdentifier:@"component-0" customData:nil],
-                                                         [self createComponentModelWithIdentifier:@"component-00" customData:nil],
-                                                         [self createComponentModelWithIdentifier:@"component-1" customData:@{@"test": @1}],
-                                                         [self createComponentModelWithIdentifier:@"component-2" customData:@{@"test": @1}],
-                                                         [self createComponentModelWithIdentifier:@"component-3" customData:@{@"test": @1}]
-                                                         ];
+        [self createComponentModelWithIdentifier:@"component-0" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-00" customData:nil],
+        [self createComponentModelWithIdentifier:@"component-1" customData:@{@"test": @1}],
+        [self createComponentModelWithIdentifier:@"component-2" customData:@{@"test": @1}],
+        [self createComponentModelWithIdentifier:@"component-3" customData:@{@"test": @1}]
+    ];
     id<HUBViewModel> secondViewModel = [self createViewModelWithIdentifier:@"Test"
                                                                 components:secondComponents];
 

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -184,10 +184,68 @@
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:2 inSection:0]]);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:9 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
-    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:7 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:8 inSection:0]]);
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
+}
+
+- (void)testInsertionOfComponentModelAtStartWithDataChanges
+{
+    NSArray<id<HUBComponentModel>> *firstComponents = @[
+                                                        [self createComponentModelWithIdentifier:@"component-1" customData:nil],
+                                                        [self createComponentModelWithIdentifier:@"component-2" customData:nil],
+                                                        [self createComponentModelWithIdentifier:@"component-3" customData:nil]
+                                                        ];
+    id<HUBViewModel> firstViewModel = [self createViewModelWithIdentifier:@"Test"
+                                                               components:firstComponents];
+    NSArray<id<HUBComponentModel>> *secondComponents = @[
+                                                         [self createComponentModelWithIdentifier:@"component-0" customData:nil],
+                                                         [self createComponentModelWithIdentifier:@"component-1" customData:@{@"test": @1}],
+                                                         [self createComponentModelWithIdentifier:@"component-2" customData:@{@"test": @1}],
+                                                         [self createComponentModelWithIdentifier:@"component-3" customData:@{@"test": @1}]
+                                                         ];
+    id<HUBViewModel> secondViewModel = [self createViewModelWithIdentifier:@"Test"
+                                                                components:secondComponents];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:firstViewModel toViewModel:secondViewModel];
+    XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
+    XCTAssert(diff.insertedBodyComponentIndexPaths.count == 1);
+    XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:2 inSection:0]]);
+}
+
+- (void)testInsertionOfComponentModelsAtStartWithDataChanges
+{
+    NSArray<id<HUBComponentModel>> *firstComponents = @[
+                                                        [self createComponentModelWithIdentifier:@"component-1" customData:nil],
+                                                        [self createComponentModelWithIdentifier:@"component-2" customData:nil],
+                                                        [self createComponentModelWithIdentifier:@"component-3" customData:nil]
+                                                        ];
+    id<HUBViewModel> firstViewModel = [self createViewModelWithIdentifier:@"Test"
+                                                               components:firstComponents];
+    NSArray<id<HUBComponentModel>> *secondComponents = @[
+                                                         [self createComponentModelWithIdentifier:@"component-0" customData:nil],
+                                                         [self createComponentModelWithIdentifier:@"component-00" customData:nil],
+                                                         [self createComponentModelWithIdentifier:@"component-1" customData:@{@"test": @1}],
+                                                         [self createComponentModelWithIdentifier:@"component-2" customData:@{@"test": @1}],
+                                                         [self createComponentModelWithIdentifier:@"component-3" customData:@{@"test": @1}]
+                                                         ];
+    id<HUBViewModel> secondViewModel = [self createViewModelWithIdentifier:@"Test"
+                                                                components:secondComponents];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:firstViewModel toViewModel:secondViewModel];
+    XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
+    XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
+    XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
+    XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
+    XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:2 inSection:0]]);
 }
 
 @end


### PR DESCRIPTION
Changes so that the HUBViewModelDiff calculates updated indices using the previous data model rather than the new one.

@spotify/objc-dev (@cerihughes, @JohnSundell @rastersize)