### PR TITLE
Introduce Live Editing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ matrix:
     # Main job; builds, tests, validates the changes and updates our documentation.
     - osx_image: xcode8
       rvm: 2.2.5
-      env: LINT=YES  RUN_TESTS=YES  RUN_DANGER=YES  BUILD_DEMO_APP=YES  UPDATE_DOCUMENTATION=YES
+      env: LINT=YES  RUN_TESTS=YES  RUN_DANGER=YES  BUILD_DEMO_APP=YES   BUILD_LIVE_CLI=YES  UPDATE_DOCUMENTATION=YES
     # Compatibility job; makes sure the library is buildable by Xcode 7.3.1. The demo app requires
     # Xcode 8 to build and link so skip it.
     - osx_image: xcode7.3
       rvm: 2.2.5
-      env: LINT=YES  RUN_TESTS=YES  RUN_DANGER=NO   BUILD_DEMO_APP=NO   UPDATE_DOCUMENTATION=NO
+      env: LINT=YES  RUN_TESTS=YES  RUN_DANGER=NO   BUILD_DEMO_APP=NO   BUILD_LIVE_CLI=NO   UPDATE_DOCUMENTATION=NO
 
 cache: bundler
 

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		8A1132C11CDA4BA60053AA26 /* HUBFeatureInfoImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A1132C01CDA4BA60053AA26 /* HUBFeatureInfoImplementation.m */; };
 		8A15132C1DB7AF4800DE8C7A /* HUBComponentGestureRecognizerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A15132B1DB7AF4800DE8C7A /* HUBComponentGestureRecognizerTests.m */; };
 		8A1513311DB7B5B100DE8C7A /* HUBTouchMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A15132F1DB7B5AD00DE8C7A /* HUBTouchMock.m */; };
+		8A15729B1D9E735C00E9DD4D /* HUBLiveServiceImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A15729A1D9E735C00E9DD4D /* HUBLiveServiceImplementation.m */; };
+		8A1638BD1DC38B2E00AAD200 /* HUBLiveContentOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A1638BC1DC38B2E00AAD200 /* HUBLiveContentOperation.m */; };
 		8A1A19A61D8813DB0022438F /* HUBInitialViewModelRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A1A19A51D8813DB0022438F /* HUBInitialViewModelRegistryTests.m */; };
 		8A2A72E31D4B6E3300141619 /* HUBComponentTargetImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A72E21D4B6E3300141619 /* HUBComponentTargetImplementation.m */; };
 		8A2A72E61D4B6F1700141619 /* HUBComponentTargetBuilderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A72E51D4B6F1700141619 /* HUBComponentTargetBuilderImplementation.m */; };
@@ -165,10 +167,15 @@
 		8A15132B1DB7AF4800DE8C7A /* HUBComponentGestureRecognizerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentGestureRecognizerTests.m; sourceTree = "<group>"; };
 		8A15132E1DB7B5AD00DE8C7A /* HUBTouchMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBTouchMock.h; sourceTree = "<group>"; };
 		8A15132F1DB7B5AD00DE8C7A /* HUBTouchMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBTouchMock.m; sourceTree = "<group>"; };
+		8A1572941D9E728200E9DD4D /* HUBLiveService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBLiveService.h; sourceTree = "<group>"; };
+		8A1572991D9E735C00E9DD4D /* HUBLiveServiceImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBLiveServiceImplementation.h; sourceTree = "<group>"; };
+		8A15729A1D9E735C00E9DD4D /* HUBLiveServiceImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBLiveServiceImplementation.m; sourceTree = "<group>"; };
 		8A1585941C8EFF1E0008FDF9 /* HUBComponentWithImageHandling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentWithImageHandling.h; sourceTree = "<group>"; };
 		8A1585951C8EFF550008FDF9 /* HUBComponentContentOffsetObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentContentOffsetObserver.h; sourceTree = "<group>"; };
 		8A1585961C8F003C0008FDF9 /* HUBComponentWithChildren.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentWithChildren.h; sourceTree = "<group>"; };
 		8A1627DD1CC915CB005CC3FB /* HUBComponentViewObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentViewObserver.h; sourceTree = "<group>"; };
+		8A1638BB1DC38B2E00AAD200 /* HUBLiveContentOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBLiveContentOperation.h; sourceTree = "<group>"; };
+		8A1638BC1DC38B2E00AAD200 /* HUBLiveContentOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBLiveContentOperation.m; sourceTree = "<group>"; };
 		8A1A199E1D86B5380022438F /* HUBComponentType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentType.h; sourceTree = "<group>"; };
 		8A1A19A51D8813DB0022438F /* HUBInitialViewModelRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBInitialViewModelRegistryTests.m; sourceTree = "<group>"; };
 		8A2A72E01D4B6D2700141619 /* HUBComponentTarget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentTarget.h; sourceTree = "<group>"; };
@@ -464,6 +471,7 @@
 				8ADD42AC1C21D13B00D1A801 /* Components */,
 				8A49BA8C1C77707A005F7453 /* Images & icons */,
 				8A2A72EC1D4B743700141619 /* Actions */,
+				8A1572931D9E726C00E9DD4D /* Live */,
 				8A2061111CCA1992008C34E3 /* Utilities */,
 			);
 			name = include;
@@ -482,6 +490,7 @@
 				8AA29C891C4FAD4200E972B7 /* Components */,
 				8A49BAF51C777F97005F7453 /* Images & icons */,
 				8A2A72F01D4B75C500141619 /* Actions */,
+				8A1572951D9E730A00E9DD4D /* Live */,
 				8A2061101CCA1971008C34E3 /* Utilities */,
 			);
 			path = sources;
@@ -503,6 +512,25 @@
 				8A15132F1DB7B5AD00DE8C7A /* HUBTouchMock.m */,
 			);
 			name = Touches;
+			sourceTree = "<group>";
+		};
+		8A1572931D9E726C00E9DD4D /* Live */ = {
+			isa = PBXGroup;
+			children = (
+				8A1572941D9E728200E9DD4D /* HUBLiveService.h */,
+			);
+			name = Live;
+			sourceTree = "<group>";
+		};
+		8A1572951D9E730A00E9DD4D /* Live */ = {
+			isa = PBXGroup;
+			children = (
+				8A1572991D9E735C00E9DD4D /* HUBLiveServiceImplementation.h */,
+				8A15729A1D9E735C00E9DD4D /* HUBLiveServiceImplementation.m */,
+				8A1638BB1DC38B2E00AAD200 /* HUBLiveContentOperation.h */,
+				8A1638BC1DC38B2E00AAD200 /* HUBLiveContentOperation.m */,
+			);
+			name = Live;
 			sourceTree = "<group>";
 		};
 		8A2061101CCA1971008C34E3 /* Utilities */ = {
@@ -1123,6 +1151,7 @@
 				8AA29C851C4FAA9200E972B7 /* HUBComponentModelImplementation.m in Sources */,
 				8AD14E8A1D994BB40008E182 /* HUBDefaultImageLoaderFactory.m in Sources */,
 				8AD064741C68F0820086C081 /* HUBViewModelLoaderFactoryImplementation.m in Sources */,
+				8A1638BD1DC38B2E00AAD200 /* HUBLiveContentOperation.m in Sources */,
 				8ADD42921C21C81100D1A801 /* HUBManager.m in Sources */,
 				8A786BBB1C5A4F1800B2AB9E /* HUBJSONParsingOperation.m in Sources */,
 				8A7B48EC1CD77C8200130C25 /* HUBContentOperationWrapper.m in Sources */,
@@ -1154,6 +1183,7 @@
 				8A786BAB1C5A326300B2AB9E /* HUBJSONSchemaImplementation.m in Sources */,
 				8A2A72EB1D4B726800141619 /* HUBComponentTargetJSONSchemaImplementation.m in Sources */,
 				8AD064561C64B6DB0086C081 /* HUBComponentModelJSONSchemaImplementation.m in Sources */,
+				8A15729B1D9E735C00E9DD4D /* HUBLiveServiceImplementation.m in Sources */,
 				8AD064691C68DEA10086C081 /* HUBViewControllerImplementation.m in Sources */,
 				8A786BA81C5A2E8F00B2AB9E /* HUBJSONSchemaRegistryImplementation.m in Sources */,
 				8A2A72E61D4B6F1700141619 /* HUBComponentTargetBuilderImplementation.m in Sources */,

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		528498871DC4E8E800291C0C /* HUBLiveServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 528498861DC4E8E800291C0C /* HUBLiveServiceTests.m */; };
+		5284988B1DC4FC1300291C0C /* HUBInputStreamMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 5284988A1DC4FC1300291C0C /* HUBInputStreamMock.m */; };
 		52977ACA1DA7D0B40064629E /* HUBBlockContentOperationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 52977AC91DA7D0B40064629E /* HUBBlockContentOperationFactory.m */; };
 		52E7FC661D9C78700053EECF /* HUBActionFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6525321D802DCD007B1A15 /* HUBActionFactoryMock.m */; };
 		52E7FC671D9C78730053EECF /* HUBActionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6525351D802E3F007B1A15 /* HUBActionMock.m */; };
