### PR TITLE
Adds possibility of scrolling to indexpaths (children included) to the HUBViewController.

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 		DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		F64C5C2B1DB82CA30077E619 /* HUBViewModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelRenderer.h; sourceTree = "<group>"; };
 		F64C5C2C1DB82CA30077E619 /* HUBViewModelRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelRenderer.m; sourceTree = "<group>"; };
+		F65C149A1DC93AEB0030958D /* HUBComponentWithScrolling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentWithScrolling.h; sourceTree = "<group>"; };
 		F663FE7C1D10BECE003E19B6 /* HUBActionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBActionContext.h; sourceTree = "<group>"; };
 		F66658D71D9925CC0097929F /* HUBViewModelDiff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelDiff.h; sourceTree = "<group>"; };
 		F66658D81D9925CC0097929F /* HUBViewModelDiff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelDiff.m; sourceTree = "<group>"; };
@@ -977,6 +978,7 @@
 				8A0754AC1C21A7C700AFAD38 /* HUBComponent.h */,
 				1D98E5BC1DC09FB500607097 /* HUBComponentActionObserver.h */,
 				8A1585961C8F003C0008FDF9 /* HUBComponentWithChildren.h */,
+				F65C149A1DC93AEB0030958D /* HUBComponentWithScrolling.h */,
 				8A1585941C8EFF1E0008FDF9 /* HUBComponentWithImageHandling.h */,
 				8AFD984F1D09BCA500AFF898 /* HUBComponentWithRestorableUIState.h */,
 				8A4C28191DB6464B00152429 /* HUBComponentWithSelectionState.h */,

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 		F66658D71D9925CC0097929F /* HUBViewModelDiff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelDiff.h; sourceTree = "<group>"; };
 		F66658D81D9925CC0097929F /* HUBViewModelDiff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelDiff.m; sourceTree = "<group>"; };
 		F6665AA61D9947E00097929F /* HUBViewModelDiffTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelDiffTests.m; sourceTree = "<group>"; };
+		F68DF5D41DCAA0D4004C538A /* HUBScrollPosition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBScrollPosition.h; sourceTree = "<group>"; };
 		F6AC23C11DA2863A001B1A6A /* HUBComponentWrapperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentWrapperTests.m; sourceTree = "<group>"; };
 		F6B6B7541D9A8E7E0000D7AF /* HUBURLProtocolMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBURLProtocolMock.h; sourceTree = "<group>"; };
 		F6B6B7551D9A8E7E0000D7AF /* HUBURLProtocolMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBURLProtocolMock.m; sourceTree = "<group>"; };
@@ -1002,6 +1003,7 @@
 				8A5D7A6F1CBE586700B987BA /* HUBComponentFallbackHandler.h */,
 				8ACA8C801D180EC80015310F /* HUBComponentShowcaseManager.h */,
 				8ACA8C841D1816C90015310F /* HUBComponentShowcaseShapshotGenerator.h */,
+				F68DF5D41DCAA0D4004C538A /* HUBScrollPosition.h */,
 			);
 			name = Components;
 			sourceTree = "<group>";

--- a/include/HubFramework/HUBComponentWithChildren.h
+++ b/include/HubFramework/HUBComponentWithChildren.h
@@ -110,6 +110,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, weak, nullable) id<HUBComponentChildDelegate> childDelegate;
 
+/**
+ * Called when programmatically scrolling to a child within this parent component.
+ *
+ * @param childIndex The index of the component that is being scrolled to.
+ * @param scrollPosition The preferred position of the component after scrolling.
+ * @param animated Whether or not the scrolling should be animated.
+ * @param completionHandler The block to call once the component is visible.
+ */
+- (void)scrollToComponentAtIndex:(NSUInteger)childIndex
+                atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                        animated:(BOOL)animated
+                      completion:(void (^)())completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBComponentWithChildren.h
+++ b/include/HubFramework/HUBComponentWithChildren.h
@@ -110,19 +110,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, weak, nullable) id<HUBComponentChildDelegate> childDelegate;
 
-/**
- * Called when programmatically scrolling to a child within this parent component.
- *
- * @param childIndex The index of the component that is being scrolled to.
- * @param scrollPosition The preferred position of the component after scrolling.
- * @param animated Whether or not the scrolling should be animated.
- * @param completionHandler The block to call once the component is visible.
- */
-- (void)scrollToComponentAtIndex:(NSUInteger)childIndex
-                atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
-                        animated:(BOOL)animated
-                      completion:(void (^)())completionHandler;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBComponentWithScrolling.h
+++ b/include/HubFramework/HUBComponentWithScrolling.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBComponentWithChildren.h"
+
+/**
+ * Extended Hub component protocol that adds the ability scroll between child components.
+ *
+ * Use this protocol if your component supports scrolling between components within it. 
+ * See `HUBComponent` for more info.
+ */
+@protocol HUBComponentWithScrolling <HUBComponentWithChildren>
+
+/**
+ * Called when programmatically scrolling to a child within this parent component.
+ *
+ * @param childIndex The index of the component that is being scrolled to.
+ * @param animated Whether or not the scrolling should be animated.
+ * @param completionHandler The block to call once the component is visible.
+ */
+- (void)scrollToComponentAtIndex:(NSUInteger)childIndex
+                        animated:(BOOL)animated
+                      completion:(void (^)())completionHandler;
+
+@end

