### PR TITLE
View controller: Add property to inspect whether view is scrolling

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -135,6 +135,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, nullable, readonly) id<HUBViewModel> viewModel;
 
+/// Whether the view controller's content view is currently being scrolled
+@property (nonatomic, assign, readonly) BOOL isViewScrolling;
+
 /**
  *  Return the frame used to render a body component at a given index
  *

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -260,6 +260,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBViewController
 
+- (BOOL)isViewScrolling
+{
+    return self.collectionView.isDragging || self.collectionView.isDecelerating;
+}
+
 - (NSDictionary<NSIndexPath *, UIView *> *)visibleComponentViewsForComponentType:(HUBComponentType)componentType
 {
     NSMutableDictionary<NSIndexPath *, UIView *> * const visibleViewIndexPaths = [NSMutableDictionary new];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1658,6 +1658,15 @@
     XCTAssertEqualWithAccuracy(targetContentOffset.y, 500, 0.001);
 }
 
+- (void)testIsViewScrolling
+{
+    [self simulateViewControllerLayoutCycle];
+    
+    XCTAssertFalse(self.viewController.isViewScrolling);
+    self.collectionView.mockedIsDragging = YES;
+    XCTAssertTrue(self.viewController.isViewScrolling);
+}
+
 - (void)testFrameForBodyComponentAtIndex
 {
     HUBComponentMock * const componentA = [HUBComponentMock new];

--- a/tests/mocks/HUBCollectionViewMock.h
+++ b/tests/mocks/HUBCollectionViewMock.h
@@ -47,6 +47,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The animated flag applied when offet is scrolled to.
 @property (nonatomic) BOOL appliedScrollViewOffsetAnimatedFlag;
 
+/// Whether the collection view should act like the user is dragging its content
+@property (nonatomic) BOOL mockedIsDragging;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBCollectionViewMock.m
+++ b/tests/mocks/HUBCollectionViewMock.m
@@ -50,6 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Property overrides
 
+- (BOOL)isDragging
+{
+    return self.mockedIsDragging;
+}
+
 - (NSSet<NSIndexPath *> *)selectedIndexPaths
 {
     return [self.mutableSelectedIndexPaths copy];


### PR DESCRIPTION
This will enable API users to make decisions based on whether the user is currently scrolling the main content view of a Hub Framework view controller.