@@ -148,6 +150,9 @@
 		1D98E5BC1DC09FB500607097 /* HUBComponentActionObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentActionObserver.h; sourceTree = "<group>"; };
 		2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentFactoryMock.m; sourceTree = "<group>"; };
 		2932EAD3C06CBB869669B382 /* HUBComponentFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactoryMock.h; sourceTree = "<group>"; };
+		528498861DC4E8E800291C0C /* HUBLiveServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBLiveServiceTests.m; sourceTree = "<group>"; };
+		528498891DC4FC1300291C0C /* HUBInputStreamMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBInputStreamMock.h; sourceTree = "<group>"; };
+		5284988A1DC4FC1300291C0C /* HUBInputStreamMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBInputStreamMock.m; sourceTree = "<group>"; };
 		52977AC61DA7D0890064629E /* HUBBlockContentOperationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBBlockContentOperationFactory.h; sourceTree = "<group>"; };
 		52977AC91DA7D0B40064629E /* HUBBlockContentOperationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBBlockContentOperationFactory.m; sourceTree = "<group>"; };
 		8A0568F31CBFB073007C296A /* HUBComponentCategories.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentCategories.h; sourceTree = "<group>"; };
@@ -436,6 +441,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		528498851DC4E8B800291C0C /* Live */ = {
+			isa = PBXGroup;
+			children = (
+				528498861DC4E8E800291C0C /* HUBLiveServiceTests.m */,
+			);
+			name = Live;
+			sourceTree = "<group>";
+		};
 		8A0754951C21A79200AFAD38 = {
 			isa = PBXGroup;
 			children = (
@@ -632,6 +645,7 @@
 				8A6529E71D82B324007B1A15 /* Components */,
 				8AD1517C1D9962FA0008E182 /* Images & icons */,
 				8A6529E41D82B2FC007B1A15 /* Actions */,
+				528498851DC4E8B800291C0C /* Live */,
 			);
 			name = "Test Cases";
 			sourceTree = "<group>";
@@ -914,7 +928,7 @@
 			name = "Images & icons";
 			sourceTree = "<group>";
 		};
-		8AD152101D9972850008E182 /* URL Session */ = {
+		8AD152101D9972850008E182 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
 				8AD1517F1D9966080008E182 /* HUBURLSessionMock.h */,
@@ -923,8 +937,10 @@
 				F6B6B7551D9A8E7E0000D7AF /* HUBURLProtocolMock.m */,
 				8AD151821D9968390008E182 /* HUBURLSessionDataTaskMock.h */,
 				8AD151831D9968390008E182 /* HUBURLSessionDataTaskMock.m */,
+				528498891DC4FC1300291C0C /* HUBInputStreamMock.h */,
+				5284988A1DC4FC1300291C0C /* HUBInputStreamMock.m */,
 			);
-			name = "URL Session";
+			name = Networking;
 			sourceTree = "<group>";
 		};
 		8AD732001D9AD2EA00E4B427 /* Connectivity */ = {
@@ -997,7 +1013,7 @@
 				8A6529EA1D82B43E007B1A15 /* Components */,
 				8A6529ED1D82B469007B1A15 /* Images & icons */,
 				8A6529F01D82B4BD007B1A15 /* Actions */,
-				8AD152101D9972850008E182 /* URL Session */,
+				8AD152101D9972850008E182 /* Networking */,
 				8A15132D1DB7B59300DE8C7A /* Touches */,
 			);
 			name = Mocks;
@@ -1221,6 +1237,7 @@
 				8AA97C1A1C60C5F60078F19D /* HUBContentOperationFactoryMock.m in Sources */,
 				8A58E1491C5FA62E00F41A5C /* HUBComponentImageDataBuilderTests.m in Sources */,
 				8A6529E61D82B313007B1A15 /* HUBActionRegistryTests.m in Sources */,
+				528498871DC4E8E800291C0C /* HUBLiveServiceTests.m in Sources */,
 				8A5D7A4B1CB7F0B400B987BA /* HUBContentReloadPolicyMock.m in Sources */,
 				8ADD42A71C21CFE800D1A801 /* HUBComponentRegistryTests.m in Sources */,
 				8AD151841D9968390008E182 /* HUBURLSessionDataTaskMock.m in Sources */,
@@ -1230,6 +1247,7 @@
 				8A6BA0561C89A00F0057485D /* HUBComponentLayoutManagerMock.m in Sources */,
 				8A1513311DB7B5B100DE8C7A /* HUBTouchMock.m in Sources */,
 				8A9ED75F1D4A24C2006B27D8 /* HUBComponentModelTests.m in Sources */,
+				5284988B1DC4FC1300291C0C /* HUBInputStreamMock.m in Sources */,
 				8A89EFE81C7C866500A27EE9 /* HUBImageLoaderFactoryMock.m in Sources */,
 				8ACE24C71C6B650B0036240A /* HUBViewControllerFactoryTests.m in Sources */,
 				52E7FC671D9C78730053EECF /* HUBActionMock.m in Sources */,

--- a/HubFramework.xcworkspace/contents.xcworkspacedata
+++ b/HubFramework.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,9 @@
       location = "group:HubFramework.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:live/HubFrameworkLive.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:demo/HubFrameworkDemo.xcodeproj">
    </FileRef>
 </Workspace>

