### PR TITLE
HeaderView and Overlay components are now configured before the viewmodel is rendered

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -881,12 +881,12 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 
     [self saveStatesForVisibleComponents];
 
+    [self configureHeaderComponent];
+    [self configureOverlayComponents];
     [self.viewModelRenderer renderViewModel:viewModel
                           usingBatchUpdates:self.viewHasAppeared
                                    animated:animated
                                  completion:^{
-        [self configureHeaderComponent];
-        [self configureOverlayComponents];
         [self headerAndOverlayComponentViewsWillAppear];
         [self.delegate viewControllerDidFinishRendering:self];
     }];


### PR DESCRIPTION
The issue:
- For a brief moment, the view was shown without header and overlay components even though the model had them. 

Fix:
- configuring the overlay and header before the model is rendered