--- a/include/HubFramework/HUBComponentWithScrolling.h
+++ b/include/HubFramework/HUBComponentWithScrolling.h
@@ -33,10 +33,12 @@
  * Called when programmatically scrolling to a child within this parent component.
  *
  * @param childIndex The index of the component that is being scrolled to.
+ * @param scrollPosition The preferred position of the component after scrolling.
  * @param animated Whether or not the scrolling should be animated.
  * @param completionHandler The block to call once the component is visible.
  */
 - (void)scrollToComponentAtIndex:(NSUInteger)childIndex
+                  scrollPosition:(UICollectionViewScrollPosition)scrollPosition
                         animated:(BOOL)animated
                       completion:(void (^)())completionHandler;
 

--- a/include/HubFramework/HUBComponentWithScrolling.h
+++ b/include/HubFramework/HUBComponentWithScrolling.h
@@ -23,7 +23,7 @@
 #import "HUBScrollPosition.h"
 
 /**
- * Extended Hub component protocol that adds the ability scroll between child components.
+ * Extended Hub component protocol that adds the ability to scroll between child components.
  *
  * Use this protocol if your component supports scrolling between components within it. 
  * See `HUBComponent` for more info.

--- a/include/HubFramework/HUBComponentWithScrolling.h
+++ b/include/HubFramework/HUBComponentWithScrolling.h
@@ -20,6 +20,7 @@
  */
 
 #import "HUBComponentWithChildren.h"
+#import "HUBScrollPosition.h"
 
 /**
  * Extended Hub component protocol that adds the ability scroll between child components.
@@ -35,11 +36,11 @@
  * @param childIndex The index of the component that is being scrolled to.
  * @param scrollPosition The preferred position of the component after scrolling.
  * @param animated Whether or not the scrolling should be animated.
- * @param completionHandler The block to call once the component is visible.
+ * @param completion The block to call once the component is visible.
  */
 - (void)scrollToComponentAtIndex:(NSUInteger)childIndex
-                  scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                  scrollPosition:(HUBScrollPosition)scrollPosition
                         animated:(BOOL)animated
-                      completion:(void (^)())completionHandler;
+                      completion:(void (^)(void))completion;
 
 @end

--- a/include/HubFramework/HUBScrollPosition.h
+++ b/include/HubFramework/HUBScrollPosition.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ * An enumeration to be used when scrolling to a specific position within a scrollable component.
+ * For ease of use, the different options map to their corresponding UICollectionViewScrollPosition. 
+ */
+typedef NS_OPTIONS(NSUInteger, HUBScrollPosition) {
+    HUBScrollPositionNone                 = 0,
+    HUBScrollPositionTop                  = UICollectionViewScrollPositionTop,
+    HUBScrollPositionCenteredVertically   = UICollectionViewScrollPositionCenteredVertically,
+    HUBScrollPositionBottom               = UICollectionViewScrollPositionBottom,
+    HUBScrollPositionLeft                 = UICollectionViewScrollPositionLeft,
+    HUBScrollPositionCenteredHorizontally = UICollectionViewScrollPositionCenteredHorizontally,
+    HUBScrollPositionRight                = UICollectionViewScrollPositionRight
+};

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -176,10 +176,12 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param componentIndexPath The index path of the component to scroll to.
  *  @param scrollPosition The preferred position of the component after scrolling.
  *  @param animated Whether or not the scrolling should be animated.
+ *  @param completionHandler A block that is called once the component at the provided index path is visible.
  */
 - (void)scrollToComponentAtIndexPath:(NSIndexPath *)componentIndexPath
-                    atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
-                            animated:(BOOL)animated;
+                      scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                            animated:(BOOL)animated
+                          completion:(void (^ _Nullable)())completionHandler;
 
 /**
  *  Returns the views of the components of the given type that are currently visible on screen, keyed by their index path

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -179,17 +179,19 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  In order for child components to support nested scrolling, they must implement @c HUBComponentWithScrolling.
  *
- *  @param componentIndexPath The index path of the component to scroll to.
+ *  @param componentType The type of component you want to scroll to.
+ *  @param indexPath The index path of the component to scroll to.
  *  @param scrollPosition The preferred position of the component after scrolling.
  *  @param animated Whether or not the scrolling should be animated.
  *  @param completion A block that is called once the component at the provided index path is visible.
  *
  *  @seealso HUBComponentWithScrolling
  */