--- a/demo/sources/AppDelegate.swift
+++ b/demo/sources/AppDelegate.swift
@@ -161,7 +161,7 @@ import HubFramework
     }
     
     private func startLiveService() {
-        #if HUB_DEBUG
+        #if DEBUG
         hubManager.liveService?.delegate = self
         hubManager.liveService?.start(onPort: 7777)
         #endif

--- a/demo/sources/AppDelegate.swift
+++ b/demo/sources/AppDelegate.swift
@@ -161,7 +161,7 @@ import HubFramework
     }
     
     private func startLiveService() {
-        #if DEBUG
+        #if HUB_DEBUG
         hubManager.liveService?.delegate = self
         hubManager.liveService?.start(onPort: 7777)
         #endif

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,7 +63,7 @@ platform :ios do
     pod_lib_lint(:quick => true)
 
     license_header_files = Dir.chdir("..") do
-      license_header_files = Dir.glob('{demo/sources/*.swift,include/HubFramework/*.h,sources/*.{h,m},tests/*/*.{h,m},tests/*.m}')
+      license_header_files = Dir.glob('{live/sources/*.swift,demo/sources/*.swift,include/HubFramework/*.h,sources/*.{h,m},tests/*/*.{h,m},tests/*.m}')
     end
     lint_sources_for_license_header(
       :template => 'other/license_header_template.txt',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,6 +58,26 @@ platform :ios do
   end
 
 
+  desc 'Build the live CLI'
+  lane :live do
+    ENV['XCPRETTY_JSON_FILE_OUTPUT'] = 'build/live/summary.json'
+    live_project = 'live/HubFrameworkLive.xcodeproj'
+
+    recreate_schemes(project: live_project)
+
+    xcodebuild(
+      :build => true,
+      :parallelize_targets => true,
+      :project => live_project,
+      :scheme => 'HubFrameworkLive',
+      :sdk => 'macosx',
+      :configuration => 'Release',
+      :derivedDataPath => 'build/DerivedData',
+      :buildlog_path => 'build/logs/live',
+      :xcpretty_output => 'formatter `xcpretty-json-formatter`',
+    )
+  end
+
   desc 'Lint the source code and other linteable artifacts'
   lane :lint do
     pod_lib_lint(:quick => true)
@@ -92,10 +112,12 @@ platform :ios do
   desc '- `LINT`:           Whether the sources and certain artifacts should be linted defaults to `YES`'
   desc '- `RUN_TESTS`:      Whether unit tests should be run, defaults to `YES`'
   desc '- `BUILD_DEMO_APP`: Whether the demo app should be built or not, defaults to `YES`'
+  desc '- `BUILD_LIVE_CLI`: Whether the live CLI should be built or not, defaults to `YES`'
   lane :ci_all do
     lint unless shouldSkipStep('LINT')
     test unless shouldSkipStep('RUN_TESTS')
     demo unless shouldSkipStep('BUILD_DEMO_APP')
+    live unless shouldSkipStep('BUILD_LIVE_CLI')
   end
 
   # Whether we should execute the step or not.

--- a/include/HubFramework/HUBHeaderMacros.h
+++ b/include/HubFramework/HUBHeaderMacros.h
@@ -35,3 +35,10 @@
 #ifndef NS_EXTENSIBLE_STRING_ENUM
     #define NS_EXTENSIBLE_STRING_ENUM
 #endif
+
+/// Define an explicit `HUB_DEBUG` macro for conditionally compiling debug code
+#ifdef DEBUG
+    #define HUB_DEBUG DEBUG
+#else
+    #define HUB_DEBUG 0
+#endif

--- a/include/HubFramework/HUBLiveService.h
+++ b/include/HubFramework/HUBLiveService.h
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol HUBLiveService;
+@protocol HUBViewController;
+
+/**
+ *  Delegate protocol for `HUBLiveService`
+ *
+ *  Implement this to recieve view controllers created by the service (using JSON passed from the
+ *  `hublive` command line application).
+ */
+@protocol HUBLiveServiceDelegate <NSObject>
+
+/**
+ *  Sent to the delegate whenever the live service created a new view controller
+ *
+ *  @param liveService The live service in question
+ *  @param viewController The view controller that was created
+ *
+ *  The live service will reuse any existing view controller if possible. The service does not
+ *  retain the view controllers it creates. Whenever this method is called, you should perform
+ *  any manual configuration of the view controller you wish to do, then push it onto your app's
+ *  navigation stack.
+ */
+- (void)liveService:(id<HUBLiveService>)liveService
+        didCreateViewController:(UIViewController<HUBViewController> *)viewController;
+
+@end
+
+/**
+ *  Protocol defining the public API for the Hub Framework Live service
+ *
+ *  The live service enables live editing of Hub Framework-powered view controllers, using the `hublive`
+ *  command line application (you can find it in the /live folder of the Hub Framework repo).
+ *
+ *  To start the service, simply call `startOnPort:` with a port number that you wish to enable the
+ *  `hublive` application to connect on (the same port should then be supplied when starting `hublive`).
+ *  The service will then call its delegate once it has created a view controller for any JSON data that
+ *  was passed from `hublive`.
+ *
+ *  You don't implement this protocol yourself, instead the Hub Framework contains an implementation of it.
+ *  Note though that this implementation is only compiled when the application hosting the framework is
+ *  compiled for DEBUG.
+ */
+@protocol HUBLiveService <NSObject>
+
+/// The service's delegate. See `HUBLiveServiceDelegate` for more information.
+@property (nonatomic, weak, nullable) id<HUBLiveServiceDelegate> delegate;
+
+/**
+ *  Start the live service on a given port
+ *
+ *  @param port The port to start the service on
+ *
+ *  When calling this, the live service will start by creating a Bonjour net service for the given port,
+ *  which the `hublive` command application can then connect to to push JSON data for live editing.
+ */
+- (void)startOnPort:(NSUInteger)port;
+
+/**
+ *  Stop the service
+ *
+ *  The service will immediately stop and tear down its Bonjour net service.
+ */
+- (void)stop;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBManager.h
+++ b/include/HubFramework/HUBManager.h
@@ -28,6 +28,7 @@
 @protocol HUBViewModelLoaderFactory;
 @protocol HUBViewControllerFactory;
 @protocol HUBComponentShowcaseManager;
+@protocol HUBLiveService;
 @protocol HUBConnectivityStateResolver;
 @protocol HUBDataLoaderFactory;
 @protocol HUBImageLoaderFactory;
@@ -69,6 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// The manager used to create component showcases. See `HUBComponentShowcaseManager` for more info.
 @property (nonatomic, strong, readonly) id<HUBComponentShowcaseManager> componentShowcaseManager;
+
+/// The service that can be used to enable live editing of Hub Framework-powered view controllers. Always `nil` in release builds.
+@property (nonatomic, strong, readonly, nullable) id<HUBLiveService> liveService;
 
 /**
  *  Initialize an instance of this class with its required dependencies

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -100,3 +100,6 @@
 #import "HUBActionHandler.h"
 #import "HUBActionContext.h"
 #import "HUBActionTrigger.h"
+
+// Live
+#import "HUBLiveService.h"

--- a/live/HubFrameworkLive.xcodeproj/project.pbxproj
+++ b/live/HubFrameworkLive.xcodeproj/project.pbxproj
@@ -1,0 +1,295 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		8A0B4BE61DC35C070018E84B /* CommandLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0B4BE51DC35C070018E84B /* CommandLine.swift */; };
+		8A0B4BE81DC35C3E0018E84B /* CommandLineResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0B4BE71DC35C3E0018E84B /* CommandLineResult.swift */; };
+		8A1572B61D9EA7EF00E9DD4D /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572B51D9EA7EF00E9DD4D /* main.swift */; };
+		8A1572B81D9EA93500E9DD4D /* Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572B71D9EA93500E9DD4D /* Live.swift */; };
+		8A1572BA1D9EAAB100E9DD4D /* LiveError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572B91D9EAAB100E9DD4D /* LiveError.swift */; };
+		8A1572BC1D9EAB7400E9DD4D /* FileWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572BB1D9EAB7400E9DD4D /* FileWatcher.swift */; };
+		8A1572BE1D9EB7BA00E9DD4D /* Error+Print.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572BD1D9EB7BA00E9DD4D /* Error+Print.swift */; };
+		8A1572C01D9EB87900E9DD4D /* AnsiColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572BF1D9EB87900E9DD4D /* AnsiColor.swift */; };
+		8A1572C21D9EB8BF00E9DD4D /* String+PrintWithColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1572C11D9EB8BF00E9DD4D /* String+PrintWithColor.swift */; };
+		8AA1D9811DA3BE7000A655DF /* SocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA1D9801DA3BE7000A655DF /* SocketClient.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		8A1572A81D9EA7A900E9DD4D /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		8A0B4BE51DC35C070018E84B /* CommandLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandLine.swift; sourceTree = "<group>"; };
+		8A0B4BE71DC35C3E0018E84B /* CommandLineResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandLineResult.swift; sourceTree = "<group>"; };
+		8A1572AA1D9EA7A900E9DD4D /* hublive */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = hublive; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A1572B51D9EA7EF00E9DD4D /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		8A1572B71D9EA93500E9DD4D /* Live.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Live.swift; sourceTree = "<group>"; };
+		8A1572B91D9EAAB100E9DD4D /* LiveError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveError.swift; sourceTree = "<group>"; };
+		8A1572BB1D9EAB7400E9DD4D /* FileWatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileWatcher.swift; sourceTree = "<group>"; };
+		8A1572BD1D9EB7BA00E9DD4D /* Error+Print.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Error+Print.swift"; sourceTree = "<group>"; };
+		8A1572BF1D9EB87900E9DD4D /* AnsiColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnsiColor.swift; sourceTree = "<group>"; };
+		8A1572C11D9EB8BF00E9DD4D /* String+PrintWithColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+PrintWithColor.swift"; sourceTree = "<group>"; };
+		8AA1D9801DA3BE7000A655DF /* SocketClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketClient.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8A1572A71D9EA7A900E9DD4D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8A1572A11D9EA7A900E9DD4D = {
+			isa = PBXGroup;
+			children = (
+				8A1572B41D9EA7EF00E9DD4D /* Sources */,
+				8A1572AB1D9EA7A900E9DD4D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		8A1572AB1D9EA7A900E9DD4D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8A1572AA1D9EA7A900E9DD4D /* hublive */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8A1572B41D9EA7EF00E9DD4D /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				8A1572B51D9EA7EF00E9DD4D /* main.swift */,
+				8A1572B71D9EA93500E9DD4D /* Live.swift */,
+				8A1572B91D9EAAB100E9DD4D /* LiveError.swift */,
+				8A1572BB1D9EAB7400E9DD4D /* FileWatcher.swift */,
+				8A1572BD1D9EB7BA00E9DD4D /* Error+Print.swift */,
+				8A1572C11D9EB8BF00E9DD4D /* String+PrintWithColor.swift */,
+				8A1572BF1D9EB87900E9DD4D /* AnsiColor.swift */,
+				8AA1D9801DA3BE7000A655DF /* SocketClient.swift */,
+				8A0B4BE51DC35C070018E84B /* CommandLine.swift */,
+				8A0B4BE71DC35C3E0018E84B /* CommandLineResult.swift */,
+			);
+			name = Sources;
+			path = sources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8A1572A91D9EA7A900E9DD4D /* HubFrameworkLive */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8A1572B11D9EA7A900E9DD4D /* Build configuration list for PBXNativeTarget "HubFrameworkLive" */;
+			buildPhases = (
+				8A1572A61D9EA7A900E9DD4D /* Sources */,
+				8A1572A71D9EA7A900E9DD4D /* Frameworks */,
+				8A1572A81D9EA7A900E9DD4D /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HubFrameworkLive;
+			productName = HubFrameworkLive;
+			productReference = 8A1572AA1D9EA7A900E9DD4D /* hublive */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8A1572A21D9EA7A900E9DD4D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0800;
+				LastUpgradeCheck = 0800;
+				ORGANIZATIONNAME = Spotify;
+				TargetAttributes = {
+					8A1572A91D9EA7A900E9DD4D = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 8A1572A51D9EA7A900E9DD4D /* Build configuration list for PBXProject "HubFrameworkLive" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 8A1572A11D9EA7A900E9DD4D;
+			productRefGroup = 8A1572AB1D9EA7A900E9DD4D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8A1572A91D9EA7A900E9DD4D /* HubFrameworkLive */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8A1572A61D9EA7A900E9DD4D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8A1572B81D9EA93500E9DD4D /* Live.swift in Sources */,
+				8A1572C01D9EB87900E9DD4D /* AnsiColor.swift in Sources */,
+				8A1572C21D9EB8BF00E9DD4D /* String+PrintWithColor.swift in Sources */,
+				8A1572BA1D9EAAB100E9DD4D /* LiveError.swift in Sources */,
+				8A0B4BE81DC35C3E0018E84B /* CommandLineResult.swift in Sources */,
+				8A1572BC1D9EAB7400E9DD4D /* FileWatcher.swift in Sources */,
+				8A0B4BE61DC35C070018E84B /* CommandLine.swift in Sources */,
+				8AA1D9811DA3BE7000A655DF /* SocketClient.swift in Sources */,
+				8A1572BE1D9EB7BA00E9DD4D /* Error+Print.swift in Sources */,
+				8A1572B61D9EA7EF00E9DD4D /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		8A1572AF1D9EA7A900E9DD4D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		8A1572B01D9EA7A900E9DD4D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		8A1572B21D9EA7A900E9DD4D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = hublive;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		8A1572B31D9EA7A900E9DD4D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = hublive;
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8A1572A51D9EA7A900E9DD4D /* Build configuration list for PBXProject "HubFrameworkLive" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A1572AF1D9EA7A900E9DD4D /* Debug */,
+				8A1572B01D9EA7A900E9DD4D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8A1572B11D9EA7A900E9DD4D /* Build configuration list for PBXNativeTarget "HubFrameworkLive" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8A1572B21D9EA7A900E9DD4D /* Debug */,
+				8A1572B31D9EA7A900E9DD4D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 8A1572A21D9EA7A900E9DD4D /* Project object */;
+}

--- a/live/sources/AnsiColor.swift
+++ b/live/sources/AnsiColor.swift
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Enum describing various Ansi colors that can be used for printing
+enum AnsiColor: String {
+    /// A red color
+    case red = "\u{001B}[0;31m"
+}

--- a/live/sources/CommandLine.swift
+++ b/live/sources/CommandLine.swift
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Class acting as a programmatic interface to the macOS command line
+class CommandLine {
+    /**
+     *  Execute a command on the command line and return the result
+     *
+     *  - Parameter command: The command to execute
+     *  - Parameter arguments: The arguments to pass to the executed command
+     */
+    static func execute(command: String, arguments: [String] = []) -> CommandLineResult {
+        let process = Process()
+        process.launchPath = "/usr/bin/env"
+        process.arguments = command.components(separatedBy: " ") + arguments
+        
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        process.launch()
+        
+        if let errorOuput = output(fromPipe: errorPipe) {
+            if errorOuput.characters.count > 0 {
+                return .error(errorOuput)
+            }
+        }
+        
+        return .output(output(fromPipe: outputPipe) ?? "")
+    }
+    
+    private static func output(fromPipe pipe: Pipe) -> String? {
+        let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: outputData, encoding: .utf8)
+    }
+}

