### PR TITLE
Don’t compare index path for equality.

### DIFF
--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -65,7 +65,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSSet<NSString *> *)ignoredAutoEquatablePropertyNames
 {
-    return [NSSet setWithObjects:HUBKeyPath((id<HUBComponentModel>)nil, parent), HUBKeyPath((id<HUBComponentModel>)nil, index), nil];
+    return [NSSet setWithObjects:HUBKeyPath((id<HUBComponentModel>)nil, parent),
+        HUBKeyPath((id<HUBComponentModel>)nil, index),
+        HUBKeyPath((id<HUBComponentModel>)nil, indexPath),
+        nil];
 }
 
 #pragma mark - Initializer

--- a/tests/HUBComponentModelTests.m
+++ b/tests/HUBComponentModelTests.m
@@ -181,6 +181,23 @@
     XCTAssertEqual(grandchild.indexPath, [NSIndexPath indexPathWithIndexes:grandchildIndexPathArray length:3]);
 }
 
+- (void)testPropertiesThatDoNotAffectEquality
+{
+    HUBComponentModelImplementation * const parent1 = [self createComponentModelWithIdentifier:@"parent1" index:0];
+    HUBComponentModelImplementation * const child1 = [self createComponentModelWithIdentifier:@"child" index:0 parent:parent1];
+    parent1.children = @[child1];
+    HUBComponentModelImplementation * const parent2 = [self createComponentModelWithIdentifier:@"parent2" index:1];
+    HUBComponentModelImplementation * const child2 = [self createComponentModelWithIdentifier:@"child" index:1 parent:parent2];
+    parent2.children = @[child2];
+
+    XCTAssertNotEqualObjects(child1.parent, child2.parent);
+    XCTAssertNotEqual(child1.index, child2.index);
+    XCTAssertNotEqualObjects(child1.indexPath, child2.indexPath);
+
+    // The parents, indices and index paths should not affect the children's equality.
+    XCTAssertEqualObjects(child1, child2);
+}
+
 #pragma mark - Utilities
 
 - (HUBComponentModelImplementation *)createComponentModelWithIdentifier:(NSString *)identifier index:(NSUInteger)index


### PR DESCRIPTION
The index path shouldn't be used when considering equality as it uses information about the parent, (which is already excluded from the calculation).