### PR TITLE
Moves the configuration of header and overlay components when reloading

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -773,12 +773,11 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                           usingBatchUpdates:self.viewHasAppeared
                                    animated:animated
                                  completion:^{
+        [self configureHeaderComponent];
+        [self configureOverlayComponents];
+        [self headerAndOverlayComponentViewsWillAppear];
         [self.delegate viewControllerDidFinishRendering:self];
     }];
-    
-    [self configureHeaderComponent];
-    [self configureOverlayComponents];
-    [self headerAndOverlayComponentViewsWillAppear];
     
     self.viewModelHasChangedSinceLastLayoutUpdate = NO;
 }

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -86,7 +86,7 @@
 @property (nonatomic, strong) NSMutableArray<id<HUBComponentModel>> *componentModelsFromSelectionDelegateMethod;
 @property (nonatomic, strong) NSMutableArray<UIView *> *componentViewsFromApperanceDelegateMethod;
 @property (nonatomic, assign) BOOL didReceiveViewControllerDidFinishRendering;
-
+@property (nonatomic, copy) void (^viewControllerDidFinishRenderingBlock)(void);
 
 @end
 
@@ -2053,6 +2053,42 @@
     XCTAssertEqualWithAccuracy(self.component.view.center.y, 200, 0.001);
 }
 
+- (void)testScrollingToComponentAfterViewModelFinishesRendering
+{
+    HUBComponentMock * const componentA = [HUBComponentMock new];
+    componentA.preferredViewSize = CGSizeMake(300, 200);
+    
+    HUBComponentFactoryMock * const componentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{@"A": componentA}];
+    [self.componentRegistry registerComponentFactory:componentFactory forNamespace:@"frameForBodyComponent"];
+    
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        viewModelBuilder.headerComponentModelBuilder.title = @"header";
+
+        for (NSUInteger i = 0; i < 4; i++) {
+            id<HUBComponentModelBuilder> builder = [viewModelBuilder builderForBodyComponentModelWithIdentifier:[NSString stringWithFormat:@"%@", @(i)]];
+            builder.componentNamespace = @"frameForBodyComponent";
+            builder.componentName = @"A";
+        }
+
+        return YES;
+    };
+
+    self.scrollHandler.contentInsets = UIEdgeInsetsMake(100, 30, 40, 200);
+
+    __weak HUBViewControllerTests *weakSelf = self;
+    __block CGPoint expectedOffset = CGPointZero;
+    self.viewControllerDidFinishRenderingBlock = ^{
+        HUBViewControllerTests *strongSelf = weakSelf;
+        CGRect componentFrame = [strongSelf.viewController frameForBodyComponentAtIndex:3];
+        CGPoint offset = CGPointMake(0.0, CGRectGetMinY(componentFrame));
+        expectedOffset = CGPointMake(offset.x, offset.y - strongSelf.scrollHandler.contentInsets.top);
+        [strongSelf.viewController scrollToContentOffset:offset animated:NO];
+    };
+
+    [self simulateViewControllerLayoutCycle];
+    XCTAssertTrue(CGPointEqualToPoint(expectedOffset, self.collectionView.appliedScrollViewOffset));
+}
+
 #pragma mark - HUBViewControllerDelegate
 
 - (void)viewController:(UIViewController<HUBViewController> *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel
@@ -2077,6 +2113,10 @@
 {
     XCTAssertEqual(viewController, self.viewController);
     self.didReceiveViewControllerDidFinishRendering = YES;
+
+    if (self.viewControllerDidFinishRenderingBlock) {
+        self.viewControllerDidFinishRenderingBlock();
+    }
 }
 
 - (void)viewController:(UIViewController<HUBViewController> *)viewController


### PR DESCRIPTION
This caused some issues when attempting to scroll somewhere in the initial `viewControllerDidFinishRendering:`-call, as `configureHeaderComponent` would change the content offset _after_ the delegate was notified (as the completion block is called instantly).

@spotify/objc-dev 