--- a/live/sources/CommandLineResult.swift
+++ b/live/sources/CommandLineResult.swift
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Enum representing a result from executing a command on the command line
+enum CommandLineResult {
+    /// The command returned output. Contains the output string.
+    case output(String)
+    /// The command resulted in an error. Contains the error message.
+    case error(String)
+}

--- a/live/sources/Error+Print.swift
+++ b/live/sources/Error+Print.swift
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Extension that enables errors to be printed in a normalized manner
+extension Error {
+    /// Print this error with the red Ansi color
+    func print() {
+        "\(self)".print(withColor: .red)
+    }
+}

--- a/live/sources/FileWatcher.swift
+++ b/live/sources/FileWatcher.swift
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Class that enables observation of a file on disk
+class FileWatcher {
+    /// Enum containing events that `FileWatcher` generates
+    enum Event {
+        /// Sent when the observed file was changed. Contains the new file data.
+        case fileChanged(Data)
+        /// Sent when an error occurred. Contains the error that was encountered.
+        case errorEncountered(Error)
+    }
+    
+    private let filePath: String
+    private let dispatchQueue: DispatchQueue
+    private var dispatchSource: DispatchSourceFileSystemObject?
+    private var fileDescriptor: CInt?
+    
+    /**
+     *  Initialize an instance of this class
+     *
+     *  - Parameter filePath: The path of the file to watch
+     */
+    init(filePath: String) {
+        self.filePath = filePath
+        dispatchQueue = DispatchQueue(label: "com.spotify.hubframework.live")
+    }
+    
+    /**
+     *  Start watching the file that this watcher is for
+     *
+     *  - Parameter handler: The handler to call whenever an event occured. See
+     *    `FileWatcher.Event` for more information about events.
+     */
+    func start(withHandler handler: @escaping (Event) -> Void) throws {
+        let fileSystemRepresentation = (filePath as NSString).fileSystemRepresentation
+        let fileDescriptor = open(fileSystemRepresentation, O_EVTONLY)
+        
+        guard fileDescriptor >= 0 else {
+            throw LiveError.invalidFilePath
+        }
+        
+        let dispatchSource = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fileDescriptor, eventMask: .write, queue: dispatchQueue)
+        self.dispatchSource = dispatchSource
+        self.fileDescriptor = fileDescriptor
+        
+        let fileEventHandler = {
+            let url = URL(fileURLWithPath: self.filePath)
+            
+            do {
+                let data = try Data(contentsOf: url)
+                handler(.fileChanged(data))
+            } catch {
+                handler(.errorEncountered(error))
+            }
+        }
+        
+        dispatchSource.setEventHandler(handler: fileEventHandler)
+        
+        dispatchSource.setCancelHandler {
+            self.stop()
+        }
+        
+        dispatchSource.resume()
+        
+        fileEventHandler()
+    }
+    
+    /// Stop the file watcher, and tear down any current file observations.
+    func stop() {
+        if let fileDescriptor = fileDescriptor {
+            close(fileDescriptor)
+        }
+        
+        dispatchSource?.cancel()
+        
+        fileDescriptor = nil
+        dispatchSource = nil
+    }
+}

