### PR TITLE
Remove HUBViewModel.extensionURL

### DIFF
--- a/documentation/JSON programming guide.md
+++ b/documentation/JSON programming guide.md
@@ -45,7 +45,6 @@ Here is a reference for the default JSON schema:
 | `header` | `Dictionary -> ComponentModel` | Dictionary for a component model that should be used as the view's header component. Will be parsed using the schema for component models. | `headerComponentModel` |
 | `body` | `[Dictionary] -> [ComponentModel]` | An array of dictionaries for the component models that should be used for the view's body components. Will be parsed using the schema for component models. | `bodyComponentModels` |
 | `overlays` | `[Dictionary] -> [ComponentModel]` | An array of dictionaries for the component models that should be used for the view's overlay components. Will be parsed using the schema for component models. | `overlayComponentModels` |
-| `extension` | `String -> URL` | Any URI to use to extend this view model. This can be used to easily implement content pagination. | `extensionURL` |
 | `custom` | `Dictionary` | Any custom (free-form) data to associate with the view model. | `customData` |
 
 ### Component model schema

--- a/include/HubFramework/HUBViewModel.h
+++ b/include/HubFramework/HUBViewModel.h
@@ -81,14 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Metadata
 
 /**
- *  Any HTTP URL from which data can be downloaded to extend this view model
- *
- *  When a view has content that should be paginated, the URL of this property points to a JSON endpoint that describes
- *  the "next page". Once downloaded, the content of this URL will be appended to this view model.
- */
-@property (nonatomic, copy, readonly, nullable) NSURL *extensionURL;
-
-/**
  *  Any custom data that is associated with the view
  *
  *  This dictionary contains any custom data passed from the server side, or added in the local content loading process.

--- a/include/HubFramework/HUBViewModelBuilder.h
+++ b/include/HubFramework/HUBViewModelBuilder.h
@@ -103,16 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) BOOL headerComponentModelBuilderExists;
 
-#pragma mark - Metadata
-
-/**
- *  Any HTTP URL from which data can be downloaded to extend the view model
- *
- *  You can use this property to implement pagination for your view's content. When the user has scrolled to the bottom
- *  of a view, and that view model's extension URL != nil, the Hub Framework will automatically ask its content operations
- *  to extend the view model with data from this URL.
- */
-@property (nonatomic, copy, nullable) NSURL *extensionURL;
+#pragma mark - Custom data
 
 /**
  *  Any custom data that should be associated with the view model

--- a/include/HubFramework/HUBViewModelJSONSchema.h
+++ b/include/HubFramework/HUBViewModelJSONSchema.h
@@ -77,9 +77,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) id<HUBJSONDictionaryPath> overlayComponentModelDictionariesPath;
 
-/// The path to follow to extract a view model extension URL. Maps to `extensionURL`.
-@property (nonatomic, strong) id<HUBJSONURLPath> extensionURLPath;
-
 /// The path to follow to extract custom data for a view model. Maps to `customData`.
 @property (nonatomic, strong) id<HUBJSONDictionaryPath> customDataPath;
 

--- a/sources/HUBJSONKeys.h
+++ b/sources/HUBJSONKeys.h
@@ -51,9 +51,6 @@ static NSString * const HUBJSONKeyDate = @"date";
 /// JSON key used to encode a description text
 static NSString * const HUBJSONKeyDescription = @"description";
 
-/// JSON key used to encode extension information
-static NSString * const HUBJSONKeyExtension = @"extension";
-
 /// JSON key used to encode a feature identifier
 static NSString * const HUBJSONKeyFeature = @"feature";
 

--- a/sources/HUBViewModelBuilderImplementation.m
+++ b/sources/HUBViewModelBuilderImplementation.m
@@ -51,7 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Property synthesization
 
 @synthesize viewIdentifier = _viewIdentifier;
-@synthesize extensionURL = _extensionURL;
 @synthesize customData = _customData;
 
 #pragma mark - Initializer
@@ -264,7 +263,6 @@ NS_ASSUME_NONNULL_BEGIN
                                              headerComponentModel:headerComponentModel
                                               bodyComponentModels:bodyComponentModels
                                            overlayComponentModels:overlayComponentModels
-                                                     extensionURL:self.extensionURL
                                                        customData:[self.customData copy]];
 }
 
@@ -304,12 +302,6 @@ NS_ASSUME_NONNULL_BEGIN
     
     if (navigationBarTitle != nil) {
         self.navigationBarTitle = navigationBarTitle;
-    }
-    
-    NSURL * const extensionURL = [viewModelSchema.extensionURLPath URLFromJSONDictionary:dictionary];
-    
-    if (extensionURL != nil) {
-        self.extensionURL = extensionURL;
     }
     
     NSDictionary * const customData = [viewModelSchema.customDataPath dictionaryFromJSONDictionary:dictionary];
@@ -369,7 +361,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     copy.viewIdentifier = self.viewIdentifier;
-    copy.extensionURL = self.extensionURL;
     copy.customData = self.customData;
     copy.headerComponentModelBuilderImplementation = [self.headerComponentModelBuilderImplementation copy];
     

--- a/sources/HUBViewModelImplementation.h
+++ b/sources/HUBViewModelImplementation.h
@@ -36,7 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param headerComponentModel The model for any component that make up the view's header
  *  @param bodyComponentModels The models for the components that make up the view's body
  *  @param overlayComponentModels The models for the components that will be rendered as overlays
- *  @param extensionURL Any HTTP URL from which data can be downloaded to extend this view model
  *  @param customData Any custom data that should be associated with the view
  */
 - (instancetype)initWithIdentifier:(nullable NSString *)identifier
