### PR TITLE
Fix components background color gets overridden when added to HubContainerView

### DIFF
--- a/sources/HUBContainerView.h
+++ b/sources/HUBContainerView.h
@@ -26,7 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// View that acts as a container view for a Hub Framework view controller
 @interface HUBContainerView : UIView
 
-/// Collection view contained by the container
+/**
+ *  Collection view contained by the container.
+ *
+ *  @discussion When collectionView is set it's also added as a subview.
+ */
 @property (nonatomic, strong, nullable) UICollectionView *collectionView;
 
 @end

--- a/sources/HUBContainerView.h
+++ b/sources/HUBContainerView.h
@@ -26,6 +26,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// View that acts as a container view for a Hub Framework view controller
 @interface HUBContainerView : UIView
 
+/// Collection view contained by the container
+@property (nonatomic, strong, nullable) UICollectionView *collectionView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBContainerView.m
+++ b/sources/HUBContainerView.m
@@ -27,19 +27,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setCollectionView:(nullable UICollectionView *)collectionView
 {
-    if (collectionView == nil) {
-        [_collectionView removeFromSuperview];
-        _collectionView = nil;
-        return;
-    }
-
     if (_collectionView == collectionView) {
         return;
     }
 
     [_collectionView removeFromSuperview];
-    _collectionView = collectionView;
-    [self insertSubview:(UICollectionView *)collectionView atIndex:0];
+    _collectionView = nil;
+
+    if (collectionView) {
+        _collectionView = collectionView;
+        [self insertSubview:(UICollectionView *)collectionView atIndex:0];
+    }
 }
 
 - (void)setBackgroundColor:(nullable UIColor *)backgroundColor

--- a/sources/HUBContainerView.m
+++ b/sources/HUBContainerView.m
@@ -25,18 +25,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBContainerView
 
+- (void)setCollectionView:(nullable UICollectionView *)collectionView
+{
+    if (collectionView == nil) {
+        [_collectionView removeFromSuperview];
+        _collectionView = nil;
+        return;
+    }
+
+    if (_collectionView == collectionView) {
+        return;
+    }
+
+    [_collectionView removeFromSuperview];
+    _collectionView = collectionView;
+    [self insertSubview:(UICollectionView *)collectionView atIndex:0];
+}
+
 - (void)setBackgroundColor:(nullable UIColor *)backgroundColor
 {
     [super setBackgroundColor:backgroundColor];
-    
-    for (UIView * const view in self.subviews) {
-        view.backgroundColor = backgroundColor;
-    }
-}
 
-- (void)didAddSubview:(UIView *)subview
-{
-    subview.backgroundColor = self.backgroundColor;
+    self.collectionView.backgroundColor = backgroundColor;
 }
 
 @end

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -173,8 +173,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    self.view = [[HUBContainerView alloc] initWithFrame:CGRectZero];
+    HUBContainerView *hubContainerView = [[HUBContainerView alloc] initWithFrame:CGRectZero];
+    self.view = hubContainerView;
+
     [self createCollectionViewIfNeeded];
+    hubContainerView.collectionView = self.collectionView;
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -173,11 +173,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    HUBContainerView *hubContainerView = [[HUBContainerView alloc] initWithFrame:CGRectZero];
-    self.view = hubContainerView;
+    self.view = [[HUBContainerView alloc] initWithFrame:CGRectZero];
 
     [self createCollectionViewIfNeeded];
-    hubContainerView.collectionView = self.collectionView;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -868,6 +866,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     collectionView.delegate = self;
     
     [self.view insertSubview:collectionView atIndex:0];
+
+    HUBContainerView *containerView = (HUBContainerView *)self.view;
+    containerView.collectionView = self.collectionView;
 }
 
 - (void)reloadCollectionViewWithViewModel:(id<HUBViewModel>)viewModel animated:(BOOL)animated

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -864,8 +864,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
     collectionView.dataSource = self;
     collectionView.delegate = self;
-    
-    [self.view insertSubview:collectionView atIndex:0];
 
     HUBContainerView *containerView = (HUBContainerView *)self.view;
     containerView.collectionView = self.collectionView;

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1363,6 +1363,20 @@
     XCTAssertEqualObjects(self.collectionView.backgroundColor, [UIColor redColor]);
 }
 
+- (void)testSettingBackgroundColorOfViewDoesNotUpdateHeaderComponentBackgroundColor
+{
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        viewModelBuilder.headerComponentModelBuilder.title = @"header";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    self.component.view.backgroundColor = [UIColor greenColor];
+    self.viewController.view.backgroundColor = [UIColor redColor];
+    XCTAssertEqualObjects(self.component.view.backgroundColor, [UIColor greenColor]);
+}
+
 - (void)testContainerViewSizeForNonReusedRootComponentsAreSameAsCollectionViewSize
 {
     __weak __typeof(self) weakSelf = self;


### PR DESCRIPTION
Make HubContainerView set background color only for the collection view it contains instead of overriding background color of all the subviews.