### PR TITLE
Ignore warnings for Xcode 8.2

### DIFF
--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -57,7 +57,8 @@ GCC_PREPROCESSOR_DEFINITIONS = $SPOTIFY_OS_CONFIG_PREPROCESSOR_DEFINITIONS
 // Warnings, by Xcode version, we want to ignore.
 HF_IGNORED_WARNINGS_0730 = -Wno-double-promotion -Wno-partial-availability
 HF_IGNORED_WARNINGS_0800 = $(HF_IGNORED_WARNINGS_0730)
-HF_IGNORED_WARNINGS_0810 = $(HF_IGNORED_WARNINGS_0730)
+HF_IGNORED_WARNINGS_0810 = $(HF_IGNORED_WARNINGS_0800)
+HF_IGNORED_WARNINGS_0820 = $(HF_IGNORED_WARNINGS_0810)
 
 WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Werror $(HF_IGNORED_WARNINGS_$(XCODE_VERSION_MINOR))
 


### PR DESCRIPTION
Since the beta is out it’d be nice to make the framework work with it 😋

Like the recently merged PR but also for Xcode 8.2.

@spotify/objc-dev 