--- a/live/sources/Live.swift
+++ b/live/sources/Live.swift
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import AppKit
+
+/// Class representing the Hub Framework Live application
+class Live {
+    /**
+     *  Run the application with an array of command line arguments
+     *
+     *  - Parameter arguments: The command line arguments to run the application with
+     */
+    static func run(withArguments arguments: [String]) throws {
+        let filePath = try self.filePath(fromArguments: arguments)
+        let fileWatcher = FileWatcher(filePath: filePath)
+        
+        let socketPort = self.socketPort(fromParguments: arguments)
+        let socketClient = SocketClient(port: socketPort)
+        
+        do {
+            try socketClient.connect()
+            
+            try fileWatcher.start { event in
+                switch event {
+                case .fileChanged(let data):
+                    socketClient.send(data: data)
+                case .errorEncountered(let error):
+                    error.print()
+                }
+            }
+        } catch {
+            fileWatcher.stop()
+            socketClient.disconnect()
+            throw error
+        }
+        
+        print("Live is running on port \(socketPort) for file \"\(filePath)\". Press any key to stop.")
+        _ = FileHandle.standardInput.availableData
+        
+        fileWatcher.stop()
+        socketClient.disconnect()
+    }
+    
+    private static func filePath(fromArguments arguments: [String]) throws -> String {
+        guard arguments.count > 1 else {
+            throw LiveError.noFilePath
+        }
+        
+        let filePath = arguments[1]
+        
+        guard filePath.characters.count > 0 else {
+            throw LiveError.noFilePath
+        }
+        
+        return (filePath as NSString).expandingTildeInPath
+    }
+    
+    private static func socketPort(fromParguments arguments: [String]) -> Int {
+        let defaultPort = 7777
+        
+        guard arguments.count > 2 else {
+            return defaultPort
+        }
+        
+        return Int(arguments[2]) ?? defaultPort
+    }
+}

--- a/live/sources/LiveError.swift
+++ b/live/sources/LiveError.swift
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Enum containing errors that can be thrown when running the live application
+enum LiveError: Error {
+    /// Thrown when no file path was given
+    case noFilePath
+    /// Thrown when an invalid file path was given
+    case invalidFilePath
+    /// Thrown when the given file path contained invalid data
+    case invalidFileData
+    /// Thrown when a connection error occured (contains an error message)
+    case couldNotConnect(String)
+}
+
+extension LiveError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .noFilePath:
+            return "No file path given"
+        case .invalidFilePath:
+            return "Invalid file path given"
+        case .invalidFileData:
+            return "Invalid data for given file path. Make sure the file is a JSON file."
+        case .couldNotConnect(let message):
+            return "Could not connect to live service. Error: \(message)"
+        }
+    }
+}

--- a/live/sources/SocketClient.swift
+++ b/live/sources/SocketClient.swift
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Class acting as a socket client for communication with a Hub Framework-powered application
+class SocketClient {
+    private let port: Int
+    private var stream: OutputStream?
+    
+    /**
+     *  Initialize an instance of this class
+     *
+     *  - Parameter port: The port to connect a socket to
+     */
+    init(port: Int) {
+        self.port = port
+    }
+    
+    /// Connect the socket, or throw an error
+    func connect() throws {
+        let stream = try makeStream()
+        stream.open()
+        
+        if let error = stream.streamError {
+            throw error
+        }
+        
+        self.stream = stream
+    }
+    
+    /// Disconnect any previously connected socket
+    func disconnect() {
+        self.stream?.close()
+        self.stream = nil
+    }
+    
+    /**
+     *  Send binary data over the socket
+     *
+     *  - Parameter data: The data to send. Should be JSON data.
+     */
+    func send(data: Data) {
+        guard let stream = stream else {
+            print("Stream not setup")
+            return
+        }
+        
+        let result = data.withUnsafeBytes { bytes in
+            return stream.write(bytes, maxLength: data.count)
+        }
+        
+        if result <= 0 {
+            "Could not send JSON data to application".print(withColor: .red)
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func makeStream() throws -> OutputStream {
+        let ipConfigResult = CommandLine.execute(command: "ipconfig", arguments: ["getifaddr", "en0"])
+        
+        switch ipConfigResult {
+        case .output(let output):
+            let hostName = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            var stream: OutputStream? = nil
+            
+            Stream.getStreamsToHost(withName: hostName, port: port, inputStream: nil, outputStream: &stream)
+            
+            if let stream = stream {
+                return stream
+            }
+            
+            throw LiveError.couldNotConnect("Socket could not be created")
+        case .error(let message):
+            throw LiveError.couldNotConnect(message)
+        }
+    }
+}

--- a/live/sources/SocketClient.swift
+++ b/live/sources/SocketClient.swift
@@ -64,12 +64,16 @@ class SocketClient {
             return
         }
         
+        if !stream.hasSpaceAvailable {
+            printError()
+        }
+        
         let result = data.withUnsafeBytes { bytes in
             return stream.write(bytes, maxLength: data.count)
         }
         
         if result <= 0 {
-            "Could not send JSON data to application".print(withColor: .red)
+            printError()
         }
     }
     
@@ -93,5 +97,9 @@ class SocketClient {
         case .error(let message):
             throw LiveError.couldNotConnect(message)
         }
+    }
+    
+    private func printError() {
+        "Could not send JSON data to application".print(withColor: .red)
     }
 }

--- a/live/sources/String+PrintWithColor.swift
+++ b/live/sources/String+PrintWithColor.swift
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+/// Extension that enables strings to be printed using an Ansi color
+extension String {
+    /**
+     *  Print this string using an Ansi color
+     *
+     *  - Parameter color: The color to print the string using
+     */
+    func print(withColor color: AnsiColor) {
+        Swift.print(color.rawValue + self)
+    }
+}

