### PR TITLE
Remove viewURI argument from HUBContentOperationActionObserver API.

### DIFF
--- a/demo/sources/GitHubSearchBarContentOperation.swift
+++ b/demo/sources/GitHubSearchBarContentOperation.swift
@@ -46,7 +46,7 @@ class GitHubSearchBarContentOperation: NSObject, HUBContentOperationActionObserv
         delegate?.contentOperationDidFinish(self)
     }
 
-    func actionPerformed(with context: HUBActionContext, viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState) {
+    func actionPerformed(with context: HUBActionContext, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState) {
         guard context.customActionIdentifier == searchActionIdentifier else {
             return
         }

--- a/demo/sources/TodoListContentOperation.swift
+++ b/demo/sources/TodoListContentOperation.swift
@@ -40,7 +40,7 @@ class TodoListContentOperation: NSObject, HUBContentOperationActionPerformer, HU
         delegate?.contentOperationDidFinish(self)
     }
     
-    func actionPerformed(with context: HUBActionContext, viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState) {
+    func actionPerformed(with context: HUBActionContext, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState) {
         guard context.customActionIdentifier == HUBIdentifier(namespace: TodoListActionFactory.namespace, name: TodoListActionNames.addCompleted) else {
             return
         }

--- a/documentation/Action programming guide.md
+++ b/documentation/Action programming guide.md
@@ -165,7 +165,6 @@ Finally, we observe actions being performed in our content operation, and re-sch
 @implementation SPTSongContentOperation
 
 - (void)actionPerformedWithContext:(id<HUBActionContext>)context
-                           viewURI:(NSURL *)viewURI
                        featureInfo:(id<HUBFeatureInfo>)featureInfo
                  connectivityState:(HUBConnectivityState)connectivityState
 {

--- a/include/HubFramework/HUBContentOperationActionObserver.h
+++ b/include/HubFramework/HUBContentOperationActionObserver.h
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  Sent to a content operation whenever an action was performed in the view that it is being used in
  *
  *  @param context The contextual object that the action was performed with
- *  @param viewURI The URI of the view that the action was performed in
  *  @param featureInfo The information for the feature that the action was performed in
  *  @param connectivityState The current connectivity state of the application
  *
@@ -49,7 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  content that is being displayed in the view.
  */
 - (void)actionPerformedWithContext:(id<HUBActionContext>)context
-                           viewURI:(NSURL *)viewURI
                        featureInfo:(id<HUBFeatureInfo>)featureInfo
                  connectivityState:(HUBConnectivityState)connectivityState;
 

--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -120,7 +120,6 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         [(id<HUBContentOperationActionObserver>)operation actionPerformedWithContext:context
-                                                                             viewURI:self.viewURI
                                                                          featureInfo:self.featureInfo
                                                                    connectivityState:self.connectivityState];
     }

--- a/tests/mocks/HUBContentOperationMock.m
+++ b/tests/mocks/HUBContentOperationMock.m
@@ -79,7 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - HUBContentOperationActionObserver
 
 - (void)actionPerformedWithContext:(id<HUBActionContext>)context
-                           viewURI:(NSURL *)viewURI
                        featureInfo:(id<HUBFeatureInfo>)featureInfo
                  connectivityState:(HUBConnectivityState)connectivityState
 {


### PR DESCRIPTION
🚚  Delivers: https://github.com/spotify/HubFramework/issues/112

We can remove `viewURI` argument because `HUBActionContext` already contains it.