-- (void)scrollToComponentAtIndexPath:(NSIndexPath *)componentIndexPath
-                      scrollPosition:(HUBScrollPosition)scrollPosition
-                            animated:(BOOL)animated
-                          completion:(void (^ _Nullable)(void))completion;
+- (void)scrollToComponentOfType:(HUBComponentType)componentType
+                      indexPath:(NSIndexPath *)indexPath
+                 scrollPosition:(HUBScrollPosition)scrollPosition
+                       animated:(BOOL)animated
+                     completion:(void (^ _Nullable)(void))completion;
 
 /**
  *  Returns the views of the components of the given type that are currently visible on screen, keyed by their index path

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -23,6 +23,7 @@
 
 #import "HUBComponentType.h"
 #import "HUBComponentLayoutTraits.h"
+#import "HUBScrollPosition.h"
 
 @protocol HUBViewController;
 @protocol HUBViewModel;
@@ -171,17 +172,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)scrollToContentOffset:(CGPoint)contentOffset animated:(BOOL)animated;
 
 /**
- *  Scroll to a desired content offset.
+ *  Scroll to a desired component. Each index in the index path refers to one level of children.
+ *  For example, in order to scroll to a root component at an index, you would provide an index
+ *  path with that single index. If that component in turn has children, you can scroll between
+ *  those by providing an index path with two index, starting with the root index, and so on.
+ *
+ *  In order for child components to support nested scrolling, they must implement @c HUBComponentWithScrolling.
  *
  *  @param componentIndexPath The index path of the component to scroll to.
  *  @param scrollPosition The preferred position of the component after scrolling.
  *  @param animated Whether or not the scrolling should be animated.
- *  @param completionHandler A block that is called once the component at the provided index path is visible.
+ *  @param completion A block that is called once the component at the provided index path is visible.
+ *
+ *  @seealso HUBComponentWithScrolling
  */
 - (void)scrollToComponentAtIndexPath:(NSIndexPath *)componentIndexPath
-                      scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                      scrollPosition:(HUBScrollPosition)scrollPosition
                             animated:(BOOL)animated
-                          completion:(void (^ _Nullable)())completionHandler;
+                          completion:(void (^ _Nullable)(void))completion;
 
 /**
  *  Returns the views of the components of the given type that are currently visible on screen, keyed by their index path

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -171,6 +171,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)scrollToContentOffset:(CGPoint)contentOffset animated:(BOOL)animated;
 
 /**
+ *  Scroll to a desired content offset.
+ *
+ *  @param componentIndexPath The index path of the component to scroll to.
+ *  @param scrollPosition The preferred position of the component after scrolling.
+ *  @param animated Whether or not the scrolling should be animated.
+ */
+- (void)scrollToComponentAtIndexPath:(NSIndexPath *)componentIndexPath
+                    atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                            animated:(BOOL)animated;
+
+/**
  *  Returns the views of the components of the given type that are currently visible on screen, keyed by their index path
  *
  *  @param componentType The type of component to check for visiblilty.

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -20,6 +20,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "HUBScrollPosition.h"
 
 @protocol HUBViewController;
 
@@ -120,7 +121,7 @@
  *  @param viewController The view controller in question.
  */
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
-                                       scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                       scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
                                        viewController:(UIViewController<HUBViewController> *)viewController;

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -118,7 +118,7 @@
  * @param viewController The view controller in question.
  */
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
-                                     atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
-                                     inViewController:(UIViewController<HUBViewController> *)viewController;
+                                       scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                       viewController:(UIViewController<HUBViewController> *)viewController;
 
 @end

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -110,4 +110,15 @@
                                         currentContentOffset:(CGPoint)currentContentOffset
                                        proposedContentOffset:(CGPoint)proposedContentOffset;
 