--- a/live/sources/main.swift
+++ b/live/sources/main.swift
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+
+do {
+    try Live.run(withArguments: ProcessInfo.processInfo.arguments)
+} catch {
+    error.print()
+}
+

--- a/sources/HUBLiveContentOperation.h
+++ b/sources/HUBLiveContentOperation.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#if DEBUG
+
+#import "HUBContentOperation.h"
+#import "HUBHeaderMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Content operation used by the Hub Framework Live service.
+@interface HUBLiveContentOperation : NSObject <HUBContentOperation>
+
+/// The JSON data that should be render. When set, the content operation will reschedule itself.
+@property (nonatomic, strong) NSData *JSONData;
+
+/**
+ *  Initialize an instance of this class with JSON data
+ *
+ *  @param JSONData The JSON data to use
+ */
+- (instancetype)initWithJSONData:(NSData *)JSONData HUB_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // DEBUG

--- a/sources/HUBLiveContentOperation.h
+++ b/sources/HUBLiveContentOperation.h
@@ -19,10 +19,10 @@
  *  under the License.
  */
 
-#ifdef DEBUG
-
 #import "HUBContentOperation.h"
 #import "HUBHeaderMacros.h"
+
+#if HUB_DEBUG
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/sources/HUBLiveContentOperation.h
+++ b/sources/HUBLiveContentOperation.h
@@ -19,7 +19,7 @@
  *  under the License.
  */
 
-#if DEBUG
+#ifdef DEBUG
 
 #import "HUBContentOperation.h"
 #import "HUBHeaderMacros.h"

