### PR TITLE
View controller: Add API to retrieve a single visible component view

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -168,15 +168,29 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns the views of the components of the given type that are currently visible on screen, keyed by their index path
  *
+ *  @param componentType The type of component to check for visiblilty.
+ *
  *  The index paths used for keys contains the indexes for the components' views, starting from the root. For example,
  *  a root body component at index 4 will have an index path with just the index 4, while the child at index 2 of that
  *  component will have an index path with the indexes 4 and 2.
  *
- *  @param componentType The type of component to check for visiblilty.
+ *  Note that if you are only interested in a single component's visible view, use the API that only returns a single view
+ *  instead, since it has a lot faster lookup time.
  *
  *  @return A dictionary of index paths and visible views at that index path.
  */
 - (NSDictionary<NSIndexPath *, UIView *> *)visibleComponentViewsForComponentType:(HUBComponentType)componentType;
+
+/**
+ *  Return any currently visible view of a single component
+ *
+ *  @param componentType The type of component to check for visibility.
+ *  @param indexPath The index path of the component to check for visibility.
+ *
+ *  This method provides a fast way of looking up just a single component's visible view, but if you're interested in
+ *  getting all currently visible component views - use `visibleComponentViewsForComponentType:` instead.
+ */
+- (nullable UIView *)visibleViewForComponentOfType:(HUBComponentType)componentType indexPath:(NSIndexPath *)indexPath;
 
 /**
  *  Perform a programmatic selection of a component with a given model

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -285,6 +285,59 @@ NS_ASSUME_NONNULL_BEGIN
     return [visibleViewIndexPaths copy];
 }
 
+- (nullable UIView *)visibleViewForComponentOfType:(HUBComponentType)componentType indexPath:(NSIndexPath *)indexPath
+{
+    NSUInteger const rootIndex = [indexPath indexAtPosition:0];
+    
+    if (rootIndex == NSNotFound) {
+        return nil;
+    }
+    
+    HUBComponentWrapper *componentWrapper;
+    
+    switch (componentType) {
+        case HUBComponentTypeHeader:
+            componentWrapper = self.headerComponentWrapper;
+            break;
+        case HUBComponentTypeBody: {
+            NSIndexPath * const rootIndexPath = [NSIndexPath indexPathForItem:(NSInteger)rootIndex inSection:0];
+            HUBComponentCollectionViewCell * const cell = (HUBComponentCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:rootIndexPath];
+            
+            if (cell == nil) {
+                return nil;
+            }
+            
+            componentWrapper = [self componentWrapperFromCell:cell];
+            break;
+        }
+        case HUBComponentTypeOverlay: {
+            if (rootIndex >= self.overlayComponentWrappers.count) {
+                return nil;
+            }
+            
+            componentWrapper = self.overlayComponentWrappers[rootIndex];
+            break;
+        }
+    }
+    
+    if (indexPath.length == 1) {
+        return componentWrapper.view;
+    }
+    
+    for (NSUInteger indexPosition = 1; indexPosition < indexPath.length; indexPosition++) {
+        NSArray<HUBComponentWrapper *> * const visibleChildren = componentWrapper.visibleChildren;
+        NSUInteger const childIndex = [indexPath indexAtPosition:indexPosition];
+        
+        if (childIndex >= visibleChildren.count) {
+            return nil;
+        }
+        
+        componentWrapper = visibleChildren[childIndex];
+    }
+    
+    return componentWrapper.view;
+}
+
 - (NSArray<HUBComponentWrapper *> *)rootComponentWrappersForComponentType:(HUBComponentType)componentType
 {
     NSMutableArray<HUBComponentWrapper *> * const rootComponentWrappers = [NSMutableArray array];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1787,16 +1787,31 @@
     UICollectionViewCell * const cellC = [collectionViewDataSource collectionView:self.collectionView cellForItemAtIndexPath:indexPathC];
     
     self.collectionView.mockedVisibleCells = @[cellA, cellB, cellC];
+    self.collectionView.cells[indexPathA] = cellA;
+    self.collectionView.cells[indexPathB] = cellB;
+    self.collectionView.cells[indexPathC] = cellC;
 
     NSDictionary<NSIndexPath *, UIView *> * const visibleHeaderViews = [self.viewController visibleComponentViewsForComponentType:HUBComponentTypeHeader];
     XCTAssertEqual(visibleHeaderViews.count, 1u);
     XCTAssertEqual(visibleHeaderViews[[NSIndexPath indexPathWithIndex:0]], headerComponent.view);
+    
+    NSIndexPath * const headerIndexPath = [NSIndexPath indexPathWithIndex:0];
+    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeHeader indexPath:headerIndexPath], headerComponent.view);
 
     NSDictionary<NSIndexPath *, UIView *> * const visibleBodyViews = [self.viewController visibleComponentViewsForComponentType:HUBComponentTypeBody];
     XCTAssertEqual(visibleBodyViews.count, 3u);
-    XCTAssertEqual(visibleBodyViews[[NSIndexPath indexPathWithIndex:0]], componentA.view);
-    XCTAssertEqual(visibleBodyViews[[NSIndexPath indexPathWithIndex:1]], componentB.view);
-    XCTAssertEqual(visibleBodyViews[[NSIndexPath indexPathWithIndex:2]], componentC.view);
+    
+    NSIndexPath * const bodyIndexPathA = [NSIndexPath indexPathWithIndex:0];
+    NSIndexPath * const bodyIndexPathB = [NSIndexPath indexPathWithIndex:1];
+    NSIndexPath * const bodyIndexPathC = [NSIndexPath indexPathWithIndex:2];
+    
+    XCTAssertEqual(visibleBodyViews[bodyIndexPathA], componentA.view);
+    XCTAssertEqual(visibleBodyViews[bodyIndexPathB], componentB.view);
+    XCTAssertEqual(visibleBodyViews[bodyIndexPathC], componentC.view);
+    
+    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathA], componentA.view);
+    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathB], componentB.view);
+    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathC], componentC.view);
 
     NSDictionary<NSIndexPath *, UIView *> * const visibleOverlayViews = [self.viewController visibleComponentViewsForComponentType:HUBComponentTypeOverlay];
     XCTAssertEqual(visibleOverlayViews.count, 2u);
@@ -1817,6 +1832,12 @@
     XCTAssertEqual(visibleHeaderViews.count, 0u);
     XCTAssertEqual(visibleBodyViews.count, 0u);
     XCTAssertEqual(visibleOverlayViews.count, 0u);
+    
+    NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndex:0];
+    
+    XCTAssertNil([self.viewController visibleViewForComponentOfType:HUBComponentTypeHeader indexPath:indexPath]);
+    XCTAssertNil([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPath]);
+    XCTAssertNil([self.viewController visibleViewForComponentOfType:HUBComponentTypeOverlay indexPath:indexPath]);
 }
 
 - (void)testContentOperationNotifiedOfSelectionAction


### PR DESCRIPTION
This new API is an alternative to returning **all** visible component views, and provides a much faster (pretty much `O(1)` complexity - if you disregard the length of the index path) way of looking up just a **single** component view.