+/**
+ * Return the content offset for displaying a component at a certain scroll position.
+ * 
+ * @param componentIndex The index of the component to display.
+ * @param scrollPosition The position to display the component at.
+ * @param viewController The view controller in question.
+ */
+- (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
+                                     atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                     inViewController:(UIViewController<HUBViewController> *)viewController;
+
 @end

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -111,14 +111,18 @@
                                        proposedContentOffset:(CGPoint)proposedContentOffset;
 
 /**
- * Return the content offset for displaying a component at a certain scroll position.
- * 
- * @param componentIndex The index of the component to display.
- * @param scrollPosition The position to display the component at.
- * @param viewController The view controller in question.
+ *  Return the content offset for displaying a component at a certain scroll position.
+ *  
+ *  @param componentIndex The index of the component to display.
+ *  @param scrollPosition The position to display the component at.
+ *  @param contentInset The current content inset of the view controller's scroll view
+ *  @param contentSize The current content size of the view controller's scroll view
+ *  @param viewController The view controller in question.
  */
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
                                        scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                         contentInset:(UIEdgeInsets)contentInset
+                                          contentSize:(CGSize)contentSize
                                        viewController:(UIViewController<HUBViewController> *)viewController;
 
 @end

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -85,6 +85,7 @@
 #import "HUBComponentFallbackHandler.h"
 #import "HUBComponentShowcaseManager.h"
 #import "HUBComponentShowcaseShapshotGenerator.h"
+#import "HUBScrollPosition.h"
 
 // Images & Icons
 #import "HUBImageLoaderFactory.h"

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -60,6 +60,7 @@
 // Components
 #import "HUBComponent.h"
 #import "HUBComponentWithChildren.h"
+#import "HUBComponentWithScrolling.h"
 #import "HUBComponentWithImageHandling.h"
 #import "HUBComponentWithRestorableUIState.h"
 #import "HUBComponentWithSelectionState.h"

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -25,6 +25,7 @@
 #import "HUBComponentActionObserver.h"
 #import "HUBComponentWithRestorableUIState.h"
 #import "HUBComponentWithSelectionState.h"
+#import "HUBComponentWithChildren.h"
 #import "HUBHeaderMacros.h"
 
 @protocol HUBComponent;
@@ -133,7 +134,8 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
     HUBComponentViewObserver,
     HUBComponentContentOffsetObserver,
     HUBComponentActionObserver,
-    HUBComponentWithSelectionState
+    HUBComponentWithSelectionState,
+    HUBComponentWithChildren
 >
 
 /// A unique identifier for this component wrapper. Can be used to track it accross various operations.
@@ -195,6 +197,11 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
  *  is prepared for reuse.
  */
 - (void)saveComponentUIState;
+
+/** 
+ *  Returns the child component wrapper located at the provided index – if visible. 
+ */
+- (nullable HUBComponentWrapper *)childComponentAtIndex:(NSUInteger)index;
 
 @end
 

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -25,7 +25,7 @@
 #import "HUBComponentActionObserver.h"
 #import "HUBComponentWithRestorableUIState.h"
 #import "HUBComponentWithSelectionState.h"
-#import "HUBComponentWithChildren.h"
+#import "HUBComponentWithScrolling.h"
 #import "HUBHeaderMacros.h"
 
 @protocol HUBComponent;
@@ -135,7 +135,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
     HUBComponentContentOffsetObserver,
     HUBComponentActionObserver,
     HUBComponentWithSelectionState,
-    HUBComponentWithChildren
+    HUBComponentWithScrolling
 >
 
 /// A unique identifier for this component wrapper. Can be used to track it accross various operations.
@@ -200,6 +200,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
 
 /** 
  *  Returns the child component wrapper located at the provided index – if visible. 
+ *  @param index The index of the component to retrieve.
  */
 - (nullable HUBComponentWrapper *)childComponentAtIndex:(NSUInteger)index;
 

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -200,9 +200,10 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
 
 /** 
  *  Returns the child component wrapper located at the provided index – if visible. 
+ *
  *  @param index The index of the component to retrieve.
  */
-- (nullable HUBComponentWrapper *)childComponentAtIndex:(NSUInteger)index;
+- (nullable HUBComponentWrapper *)visibleChildComponentAtIndex:(NSUInteger)index;
 
 @end
 

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBComponentWrapper
 
+@synthesize childDelegate;
+
 - (instancetype)initWithComponent:(id<HUBComponent>)component
                             model:(id<HUBComponentModel>)model
                    UIStateManager:(HUBComponentUIStateManager *)UIStateManager
@@ -116,6 +118,11 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         [self.UIStateManager saveUIState:currentUIState forComponentModel:self.model];
     }
+}
+
+- (nullable HUBComponentWrapper *)childComponentAtIndex:(NSUInteger)index
+{
+    return self.childrenByIndex[@(index)];
 }
 
 - (NSArray<HUBComponentWrapper *> *)visibleChildren
@@ -305,6 +312,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateViewForSelectionState:(HUBComponentSelectionState)selectionState
 {
     [self updateViewForSelectionState:selectionState notifyDelegate:NO];
+}
+
+#pragma mark - HUBComponentWithChildren
+
+- (void)scrollToComponentAtIndex:(NSUInteger)childIndex
+                atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                        animated:(BOOL)animated
+                      completion:(void (^)())completionHandler
+{
+    if ([self.component conformsToProtocol:@protocol(HUBComponentWithChildren)]) {
+        [(id<HUBComponentWithChildren>)self.component scrollToComponentAtIndex:childIndex
+                                                              atScrollPosition:scrollPosition
+                                                                      animated:animated
+                                                                    completion:completionHandler];
+    }
 }
 
 #pragma mark - HUBComponentChildDelegate

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -314,16 +314,14 @@ NS_ASSUME_NONNULL_BEGIN
     [self updateViewForSelectionState:selectionState notifyDelegate:NO];
 }
 
-#pragma mark - HUBComponentWithChildren
+#pragma mark - HUBComponentWithScrolling
 
 - (void)scrollToComponentAtIndex:(NSUInteger)childIndex