--- a/sources/HUBLiveContentOperation.m
+++ b/sources/HUBLiveContentOperation.m
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#if DEBUG
+
+#import "HUBLiveContentOperation.h"
+
+#import "HUBViewModelBuilder.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation HUBLiveContentOperation
+
+@synthesize delegate = _delegate;
+
+#pragma mark - Initializer
+
+- (instancetype)initWithJSONData:(NSData *)JSONData
+{
+    NSParameterAssert(JSONData != nil);
+    
+    self = [super init];
+    
+    if (self) {
+        _JSONData = JSONData;
+    }
+    
+    return self;
+}
+
+#pragma mark - Property overrides
+
+- (void)setJSONData:(NSData *)JSONData
+{
+    _JSONData = JSONData;
+    [self.delegate contentOperationRequiresRescheduling:self];
+}
+
+#pragma mark - HUBContentOperation
+
+- (void)performForViewURI:(NSURL *)viewURI
+              featureInfo:(id<HUBFeatureInfo>)featureInfo
+        connectivityState:(HUBConnectivityState)connectivityState
+         viewModelBuilder:(id<HUBViewModelBuilder>)viewModelBuilder
+            previousError:(nullable NSError *)previousError
+{
+    [viewModelBuilder addJSONData:self.JSONData];
+    [self.delegate contentOperationDidFinish:self];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // DEBUG

--- a/sources/HUBLiveContentOperation.m
+++ b/sources/HUBLiveContentOperation.m
@@ -19,7 +19,7 @@
  *  under the License.
  */
 
-#if DEBUG
+#ifdef DEBUG
 
 #import "HUBLiveContentOperation.h"
 

--- a/sources/HUBLiveContentOperation.m
+++ b/sources/HUBLiveContentOperation.m
@@ -19,11 +19,11 @@
  *  under the License.
  */
 
-#ifdef DEBUG
-
 #import "HUBLiveContentOperation.h"
 
 #import "HUBViewModelBuilder.h"
+
+#if HUB_DEBUG
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/sources/HUBLiveServiceImplementation.h
+++ b/sources/HUBLiveServiceImplementation.h
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Concrete implementation of the `HUBLiveService` API
 @interface HUBLiveServiceImplementation : NSObject <HUBLiveService>
 
+/// The net service that the live service is using. Set up when the service is started.
+@property (nonatomic, strong, readonly, nullable) NSNetService *netService;
+
 /**
  *  Initialize an instance of this class
  *

--- a/sources/HUBLiveServiceImplementation.h
+++ b/sources/HUBLiveServiceImplementation.h
@@ -19,10 +19,10 @@
  *  under the License.
  */
 
-#ifdef DEBUG
-
 #import "HUBLiveService.h"
 #import "HUBHeaderMacros.h"
+
+#if HUB_DEBUG
 
 @protocol HUBViewControllerFactory;
 

--- a/sources/HUBLiveServiceImplementation.h
+++ b/sources/HUBLiveServiceImplementation.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#if DEBUG
+
+#import "HUBLiveService.h"
+#import "HUBHeaderMacros.h"
+
+@protocol HUBViewControllerFactory;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Concrete implementation of the `HUBLiveService` API
+@interface HUBLiveServiceImplementation : NSObject <HUBLiveService>
+
+/**
+ *  Initialize an instance of this class
+ *
+ *  @param viewControllerFactory The factory to use to create view controllers
+ */
+- (instancetype)initWithViewControllerFactory:(id<HUBViewControllerFactory>)viewControllerFactory HUB_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // DEBUG

--- a/sources/HUBLiveServiceImplementation.h
+++ b/sources/HUBLiveServiceImplementation.h
@@ -19,7 +19,7 @@
  *  under the License.
  */
 
-#if DEBUG
+#ifdef DEBUG
 
 #import "HUBLiveService.h"
 #import "HUBHeaderMacros.h"

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -19,12 +19,12 @@
  *  under the License.
  */
 
-#ifdef DEBUG
-
 #import "HUBLiveServiceImplementation.h"
 
 #import "HUBViewControllerFactory.h"
 #import "HUBLiveContentOperation.h"
+
+#if HUB_DEBUG
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBLiveServiceImplementation () <NSNetServiceDelegate, NSStreamDelegate>
 
+@property (nonatomic, strong, readwrite, nullable) NSNetService *netService;
 @property (nonatomic, strong, readonly) id<HUBViewControllerFactory> viewControllerFactory;
-@property (nonatomic, strong, nullable) NSNetService *netService;
 @property (nonatomic, strong, nullable) NSInputStream *stream;
 @property (nonatomic, weak, nullable) UIViewController<HUBViewController> *viewController;
 @property (nonatomic, strong, nullable) HUBLiveContentOperation *contentOperation;

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -19,7 +19,7 @@
  *  under the License.
  */
 
-#if DEBUG
+#ifdef DEBUG
 
 #import "HUBLiveServiceImplementation.h"
 

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#if DEBUG
+
+#import "HUBLiveServiceImplementation.h"
+
+#import "HUBViewControllerFactory.h"
+#import "HUBLiveContentOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBLiveServiceImplementation () <NSNetServiceDelegate, NSStreamDelegate>
+
+@property (nonatomic, strong, readonly) id<HUBViewControllerFactory> viewControllerFactory;
+@property (nonatomic, strong, nullable) NSNetService *netService;
+@property (nonatomic, strong, nullable) NSInputStream *stream;
+@property (nonatomic, weak, nullable) UIViewController<HUBViewController> *viewController;
+@property (nonatomic, strong, nullable) HUBLiveContentOperation *contentOperation;
+
+@end
+
+@implementation HUBLiveServiceImplementation
+
+@synthesize delegate = _delegate;
+
+#pragma mark - Initializer
+
+- (instancetype)initWithViewControllerFactory:(id<HUBViewControllerFactory>)viewControllerFactory
+{
+    NSParameterAssert(viewControllerFactory != nil);
+    
+    self = [super init];
+    
+    if (self) {
+        _viewControllerFactory = viewControllerFactory;
+    }
+    
+    return self;
+}
+
+#pragma mark - HUBLiveService
+
+- (void)startOnPort:(NSUInteger)port
+{
+    [self.netService stop];
+    
+    self.netService = [[NSNetService alloc] initWithDomain:@""
+                                                      type:@"_spotify_hub_live._tcp."
+                                                      name:@"Hub Framework Live Service"
+                                                      port:(int)port];
+    
+    self.netService.delegate = self;
+    [self.netService publishWithOptions:NSNetServiceListenForConnections];
+    [self.netService scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+- (void)stop
+{
+    [self.netService stop];
+    [self.netService removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [self closeStream];
+}
+
+#pragma mark - NSNetServiceDelegate
+
+- (void)netService:(NSNetService *)sender didAcceptConnectionWithInputStream:(NSInputStream *)inputStream outputStream:(NSOutputStream *)outputStream
+{
+    self.stream = inputStream;
+    self.stream.delegate = self;
+    [self.stream open];
+    [self.stream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+}
+
+#pragma mark - NSStreamDelegate
+
+- (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)eventCode
+{
+    switch (eventCode) { 
+        case NSStreamEventHasBytesAvailable:
+            [self handleBytesAvailableForStream:(NSInputStream *)stream];
+            break;
+        case NSStreamEventErrorOccurred:
+            [self closeStream];
+            break;
+        case NSStreamEventNone:
+        case NSStreamEventOpenCompleted:
+        case NSStreamEventEndEncountered:
+        case NSStreamEventHasSpaceAvailable:
+            break;
+    }
+}
+
+#pragma mark - Private utilities
+
+- (void)handleBytesAvailableForStream:(NSInputStream *)stream
+{
+    NSMutableData * const mutableData = [NSMutableData new];
+    NSUInteger const bufferSize = 1024;
+    
+    while (stream.hasBytesAvailable) {
+        uint8_t buffer[bufferSize];
+        NSInteger const bytesRead = [stream read:buffer maxLength:bufferSize];
+        [mutableData appendBytes:buffer length:(NSUInteger)bytesRead];
+    }
+    
+    NSData * const data = [mutableData copy];
+    
+    if (self.viewController != nil && self.contentOperation != nil) {
+        self.contentOperation.JSONData = data;
+        return;
+    }
+    
+    NSURL * const viewURI = [NSURL URLWithString:@"hubframework:live"];
+    
+    HUBLiveContentOperation * const contentOperation = [[HUBLiveContentOperation alloc] initWithJSONData:data];
+    self.contentOperation = contentOperation;
+    
+    UIViewController<HUBViewController> * const viewController = [self.viewControllerFactory createViewControllerForViewURI:viewURI
+                                                                                                          contentOperations:@[contentOperation]
+                                                                                                          featureIdentifier:@"live"
+                                                                                                               featureTitle:@"Hub Framework Live"];
+    
+    self.viewController = viewController;
+    [self.delegate liveService:self didCreateViewController:viewController];
+}
+
+- (void)closeStream
+{
+    [self.stream close];
+    self.stream = nil;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // DEBUG

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @synthesize delegate = _delegate;
 
-#pragma mark - Initializer
+#pragma mark - Lifecycle
 
 - (instancetype)initWithViewControllerFactory:(id<HUBViewControllerFactory>)viewControllerFactory
 {
@@ -55,6 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     return self;
+}
+
+- (void)dealloc
+{
+    [self stop];
 }
 
 #pragma mark - HUBLiveService

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -70,13 +70,11 @@ NS_ASSUME_NONNULL_BEGIN
     
     self.netService.delegate = self;
     [self.netService publishWithOptions:NSNetServiceListenForConnections];
-    [self.netService scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
 }
 
 - (void)stop
 {
     [self.netService stop];
-    [self.netService removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
     [self closeStream];
 }
 

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -80,6 +80,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)stop
 {
     [self.netService stop];
+    self.netService = nil;
+    
     [self closeStream];
 }
 

--- a/sources/HUBManager.m
+++ b/sources/HUBManager.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable id<HUBLiveService>)liveService
 {
-#if DEBUG
+#ifdef DEBUG
     if (_liveService == nil) {
         _liveService = [[HUBLiveServiceImplementation alloc] initWithViewControllerFactory:self.viewControllerFactory];
     }

--- a/sources/HUBManager.m
+++ b/sources/HUBManager.m
@@ -32,6 +32,7 @@
 #import "HUBComponentFallbackHandler.h"
 #import "HUBDefaultConnectivityStateResolver.h"
 #import "HUBDefaultImageLoaderFactory.h"
+#import "HUBLiveServiceImplementation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -44,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation HUBManager
+
+@synthesize liveService = _liveService;
 
 - (instancetype)initWithComponentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                       componentFallbackHandler:(id<HUBComponentFallbackHandler>)componentFallbackHandler
@@ -134,6 +137,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (id<HUBComponentShowcaseManager>)componentShowcaseManager
 {
     return self.componentRegistryImplementation;
+}
+
+- (nullable id<HUBLiveService>)liveService
+{
+#if DEBUG
+    if (_liveService == nil) {
+        _liveService = [[HUBLiveServiceImplementation alloc] initWithViewControllerFactory:self.viewControllerFactory];
+    }
+#endif
+    
+    return _liveService;
 }
 
 @end

--- a/sources/HUBManager.m
+++ b/sources/HUBManager.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable id<HUBLiveService>)liveService
 {
-#ifdef DEBUG
+#if HUB_DEBUG
     if (_liveService == nil) {
         _liveService = [[HUBLiveServiceImplementation alloc] initWithViewControllerFactory:self.viewControllerFactory];
     }

--- a/tests/HUBLiveServiceTests.m
+++ b/tests/HUBLiveServiceTests.m
@@ -70,10 +70,13 @@
     XCTAssertNil(self.service.netService);
 }
 
-- (void)testNetServiceSetupOnceStarted
+- (void)testStartingAndStoppingService
 {
     [self.service startOnPort:7777];
     XCTAssertEqual(self.service.netService.port, 7777);
+    
+    [self.service stop];
+    XCTAssertNil(self.service.netService);
 }
 
 - (void)testCreatingAndReusingViewController

--- a/tests/HUBLiveServiceTests.m
+++ b/tests/HUBLiveServiceTests.m
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "HUBLiveServiceImplementation.h"
+#import "HUBManager.h"
+#import "HUBComponentLayoutManagerMock.h"
+#import "HUBComponentFallbackHandlerMock.h"
+#import "HUBComponentDefaults+Testing.h"
+#import "HUBInputStreamMock.h"
+#import "HUBViewController.h"
+#import "HUBViewModel.h"
+#import "HUBComponentModel.h"
+
+#ifdef DEBUG
+
+@interface HUBLiveServiceTests : XCTestCase <HUBLiveServiceDelegate>
+
+@property (nonatomic, strong) HUBManager *hubManager;
+@property (nonatomic, strong) HUBLiveServiceImplementation *service;
+@property (nonatomic, strong) UIViewController<HUBViewController> *viewController;
+
+@end
+
+@implementation HUBLiveServiceTests
+
+#pragma mark - XCTestCase
+
+- (void)setUp
+{
+    [super setUp];
+    
+    id<HUBComponentLayoutManager> const layoutManager = [HUBComponentLayoutManagerMock new];
+    HUBComponentDefaults * const componentDefaults = [HUBComponentDefaults defaultsForTesting];
+    id<HUBComponentFallbackHandler> const fallbackHandler = [[HUBComponentFallbackHandlerMock alloc] initWithComponentDefaults:componentDefaults];
+    
+    self.hubManager = [[HUBManager alloc] initWithComponentLayoutManager:layoutManager componentFallbackHandler:fallbackHandler];
+    self.service = [[HUBLiveServiceImplementation alloc] initWithViewControllerFactory:self.hubManager.viewControllerFactory];
+    self.service.delegate = self;
+}
+
+- (void)tearDown
+{
+    self.service = nil;
+}
+
+#pragma mark - Tests
+
+- (void)testNetServiceNilPerDefault
+{
+    XCTAssertNil(self.service.netService);
+}
+
+- (void)testNetServiceSetupOnceStarted
+{
+    [self.service startOnPort:7777];
+    XCTAssertEqual(self.service.netService.port, 7777);
+}
+
+- (void)testCreatingAndReusingViewController
+{
+    HUBInputStreamMock * const stream = [HUBInputStreamMock new];
+    
+    NSDictionary * const dictionary = @{
+        @"title": @"Live!",
+        @"body": @[
+            @{
+                @"text": @{
+                    @"title": @"Hello world!"
+                }
+            }
+        ]
+    };
+    
+    stream.data = [NSJSONSerialization dataWithJSONObject:dictionary options:(NSJSONWritingOptions)0 error:nil];;
+    XCTAssertNotNil(stream.data);
+    
+    [self.service startOnPort:7777];
+    
+    NSNetService * const netService = self.service.netService;
+    NSOutputStream * const outputStream = nil;
+    
+    [netService.delegate netService:netService
+                         didAcceptConnectionWithInputStream:stream
+                         outputStream:outputStream];
+    
+    [stream.delegate stream:stream handleEvent:NSStreamEventHasBytesAvailable];
+    
+    UIViewController<HUBViewController> * const viewController = self.viewController;
+    XCTAssertNotNil(viewController);
+    
+    [viewController viewWillAppear:YES];
+    
+    id<HUBViewModel> const viewModel = viewController.viewModel;
+    XCTAssertEqualObjects(viewModel.navigationItem.title, @"Live!");
+    XCTAssertEqualObjects(viewModel.bodyComponentModels[0].title, @"Hello world!");
+    
+    // Now let's reload the JSON, which should result in the view controller being reused for a new view model
+    NSMutableDictionary * const newDictionary = [dictionary mutableCopy];
+    newDictionary[@"title"] = @"A new title!";
+    
+    stream.data = [NSJSONSerialization dataWithJSONObject:newDictionary options:(NSJSONWritingOptions)0 error:nil];;
+    XCTAssertNotNil(stream.data);
+    
+    [stream.delegate stream:stream handleEvent:NSStreamEventHasBytesAvailable];
+    
+    XCTAssertEqual(self.viewController, viewController, @"View controller should have been reused");
+    
+    id<HUBViewModel> const newViewModel = viewController.viewModel;
+    XCTAssertEqualObjects(newViewModel.navigationItem.title, @"A new title!");
+}
+
+#pragma mark - HUBLiveServiceDelegate
+
+- (void)liveService:(id<HUBLiveService>)liveService didCreateViewController:(UIViewController<HUBViewController> *)viewController
+{
+    XCTAssertEqual(self.service, liveService);
+    self.viewController = viewController;
+}
+
+@end
+
+#endif // DEBUG

--- a/tests/HUBLiveServiceTests.m
+++ b/tests/HUBLiveServiceTests.m
@@ -31,7 +31,7 @@
 #import "HUBViewModel.h"
 #import "HUBComponentModel.h"
 
-#ifdef DEBUG
+#if HUB_DEBUG
 
 @interface HUBLiveServiceTests : XCTestCase <HUBLiveServiceDelegate>
 

--- a/tests/HUBManagerTests.m
+++ b/tests/HUBManagerTests.m
@@ -82,6 +82,13 @@
     
     // Showcase manager should be created
     XCTAssertNotNil(manager.componentShowcaseManager);
+    
+    // Live service should be created if not DEBUG
+#ifdef DEBUG
+    XCTAssertNotNil(manager.liveService);
+#else
+    XCTAssertNil(manager.liveService);
+#endif
 }
 
 @end

--- a/tests/HUBManagerTests.m
+++ b/tests/HUBManagerTests.m
@@ -84,7 +84,7 @@
     XCTAssertNotNil(manager.componentShowcaseManager);
     
     // Live service should be created if not DEBUG
-#ifdef DEBUG
+#if HUB_DEBUG
     XCTAssertNotNil(manager.liveService);
 #else
     XCTAssertNil(manager.liveService);

--- a/tests/mocks/HUBInputStreamMock.h
+++ b/tests/mocks/HUBInputStreamMock.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/// Mocked input stream, for use in unit tests only
+@interface HUBInputStreamMock : NSInputStream
+
+/// The data that the stream should act like it contains
+@property (nonatomic, strong, nullable) NSData *data;
+
+@end

--- a/tests/mocks/HUBInputStreamMock.h
+++ b/tests/mocks/HUBInputStreamMock.h
@@ -21,6 +21,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Mocked input stream, for use in unit tests only
 @interface HUBInputStreamMock : NSInputStream
 
@@ -28,3 +30,5 @@
 @property (nonatomic, strong, nullable) NSData *data;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBInputStreamMock.m
+++ b/tests/mocks/HUBInputStreamMock.m
@@ -51,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
     // Required to override method
 }
 
-- (void)scheduleInRunLoop:(NSRunLoop *)runLoop forMode:(NSRunLoopMode)mode
+// In an earlier version of the SDK (used by Xcode 7), `mode` is typed as `NSString` (instead of `NSRunLoopMode`), so `id` is used here
+- (void)scheduleInRunLoop:(NSRunLoop *)runLoop forMode:(id)mode
 {
     // Required to override method
 }

--- a/tests/mocks/HUBInputStreamMock.m
+++ b/tests/mocks/HUBInputStreamMock.m
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBInputStreamMock.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBInputStreamMock ()
+
+@property (nonatomic, weak, nullable) id<NSStreamDelegate> streamDelegate;
+
+@end
+
+@implementation HUBInputStreamMock
+
+- (nullable id<NSStreamDelegate>)delegate
+{
+    return self.streamDelegate;
+}
+
+- (void)setDelegate:(nullable id<NSStreamDelegate>)delegate
+{
+    self.streamDelegate = delegate;
+}
+
+- (void)open
+{
+    // Required to override method
+}
+
+- (void)close
+{
+    // Required to override method
+}
+
+- (void)scheduleInRunLoop:(NSRunLoop *)runLoop forMode:(NSRunLoopMode)mode
+{
+    // Required to override method
+}
+
+- (BOOL)hasBytesAvailable
+{
+    return self.data != nil;
+}
+
+- (NSInteger)read:(uint8_t *)buffer maxLength:(NSUInteger)maxLength
+{
+    NSUInteger const dataLength = self.data.length;
+    NSParameterAssert(dataLength < maxLength);
+    memcpy(buffer, self.data.bytes, dataLength);
+    self.data = nil;
+    return (NSInteger)dataLength;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This PR adds live editing capabilites to the Hub Framework. 🎉 This is done through a new `HubFrameworkLive` project that builds a `hublive` command line application, that can then connect to a newly introduced `HUBLiveService` running in a Hub Framework powered application.

**A few notes:**

- The implementation of the `HUBLiveService` API is only compiled if the host application is being compiled for `DEBUG`. This reduces the risk of running into security issues in production code.
- The live editing system is built using `NSNetService` - which is the Apple-provided framework for interacting with the Bonjour local networking system. It uses a socket on a user configurable port.
- Using live is opt-in for applications using the Hub Framework. The live service needs to be explicitly enabled by calling `hubManager.liveService?.start(onPort: 5555)`.

**Usage:**

After installing `hublive`, simply start the live service (the demo app already does this automatically). You can then call `hublive /path/to/json/file.json`, and live edit away 🚀

Resolves https://github.com/spotify/HubFramework/issues/29

![liveediting](https://cloud.githubusercontent.com/assets/2466701/19812786/4361fc1a-9d37-11e6-826f-b5b303a6150e.gif)