@@ -44,7 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
               headerComponentModel:(nullable id<HUBComponentModel>)headerComponentModel
                bodyComponentModels:(NSArray<id<HUBComponentModel>> *)bodyComponentModels
             overlayComponentModels:(NSArray<id<HUBComponentModel>> *)overlayComponentModels
-                      extensionURL:(nullable NSURL *)extensionURL
                         customData:(nullable NSDictionary<NSString *, id> *)customData HUB_DESIGNATED_INITIALIZER;
 
 @end

--- a/sources/HUBViewModelImplementation.m
+++ b/sources/HUBViewModelImplementation.m
@@ -35,7 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 @synthesize headerComponentModel = _headerComponentModel;
 @synthesize bodyComponentModels = _bodyComponentModels;
 @synthesize overlayComponentModels = _overlayComponentModels;
-@synthesize extensionURL = _extensionURL;
 @synthesize customData = _customData;
 @synthesize buildDate = _buildDate;
 
@@ -55,7 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
               headerComponentModel:(nullable id<HUBComponentModel>)headerComponentModel
                bodyComponentModels:(NSArray<id<HUBComponentModel>> *)bodyComponentModels
             overlayComponentModels:(NSArray<id<HUBComponentModel>> *)overlayComponentModels
-                      extensionURL:(nullable NSURL *)extensionURL
                         customData:(nullable NSDictionary<NSString *, id> *)customData
 {
     self = [super init];
@@ -65,7 +63,6 @@ NS_ASSUME_NONNULL_BEGIN
         _headerComponentModel = headerComponentModel;
         _bodyComponentModels = bodyComponentModels;
         _overlayComponentModels = overlayComponentModels;
-        _extensionURL = [extensionURL copy];
         _customData = customData;
         _buildDate = [NSDate date];
         
@@ -113,7 +110,6 @@ NS_ASSUME_NONNULL_BEGIN
     serialization[HUBJSONKeyHeader] = [self.headerComponentModel serialize];
     serialization[HUBJSONKeyBody] = [self serializeComponentModels:self.bodyComponentModels];
     serialization[HUBJSONKeyOverlays] = [self serializeComponentModels:self.overlayComponentModels];
-    serialization[HUBJSONKeyExtension] = self.extensionURL.absoluteString;
     serialization[HUBJSONKeyCustom] = self.customData;
     
     return [serialization copy];

--- a/sources/HUBViewModelJSONSchemaImplementation.m
+++ b/sources/HUBViewModelJSONSchemaImplementation.m
@@ -31,7 +31,6 @@
 @synthesize headerComponentModelDictionaryPath = _headerComponentModelDictionaryPath;
 @synthesize bodyComponentModelDictionariesPath = _bodyComponentModelDictionariesPath;
 @synthesize overlayComponentModelDictionariesPath = _overlayComponentModelDictionariesPath;
-@synthesize extensionURLPath = _extensionURLPath;
 @synthesize customDataPath = _customDataPath;
 
 #pragma mark - Initializers
@@ -43,7 +42,6 @@
      headerComponentModelDictionaryPath:[[[HUBMutableJSONPathImplementation path] goTo:HUBJSONKeyHeader] dictionaryPath]
      bodyComponentModelDictionariesPath:[[[[HUBMutableJSONPathImplementation path] goTo:HUBJSONKeyBody] forEach] dictionaryPath]
   overlayComponentModelDictionariesPath:[[[[HUBMutableJSONPathImplementation path] goTo:HUBJSONKeyOverlays] forEach] dictionaryPath]
-                       extensionURLPath:[[[HUBMutableJSONPathImplementation path] goTo:HUBJSONKeyExtension] URLPath]
                          customDataPath:[[[HUBMutableJSONPathImplementation path] goTo:HUBJSONKeyCustom] dictionaryPath]];
 }
 
