### PR TITLE
View controller: Send layout traits for component appear/disappear

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -22,6 +22,7 @@
 #import <UIKit/UIKit.h>
 
 #import "HUBComponentType.h"
+#import "HUBComponentLayoutTraits.h"
 
 @protocol HUBViewController;
 @protocol HUBViewModel;
@@ -86,10 +87,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param viewController The view controller in which a component is about to appear
  *  @param componentModel The model of the component that is about to appear
+ *  @param layoutTraits The layou traits of the component that is about to appear
  *  @param componentView The view that the component is about to appear in
  */
 - (void)viewController:(UIViewController<HUBViewController> *)viewController
     componentWithModel:(id<HUBComponentModel>)componentModel
+          layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
       willAppearInView:(UIView *)componentView;
 
 /**
@@ -97,10 +100,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param viewController The view controller in which a component disappeared
  *  @param componentModel The model of the component that disappeared
+ *  @param layoutTraits The layou traits of the component that disappeared
  *  @param componentView The view that the component disappeared from
  */
 - (void)viewController:(UIViewController<HUBViewController> *)viewController
     componentWithModel:(id<HUBComponentModel>)componentModel
+          layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
   didDisappearFromView:(UIView *)componentView;
 
 /**

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param viewController The view controller in which a component is about to appear
  *  @param componentModel The model of the component that is about to appear
- *  @param layoutTraits The layou traits of the component that is about to appear
+ *  @param layoutTraits The layout traits of the component that is about to appear
  *  @param componentView The view that the component is about to appear in
  */
 - (void)viewController:(UIViewController<HUBViewController> *)viewController
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param viewController The view controller in which a component disappeared
  *  @param componentModel The model of the component that disappeared
- *  @param layoutTraits The layou traits of the component that disappeared
+ *  @param layoutTraits The layout traits of the component that disappeared
  *  @param componentView The view that the component disappeared from
  */
 - (void)viewController:(UIViewController<HUBViewController> *)viewController

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -511,10 +511,16 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     if (childIndex >= componentModel.children.count) {
         return;
     }
+    
+    [self loadImagesForComponentWrapper:componentWrapper childIndex:@(childIndex)];
 
     id<HUBComponentModel> const childComponentModel = componentModel.children[childIndex];
-    [self loadImagesForComponentWrapper:componentWrapper childIndex:@(childIndex)];
-    [self.delegate viewController:self componentWithModel:childComponentModel willAppearInView:childView];
+    NSSet<HUBComponentLayoutTrait> * const layoutTraits = childComponent.layoutTraits ?: [NSSet new];
+    
+    [self.delegate viewController:self
+               componentWithModel:childComponentModel
+                     layoutTraits:layoutTraits
+                 willAppearInView:childView];
 
     [self addComponentWrapperToLookupTables:childComponent];
 }
@@ -531,7 +537,12 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
 
     id<HUBComponentModel> const childComponentModel = componentModel.children[childIndex];
-    [self.delegate viewController:self componentWithModel:childComponentModel didDisappearFromView:childView];
+    NSSet<HUBComponentLayoutTrait> * const layoutTraits = childComponent.layoutTraits ?: [NSSet new];
+    
+    [self.delegate viewController:self
+               componentWithModel:childComponentModel
+                     layoutTraits:layoutTraits
+             didDisappearFromView:childView];
 
     [self removeComponentWrapperFromLookupTables:childComponent];
 }
@@ -650,10 +661,13 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
   didEndDisplayingCell:(UICollectionViewCell *)cell
     forItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    id<HUBComponentModel> const componentModel = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell].model;
-    [self.delegate viewController:self componentWithModel:componentModel didDisappearFromView:cell];
-    
     HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
+    
+    [self.delegate viewController:self
+               componentWithModel:componentWrapper.model
+                     layoutTraits:componentWrapper.layoutTraits
+             didDisappearFromView:cell];
+
     [self removeComponentWrapperFromLookupTables:componentWrapper];
 }
 
@@ -1005,13 +1019,18 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     
     [self componentWrapperWillAppear:wrapper];
 
-    id<HUBComponent> component = cell.component;
+    id<HUBComponent> const component = cell.component;
+    
     if (component == nil) {
         return;
     }
 
     UIView * const componentView = HUBComponentLoadViewIfNeeded(component);
-    [self.delegate viewController:self componentWithModel:wrapper.model willAppearInView:componentView];
+    
+    [self.delegate viewController:self
+               componentWithModel:wrapper.model
+                     layoutTraits:wrapper.layoutTraits
+                 willAppearInView:componentView];
 }
 
 - (void)headerAndOverlayComponentViewsWillAppear


### PR DESCRIPTION
This change makes `HUBViewController` send a component’s layout traits to its delegate as part of the methods called whenever a component is either about to appear, or just disappeared from the screen.

The reason for this change is that we want to enable API users to make decisions based on the layout traits, instead of resorting to comparing view frames (which are bound to change during the layout cycle).