### PR TITLE
Implement equality for icons.

### DIFF
--- a/sources/HUBIconImplementation.h
+++ b/sources/HUBIconImplementation.h
@@ -19,6 +19,7 @@
  *  under the License.
  */
 
+#import "HUBAutoEquatable.h"
 #import "HUBIcon.h"
 #import "HUBHeaderMacros.h"
 
@@ -27,7 +28,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Concerete implementation of the `HUBIcon` protocol
-@interface HUBIconImplementation : NSObject <HUBIcon>
+@interface HUBIconImplementation : HUBAutoEquatable <HUBIcon>
 
 /**
  *  Initialize an instance of this class with its required data

--- a/sources/HUBIconImplementation.m
+++ b/sources/HUBIconImplementation.m
@@ -22,6 +22,7 @@
 #import "HUBIconImplementation.h"
 
 #import "HUBIconImageResolver.h"
+#import "HUBKeyPath.h"
 
 @interface HUBIconImplementation ()
 
@@ -33,6 +34,13 @@
 @implementation HUBIconImplementation
 
 @synthesize identifier = _identifier;
+
+#pragma mark - HUBAutoEquatable
+
++ (nullable NSSet<NSString *> *)ignoredAutoEquatablePropertyNames
+{
+    return [NSSet setWithObjects:HUBKeyPath((HUBIconImplementation *)nil, imageResolver), nil];
+}
 
 - (instancetype)initWithIdentifier:(NSString *)identifier imageResolver:(id<HUBIconImageResolver>)imageResolver isPlaceholder:(BOOL)isPlaceholder
 {

--- a/tests/HUBIconTests.m
+++ b/tests/HUBIconTests.m
@@ -42,6 +42,21 @@
 
 #pragma mark - Tests
 
+- (void)testEquality
+{
+    HUBIconImageResolverMock *imageResolver1 = [HUBIconImageResolverMock new];
+    HUBIconImageResolverMock *imageResolver2 = [HUBIconImageResolverMock new];
+    XCTAssertNotEqualObjects(imageResolver1, imageResolver2);
+
+    HUBIconImplementation * const icon1 = [[HUBIconImplementation alloc] initWithIdentifier:@"id"
+                                                                              imageResolver:imageResolver1
+                                                                              isPlaceholder:NO];
+    HUBIconImplementation * const icon2 = [[HUBIconImplementation alloc] initWithIdentifier:@"id"
+                                                                              imageResolver:imageResolver2
+                                                                              isPlaceholder:NO];
+    XCTAssertEqualObjects(icon1, icon2);
+}
+
 - (void)testIdentifierAssignment
 {
     HUBIconImplementation * const icon = [[HUBIconImplementation alloc] initWithIdentifier:@"id"


### PR DESCRIPTION
Previously, 2 equivalent `HUBIconImplementation`s would return `NO` for `isEqual:`.