-                atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
                         animated:(BOOL)animated
                       completion:(void (^)())completionHandler
 {
-    if ([self.component conformsToProtocol:@protocol(HUBComponentWithChildren)]) {
-        [(id<HUBComponentWithChildren>)self.component scrollToComponentAtIndex:childIndex
-                                                              atScrollPosition:scrollPosition
+    if ([self.component conformsToProtocol:@protocol(HUBComponentWithScrolling)]) {
+        [(id<HUBComponentWithScrolling>)self.component scrollToComponentAtIndex:childIndex
                                                                       animated:animated
                                                                     completion:completionHandler];
     }

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -324,7 +324,7 @@ NS_ASSUME_NONNULL_BEGIN
     if ([self.component conformsToProtocol:@protocol(HUBComponentWithScrolling)]) {
         [(id<HUBComponentWithScrolling>)self.component scrollToComponentAtIndex:childIndex
                                                                  scrollPosition:scrollPosition
-                                                                      animated:animated
+                                                                       animated:animated
                                                                     completion:completionHandler];
     }
 }

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -120,9 +120,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (nullable HUBComponentWrapper *)childComponentAtIndex:(NSUInteger)index
+- (nullable HUBComponentWrapper *)visibleChildComponentAtIndex:(NSUInteger)index
 {
-    return self.childrenByIndex[@(index)];
+    NSNumber * const boxedIndex = @(index);
+    if (self.visibleChildViewsByIndex[boxedIndex] != nil) {
+        return self.childrenByIndex[boxedIndex];
+    }
+    return nil;
 }
 
 - (NSArray<HUBComponentWrapper *> *)visibleChildren
@@ -317,15 +321,15 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - HUBComponentWithScrolling
 
 - (void)scrollToComponentAtIndex:(NSUInteger)childIndex
-                  scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                  scrollPosition:(HUBScrollPosition)scrollPosition
                         animated:(BOOL)animated
-                      completion:(void (^)())completionHandler
+                      completion:(void (^)(void))completion
 {
     if ([self.component conformsToProtocol:@protocol(HUBComponentWithScrolling)]) {
         [(id<HUBComponentWithScrolling>)self.component scrollToComponentAtIndex:childIndex
                                                                  scrollPosition:scrollPosition
                                                                        animated:animated
-                                                                    completion:completionHandler];
+                                                                     completion:completion];
     }
 }
 

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -317,11 +317,13 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - HUBComponentWithScrolling
 
 - (void)scrollToComponentAtIndex:(NSUInteger)childIndex
+                  scrollPosition:(UICollectionViewScrollPosition)scrollPosition
                         animated:(BOOL)animated
                       completion:(void (^)())completionHandler
 {
     if ([self.component conformsToProtocol:@protocol(HUBComponentWithScrolling)]) {
         [(id<HUBComponentWithScrolling>)self.component scrollToComponentAtIndex:childIndex
+                                                                 scrollPosition:scrollPosition
                                                                       animated:animated
                                                                     completion:completionHandler];
     }

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
-                                       scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                       scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
                                        viewController:(UIViewController<HUBViewController> *)viewController
@@ -79,9 +79,9 @@ NS_ASSUME_NONNULL_BEGIN
     CGFloat const viewHeight = CGRectGetHeight(viewController.view.frame);
     CGFloat targetOffset = 0.0;
 
-    if (scrollPosition & UICollectionViewScrollPositionCenteredVertically) {
-        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0);
-    } else if (scrollPosition & UICollectionViewScrollPositionBottom) {
+    if (scrollPosition & HUBScrollPositionCenteredVertically) {
+        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0f);
+    } else if (scrollPosition & HUBScrollPositionBottom) {
         targetOffset = CGRectGetMaxY(componentFrame) - viewHeight;
     } else {
         // Default to putting it at the top unless a proper position is provided
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     targetOffset = MAX(-contentInset.top, MIN(contentSize.height - viewHeight, targetOffset));
-    return CGPointMake(0.0, floor(targetOffset));
+    return CGPointMake(0.0, (CGFloat)floor((double)targetOffset));
 }
 
 @end

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -70,8 +70,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
-                                     atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
-                                     inViewController:(UIViewController<HUBViewController> *)viewController
+                                       scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                       viewController:(UIViewController<HUBViewController> *)viewController
 {
     CGRect const componentFrame = [viewController frameForBodyComponentAtIndex:componentIndex];
     CGFloat const viewHeight = CGRectGetHeight(viewController.view.frame);
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (scrollPosition & UICollectionViewScrollPositionCenteredVertically) {
         targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0);
     } else if (scrollPosition & UICollectionViewScrollPositionBottom) {
-        targetOffset = CGRectGetMinY(componentFrame) - viewHeight;
+        targetOffset = CGRectGetMaxY(componentFrame) - viewHeight;
     } else {
         // Default to putting it at the top unless a proper position is provided
         targetOffset = CGRectGetMinY(componentFrame);

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -20,6 +20,7 @@
  */
 
 #import "HUBViewControllerDefaultScrollHandler.h"
+#import "HUBViewController.h"
 
 #import <UIKit/UIKit.h>
 
@@ -66,6 +67,26 @@ NS_ASSUME_NONNULL_BEGIN
                                        proposedContentOffset:(CGPoint)proposedContentOffset
 {
     return proposedContentOffset;
+}
+
+- (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
+                                     atScrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                     inViewController:(UIViewController<HUBViewController> *)viewController
+{
+    CGRect const componentFrame = [viewController frameForBodyComponentAtIndex:componentIndex];
+    CGFloat const viewHeight = CGRectGetHeight(viewController.view.frame);
+    CGFloat targetOffset = 0.0;
+
+    if (scrollPosition & UICollectionViewScrollPositionCenteredVertically) {
+        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0);
+    } else if (scrollPosition & UICollectionViewScrollPositionBottom) {
+        targetOffset = CGRectGetMinY(componentFrame) - viewHeight;
+    } else {
+        // Default to putting it at the top unless a proper position is provided
+        targetOffset = CGRectGetMinY(componentFrame);
+    }
+
+    return CGPointMake(0.0, floor(targetOffset));
 }
 
 @end

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -71,6 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
                                        scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                         contentInset:(UIEdgeInsets)contentInset
+                                          contentSize:(CGSize)contentSize
                                        viewController:(UIViewController<HUBViewController> *)viewController
 {
     CGRect const componentFrame = [viewController frameForBodyComponentAtIndex:componentIndex];
@@ -86,6 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
         targetOffset = CGRectGetMinY(componentFrame);
     }
 
+    targetOffset = MAX(-contentInset.top, MIN(contentSize.height - viewHeight, targetOffset));
     return CGPointMake(0.0, floor(targetOffset));
 }
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -414,17 +414,16 @@ NS_ASSUME_NONNULL_BEGIN
                        animated:(BOOL)animated
                      completion:(void (^ _Nullable)(void))completion
 {
-    NSUInteger rootIndex = [indexPath indexAtPosition:0];
     if (componentType == HUBComponentTypeBody) {
-        NSUInteger componentCount = (NSUInteger)[self.collectionView numberOfItemsInSection:0];
-        NSAssert(rootIndex < componentCount,
-                 @"Root index %@ specified but there are only %@ components in the list.", @(rootIndex), @(componentCount));
+        NSAssert([indexPath indexAtPosition:0] < (NSUInteger)[self.collectionView numberOfItemsInSection:0],
+                 @"Root index %@ specified but there are only %@ components in the list.",
+                 @([indexPath indexAtPosition:0]), @([self.collectionView numberOfItemsInSection:0]));
     } else if (componentType == HUBComponentTypeHeader) {
         NSAssert(self.headerComponentWrapper != nil, @"Attempted to scroll to component within header, but no header was found.");
     } else if (componentType == HUBComponentTypeOverlay) {
-        NSUInteger overlayCount = self.overlayComponentWrappers.count;
-        NSAssert(rootIndex < overlayCount,
-                 @"Root index %@ specified but there are only %@ overlays in the list.", @(rootIndex), @(overlayCount));
+        NSAssert([indexPath indexAtPosition:0] < self.overlayComponentWrappers.count,
+                 @"Root index %@ specified but there are only %@ overlays in the list.",
+                 @([indexPath indexAtPosition:0]), @(self.overlayComponentWrappers.count));
     }
     
     [self scrollToRemainingComponentsOfType:componentType

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1506,7 +1506,7 @@
     XCTestExpectation * const scrollingCompletedExpectation = [self expectationWithDescription:@"Scrolling should complete and call the handler"];
     NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndex:8];
     [self.viewController scrollToComponentAtIndexPath:indexPath
-                                       scrollPosition:UICollectionViewScrollPositionTop
+                                       scrollPosition:HUBScrollPositionTop
                                              animated:YES
                                            completion:^{
         [scrollingCompletedExpectation fulfill];
@@ -1541,7 +1541,7 @@
     
     NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndex:8];
     [self.viewController scrollToComponentAtIndexPath:indexPath
-                                       scrollPosition:UICollectionViewScrollPositionTop
+                                       scrollPosition:HUBScrollPositionTop
                                              animated:YES
                                            completion:nil];
 
@@ -1567,15 +1567,15 @@
     [self.componentRegistry registerComponentFactory:componentFactory forNamespace:componentNamespace];
 
     self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
-        for (NSUInteger i = 0; i < 20; i++) {
+        for (NSInteger i = 0; i < 20; i++) {
             NSString * const identifier = [NSString stringWithFormat:@"component-%@", @(i)];
             id<HUBComponentModelBuilder> const componentBuilder = [viewModelBuilder builderForBodyComponentModelWithIdentifier:identifier];
             componentBuilder.componentNamespace = componentNamespace;
             componentBuilder.componentName = componentName;
 
-            for (NSUInteger i = 0; i < 10; i++) {
-                NSString * const identifier = [NSString stringWithFormat:@"childComponent-%@", @(i)];
-                id<HUBComponentModelBuilder> const childBuilder = [componentBuilder builderForChildWithIdentifier:identifier];
+            for (NSInteger j = 0; j < 10; j++) {
+                NSString * const childIdentifier = [NSString stringWithFormat:@"childComponent-%@", @(j)];
+                id<HUBComponentModelBuilder> const childBuilder = [componentBuilder builderForChildWithIdentifier:childIdentifier];
                 childBuilder.componentNamespace = componentNamespace;
                 childBuilder.componentName = childComponentName;
             }
@@ -1592,24 +1592,22 @@
     self.scrollHandler.targetContentOffset = CGPointMake(0.0, 1200);
 
     NSUInteger indexes[2] = {6, 7};
-    NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndexes:indexes length:2];
+    NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndexes:indexes length:2u];
 
-    NSIndexPath * const rootIndexPath = [NSIndexPath indexPathForItem:indexes[0] inSection:0];
+    NSIndexPath * const rootIndexPath = [NSIndexPath indexPathForItem:(NSInteger)indexes[0] inSection:0];
     UICollectionViewCell *cell = [self.collectionView.dataSource collectionView:self.collectionView cellForItemAtIndexPath:rootIndexPath];
     self.collectionView.cells[rootIndexPath] = cell;
     self.collectionView.mockedVisibleCells = @[cell];
 
     XCTestExpectation * const componentScrollExpectation = [self expectationWithDescription:@"The component should be asked to scroll to its child component"];
-    __weak HUBViewControllerTests *weakSelf = self;
-    component.scrollToComponentHandler = ^(NSUInteger childIndex, UICollectionViewScrollPosition position, BOOL animated) {
-        HUBViewControllerTests *self = weakSelf;
+    component.scrollToComponentHandler = ^(NSUInteger childIndex, HUBScrollPosition position, BOOL animated) {
         [componentScrollExpectation fulfill];
         XCTAssertEqual([indexPath indexAtPosition:1], childIndex);
     };
 
     XCTestExpectation * const scrollingCompletedExpectation = [self expectationWithDescription:@"Scrolling should complete and call the handler"];
     [self.viewController scrollToComponentAtIndexPath:indexPath
-                                       scrollPosition:UICollectionViewScrollPositionTop
+                                       scrollPosition:HUBScrollPositionTop
                                              animated:YES
                                            completion:^{
         [scrollingCompletedExpectation fulfill];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1510,10 +1510,11 @@
 
     XCTestExpectation * const scrollingCompletedExpectation = [self expectationWithDescription:@"Scrolling should complete and call the handler"];
     NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndex:8];
-    [self.viewController scrollToComponentAtIndexPath:indexPath
-                                       scrollPosition:HUBScrollPositionTop
-                                             animated:YES
-                                           completion:^{
+    [self.viewController scrollToComponentOfType:HUBComponentTypeBody
+                                       indexPath:indexPath
+                                  scrollPosition:HUBScrollPositionTop
+                                        animated:YES
+                                      completion:^{
         [scrollingCompletedExpectation fulfill];
         XCTAssertTrue(CGPointEqualToPoint(self.scrollHandler.targetContentOffset, self.collectionView.contentOffset));
     }];
@@ -1545,11 +1546,12 @@
     };
     
     NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndex:8];
-    [self.viewController scrollToComponentAtIndexPath:indexPath
-                                       scrollPosition:HUBScrollPositionTop
-                                             animated:YES
-                                           completion:nil];
-
+    [self.viewController scrollToComponentOfType:HUBComponentTypeBody
+                                       indexPath:indexPath
+                                  scrollPosition:HUBScrollPositionTop
+                                        animated:YES
+                                      completion:nil];
+    
     [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
@@ -1611,10 +1613,11 @@
     };
 
     XCTestExpectation * const scrollingCompletedExpectation = [self expectationWithDescription:@"Scrolling should complete and call the handler"];
-    [self.viewController scrollToComponentAtIndexPath:indexPath
-                                       scrollPosition:HUBScrollPositionTop
-                                             animated:YES
-                                           completion:^{
+    [self.viewController scrollToComponentOfType:HUBComponentTypeBody
+                                       indexPath:indexPath
+                                  scrollPosition:HUBScrollPositionTop
+                                        animated:YES
+                                      completion:^{
         [scrollingCompletedExpectation fulfill];
     }];
 

--- a/tests/mocks/HUBComponentMock.h
+++ b/tests/mocks/HUBComponentMock.h
@@ -27,7 +27,10 @@
 #import "HUBComponentContentOffsetObserver.h"
 #import "HUBComponentActionPerformer.h"
 #import "HUBComponentActionObserver.h"
+#import "HUBComponentWithScrolling.h"
 #import "HUBActionContext.h"
+
+typedef void(^HUBComponentMockScrollToComponentHandler)(NSUInteger index, UICollectionViewScrollPosition position, BOOL animated);
 
 @protocol HUBComponentImageData;
 
@@ -42,7 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
     HUBComponentViewObserver,
     HUBComponentContentOffsetObserver,
     HUBComponentActionPerformer,
-    HUBComponentActionObserver
+    HUBComponentActionObserver,
+    HUBComponentWithScrolling
 >
 
 /// The layout traits the component should act like it's having
@@ -107,6 +111,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Whether the component's image was recently animated
 @property (nonatomic, readonly) BOOL imageWasAnimated;
+
+@property (nonatomic, copy, nullable) HUBComponentMockScrollToComponentHandler scrollToComponentHandler;
 
 @end
 

--- a/tests/mocks/HUBComponentMock.h
+++ b/tests/mocks/HUBComponentMock.h
@@ -30,7 +30,7 @@
 #import "HUBComponentWithScrolling.h"
 #import "HUBActionContext.h"
 
-typedef void(^HUBComponentMockScrollToComponentHandler)(NSUInteger index, UICollectionViewScrollPosition position, BOOL animated);
+typedef void(^HUBComponentMockScrollToComponentHandler)(NSUInteger index, HUBScrollPosition position, BOOL animated);
 
 @protocol HUBComponentImageData;
 

--- a/tests/mocks/HUBComponentMock.m
+++ b/tests/mocks/HUBComponentMock.m
@@ -150,6 +150,22 @@
     self.latestObservedActionContext = context;
 }
 
+#pragma mark - HUBComponentWithScrolling
+
+- (void)scrollToComponentAtIndex:(NSUInteger)childIndex
+                  scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                        animated:(BOOL)animated
+                      completion:(void (^)())completionHandler
+{
+    UIView * const childView = [[UIView alloc] initWithFrame:CGRectZero];
+    [self.childDelegate component:self willDisplayChildAtIndex:childIndex view:childView];
+    completionHandler();
+    
+    if (self.scrollToComponentHandler) {
+        self.scrollToComponentHandler(childIndex, scrollPosition, animated);
+    }
+}
+
 #pragma mark - Property overrides
 
 - (NSArray<id> *)restoredUIStates

--- a/tests/mocks/HUBComponentMock.m
+++ b/tests/mocks/HUBComponentMock.m
@@ -153,9 +153,9 @@
 #pragma mark - HUBComponentWithScrolling
 
 - (void)scrollToComponentAtIndex:(NSUInteger)childIndex
-                  scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                  scrollPosition:(HUBScrollPosition)scrollPosition
                         animated:(BOOL)animated
-                      completion:(void (^)())completionHandler
+                      completion:(void (^)(void))completionHandler
 {
     UIView * const childView = [[UIView alloc] initWithFrame:CGRectZero];
     [self.childDelegate component:self willDisplayChildAtIndex:childIndex view:childView];

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.h
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// The last content rect that was sent to the handler when scrolling ended
 @property (nonatomic, assign, readonly) CGRect endContentRect;
 
+/// A block that is called when the scroll handler is notified that scrolling has started.
+@property (nonatomic, copy) void (^ _Nullable scrollingWillStartHandler)(CGRect contentRect);
+
+/// A block that is called when the scroll handler is notified that scrolling has ended.
+@property (nonatomic, copy) void (^ _Nullable scrollingDidEndHandler)(CGRect contentRect);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
-                                       scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                       scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
                                        viewController:(UIViewController<HUBViewController> *)viewController

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -58,12 +58,20 @@ NS_ASSUME_NONNULL_BEGIN
                         currentContentRect:(CGRect)currentContentRect
 {
     self.startContentRect = currentContentRect;
+
+    if (self.scrollingWillStartHandler) {
+        self.scrollingWillStartHandler(currentContentRect);
+    }
 }
 
 - (void)scrollingDidEndInViewController:(UIViewController<HUBViewController> *)viewController
                      currentContentRect:(CGRect)currentContentRect
 {
     self.endContentRect = currentContentRect;
+
+    if (self.scrollingDidEndHandler) {
+        self.scrollingDidEndHandler(currentContentRect);
+    }
 }
 
 - (CGPoint)targetContentOffsetForEndedScrollInViewController:(UIViewController<HUBViewController> *)viewController
@@ -71,6 +79,13 @@ NS_ASSUME_NONNULL_BEGIN
                                                 contentInset:(UIEdgeInsets)contentInset
                                         currentContentOffset:(CGPoint)currentContentOffset
                                        proposedContentOffset:(CGPoint)proposedContentOffset
+{
+    return self.targetContentOffset;
+}
+
+- (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
+                                       scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                       viewController:(UIViewController<HUBViewController> *)viewController
 {
     return self.targetContentOffset;
 }

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -85,6 +85,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
                                        scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                                         contentInset:(UIEdgeInsets)contentInset
+                                          contentSize:(CGSize)contentSize
                                        viewController:(UIViewController<HUBViewController> *)viewController
 {
     return self.targetContentOffset;


### PR DESCRIPTION
Putting this up as work-in-progress for discussion purposes! 

This PR adds the possibility of scrolling to nested children. 

The first challenge with doing this is that the HubFramework doesn't really know anything about how its children handles _their_ children, which forces us to delegate that to the components themselves. 

The second challenge is animations – since the components are reported to the HubFramework when they are visible, we have to wait for the animations to finish each step along the way.

@JohnSundell, @cerihughes, @spotify/objc-dev 