### PR TITLE
Cleanup: More concrete block types

### DIFF
--- a/sources/HUBViewModelRenderer.h
+++ b/sources/HUBViewModelRenderer.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)renderViewModel:(id<HUBViewModel>)viewModel
       usingBatchUpdates:(BOOL)usingBatchUpdates
                animated:(BOOL)animated
-             completion:(void(^)())completionBlock;
+             completion:(void(^)(void))completionBlock;
 
 @end
 

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)renderViewModel:(id<HUBViewModel>)viewModel
       usingBatchUpdates:(BOOL)usingBatchUpdates
                animated:(BOOL)animated
-             completion:(void (^)())completionBlock
+             completion:(void (^)(void))completionBlock
 {
     HUBViewModelDiff *diff;
     if (self.lastRenderedViewModel != nil) {

--- a/tests/mocks/HUBURLProtocolMock.h
+++ b/tests/mocks/HUBURLProtocolMock.h
@@ -61,7 +61,7 @@ typedef BOOL(^HUBURLProtocolRequestPredicate)(NSURLRequest *request);
  * @param predicate The predicate that determines if a request should be handled by the mock or not.
  * @param requestHandler The request handler that will be called once a request with a matching URL goes out.
  */
-+ (void (^)())mockRequestsMatchingPredicate:(HUBURLProtocolRequestPredicate)predicate handler:(HUBURLProtocolRequestHandler)requestHandler;
++ (void (^)(void))mockRequestsMatchingPredicate:(HUBURLProtocolRequestPredicate)predicate handler:(HUBURLProtocolRequestHandler)requestHandler;
 
 @end
 

--- a/tests/mocks/HUBURLProtocolMock.m
+++ b/tests/mocks/HUBURLProtocolMock.m
@@ -120,7 +120,7 @@ static NSArray<HUBRequestFilter *> *urlFilters = nil;
     [self setFilters:[mutableFilters copy]];
 }
 
-+ (void (^)())mockRequestsMatchingPredicate:(HUBURLProtocolRequestPredicate)predicate handler:(HUBURLProtocolRequestHandler)requestHandler
++ (void (^)(void))mockRequestsMatchingPredicate:(HUBURLProtocolRequestPredicate)predicate handler:(HUBURLProtocolRequestHandler)requestHandler
 {
     HUBRequestFilter *filter = [[HUBRequestFilter alloc] initWithURL:nil predicate:predicate requestHandler:requestHandler];
     [self addRequestFilter:filter];


### PR DESCRIPTION
Blocks in Objective-C are using a syntax similar to C function pointers, so `void (^foo)()` can be called with any parameters (`foo(@"Hub", 42)`), and you can assign blocks accepting any parameters to it (`foo = ^(int i) { … };`.

The type should be `void(^)(void)` to prevent that.