@@ -52,7 +50,6 @@
     headerComponentModelDictionaryPath:(id<HUBJSONDictionaryPath>)headerComponentModelDictionaryPath
     bodyComponentModelDictionariesPath:(id<HUBJSONDictionaryPath>)bodyComponentModelDictionariesPath
  overlayComponentModelDictionariesPath:(id<HUBJSONDictionaryPath>)overlayComponentModelDictionariesPath
-                      extensionURLPath:(id<HUBJSONURLPath>)extensionURLPath
                         customDataPath:(id<HUBJSONDictionaryPath>)customDataPath
 {
     self = [super init];
@@ -63,7 +60,6 @@
         _headerComponentModelDictionaryPath = headerComponentModelDictionaryPath;
         _bodyComponentModelDictionariesPath = bodyComponentModelDictionariesPath;
         _overlayComponentModelDictionariesPath = overlayComponentModelDictionariesPath;
-        _extensionURLPath = extensionURLPath;
         _customDataPath = customDataPath;
     }
     
@@ -79,7 +75,6 @@
                                              headerComponentModelDictionaryPath:self.headerComponentModelDictionaryPath
                                              bodyComponentModelDictionariesPath:self.bodyComponentModelDictionariesPath
                                           overlayComponentModelDictionariesPath:self.overlayComponentModelDictionariesPath
-                                                               extensionURLPath:self.extensionURLPath
                                                                  customDataPath:self.customDataPath];
 }
 

--- a/tests/HUBComponentModelTests.m
+++ b/tests/HUBComponentModelTests.m
@@ -81,7 +81,6 @@
                                                                                                       headerComponentModel:nil
                                                                                                        bodyComponentModels:@[]
                                                                                                     overlayComponentModels:@[]
-                                                                                                              extensionURL:nil
                                                                                                                 customData:nil];
         
         HUBIdentifier * const actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];

--- a/tests/HUBInitialViewModelRegistryTests.m
+++ b/tests/HUBInitialViewModelRegistryTests.m
@@ -45,7 +45,6 @@
                                                                          headerComponentModel:nil
                                                                           bodyComponentModels:@[]
                                                                        overlayComponentModels:@[]
-                                                                                 extensionURL:nil
                                                                                    customData:nil];
     
     NSURL * const viewURI = [NSURL URLWithString:@"spotify:hub:framework"];

--- a/tests/HUBViewModelBuilderTests.m
+++ b/tests/HUBViewModelBuilderTests.m
@@ -64,14 +64,12 @@
     
     self.builder.viewIdentifier = @"view";
     self.builder.navigationBarTitle = @"nav title";
-    self.builder.extensionURL = [NSURL URLWithString:@"www.spotify.com"];
     self.builder.customData = @{@"custom": @"data"};
     
     id<HUBViewModel> const model = [self.builder build];
     
     XCTAssertEqualObjects(model.identifier, self.builder.viewIdentifier);
     XCTAssertEqualObjects(model.navigationItem.title, self.builder.navigationBarTitle);
-    XCTAssertEqualObjects(model.extensionURL, self.builder.extensionURL);
     XCTAssertEqualObjects(model.customData, self.builder.customData);
 }
 
@@ -331,7 +329,6 @@
     NSString * const bodyComponentModelIdentifier = @"body model";
     HUBIdentifier * const bodyComponentIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"body" name:@"component"];
     HUBIdentifier * const overlayComponentIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"overlay" name:@"component"];
-    NSURL * const extensionURL = [NSURL URLWithString:@"https://spotify.com/extension"];
     NSDictionary * const customData = @{@"custom": @"data"};
     
     NSDictionary * const dictionary = @{
@@ -362,7 +359,6 @@
                 }
             }
         ],
-        @"extension": extensionURL.absoluteString,
         @"custom": customData
     };
     
@@ -379,7 +375,6 @@
     XCTAssertEqualObjects([model.bodyComponentModels firstObject].componentCategory, @"bodyCategory");
     XCTAssertEqualObjects([model.overlayComponentModels firstObject].componentIdentifier, overlayComponentIdentifier);
     XCTAssertEqualObjects([model.overlayComponentModels firstObject].componentCategory, @"overlayCategory");
