### PR TITLE
add ignored warnings for xcode 8.1 as well

### DIFF
--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -57,6 +57,7 @@ GCC_PREPROCESSOR_DEFINITIONS = $SPOTIFY_OS_CONFIG_PREPROCESSOR_DEFINITIONS
 // Warnings, by Xcode version, we want to ignore.
 HF_IGNORED_WARNINGS_0730 = -Wno-double-promotion -Wno-partial-availability
 HF_IGNORED_WARNINGS_0800 = $(HF_IGNORED_WARNINGS_0730)
+HF_IGNORED_WARNINGS_0810 = $(HF_IGNORED_WARNINGS_0730)
 
 WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Werror $(HF_IGNORED_WARNINGS_$(XCODE_VERSION_MINOR))
 


### PR DESCRIPTION
When using xcode 8.1 you get a number of partial-availability and double-promotion build errors. Looks like you guys are just ignoring them like this?