-    XCTAssertEqualObjects(model.extensionURL, extensionURL);
     XCTAssertEqualObjects(model.customData, customData);
     
     // Serializing should produce an identical dictionary as was passed as JSON data
@@ -424,7 +419,6 @@
     self.builder.viewIdentifier = @"view";
     self.builder.navigationBarTitle = @"title";
     self.builder.headerComponentModelBuilder.title = @"header title";
-    self.builder.extensionURL = [NSURL URLWithString:@"http://spotify.extension.com"];
     self.builder.customData = @{@"custom": @"data"};
     [self.builder builderForBodyComponentModelWithIdentifier:@"component"].title = @"body title";
     
@@ -434,7 +428,6 @@
     XCTAssertEqualObjects(self.builder.viewIdentifier, @"view");
     XCTAssertEqualObjects(self.builder.navigationBarTitle, @"title");
     XCTAssertEqualObjects(self.builder.headerComponentModelBuilder.title, @"header title");
-    XCTAssertEqualObjects(self.builder.extensionURL, [NSURL URLWithString:@"http://spotify.extension.com"]);
     XCTAssertEqualObjects(self.builder.customData, @{@"custom" : @"data"});
     XCTAssertTrue([self.builder builderExistsForBodyComponentModelWithIdentifier:@"component"]);
 }
@@ -495,7 +488,6 @@
     self.builder.navigationItem.rightBarButtonItems = rightBarButtonItems;
     
     self.builder.viewIdentifier = @"id";
-    self.builder.extensionURL = [NSURL URLWithString:@"https://spotify.extension.com"];
     self.builder.customData = @{@"custom": @"data"};
     self.builder.headerComponentModelBuilder.title = @"headerTitle";
     
@@ -513,7 +505,6 @@
     XCTAssertEqualObjects(builderCopy.navigationItem.rightBarButtonItems, rightBarButtonItems);
     
     XCTAssertEqualObjects(builderCopy.viewIdentifier, @"id");
-    XCTAssertEqualObjects(builderCopy.extensionURL, [NSURL URLWithString:@"https://spotify.extension.com"]);
     XCTAssertEqualObjects(builderCopy.customData, @{@"custom": @"data"});
     
     XCTAssertNotEqual(builderCopy.headerComponentModelBuilder, self.builder.headerComponentModelBuilder);

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -67,7 +67,6 @@
                                              headerComponentModel:nil
                                               bodyComponentModels:components
                                            overlayComponentModels:@[]
-                                                     extensionURL:nil
                                                        customData:@{@"custom": @"data"}];
 }
 

--- a/tests/HUBViewModelTests.m
+++ b/tests/HUBViewModelTests.m
@@ -60,14 +60,12 @@
         };
         
         UINavigationItem * const navigationItem = [[UINavigationItem alloc] initWithTitle:@"title"];
-        NSURL * const extensionURL = [NSURL URLWithString:@"https://spotify.com/viewmodelextension"];
         
         return [[HUBViewModelImplementation alloc] initWithIdentifier:@"identifier"
                                                        navigationItem:navigationItem
                                                  headerComponentModel:createComponentModel()
                                                   bodyComponentModels:@[createComponentModel()]
                                                overlayComponentModels:@[createComponentModel()]
-                                                         extensionURL:extensionURL
                                                            customData:@{@"custom": @"data"}];
     };
     
@@ -103,14 +101,12 @@
         
         NSString * const title = [NSUUID UUID].UUIDString;
         UINavigationItem * const navigationItem = [[UINavigationItem alloc] initWithTitle:title];
-        NSURL * const extensionURL = [NSURL URLWithString:@"https://spotify.com/viewmodelextension"];
         
         return [[HUBViewModelImplementation alloc] initWithIdentifier:@"identifier"
                                                        navigationItem:navigationItem
                                                  headerComponentModel:createComponentModel()
                                                   bodyComponentModels:@[createComponentModel()]
                                                overlayComponentModels:@[createComponentModel()]
-                                                         extensionURL:extensionURL
                                                            customData:@{@"custom": @"data"}];
     };
     


### PR DESCRIPTION
This property was originally intended to provide a way to paginate content from a backend service, by letting that backend service returning a URL from where additional content can be loaded.

However, since the move to content operations (and with content operation chaining) - this has been made less and less relevant, since content operations are not required to actually load their content from a backend service.

This property wasn’t actually used anywhere in the framework, so removing it in favor of an upcoming new content operation extension API for paginated content.

Relates to https://github.com/spotify/HubFramework/issues/28