### PR TITLE
View model loader: Support appending paginated content

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		8AA97C141C60BD6D0078F19D /* HUBFeatureRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA97C131C60BD6D0078F19D /* HUBFeatureRegistration.m */; };
 		8AA97C161C60C5320078F19D /* HUBFeatureRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA97C151C60C5320078F19D /* HUBFeatureRegistryTests.m */; };
 		8AA97C1A1C60C5F60078F19D /* HUBContentOperationFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA97C181C60C5CD0078F19D /* HUBContentOperationFactoryMock.m */; };
+		8AA9894B1DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA9894A1DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.m */; };
 		8ACA8C871D1818920015310F /* HUBComponentModelBuilderShowcaseSnapshotGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA8C861D1818920015310F /* HUBComponentModelBuilderShowcaseSnapshotGenerator.m */; };
 		8ACB2A7A1C6A2F7C000741D7 /* HUBIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ACB2A791C6A2F7C000741D7 /* HUBIdentifier.m */; };
 		8ACB2A7C1C6A2F99000741D7 /* HUBIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ACB2A7B1C6A2F99000741D7 /* HUBIdentifierTests.m */; };
@@ -158,6 +159,7 @@
 		8A0568F31CBFB073007C296A /* HUBComponentCategories.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentCategories.h; sourceTree = "<group>"; };
 		8A07549E1C21A79200AFAD38 /* libHubFramework.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHubFramework.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A0754AC1C21A7C700AFAD38 /* HUBComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponent.h; sourceTree = "<group>"; };
+		8A07A51F1DC8C48500CDBE9C /* HUBContentOperationWithPaginatedContent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBContentOperationWithPaginatedContent.h; sourceTree = "<group>"; };
 		8A0C356C1D7DB656007C32D9 /* HUBActionFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBActionFactory.h; sourceTree = "<group>"; };
 		8A0E4B761CB561DE0019DE71 /* HUBViewURIPredicate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewURIPredicate.h; sourceTree = "<group>"; };
 		8A0E4B791CB562140019DE71 /* HUBViewURIPredicate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewURIPredicate.m; sourceTree = "<group>"; };
@@ -309,6 +311,8 @@
 		8AA97C171C60C5CD0078F19D /* HUBContentOperationFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBContentOperationFactoryMock.h; sourceTree = "<group>"; };
 		8AA97C181C60C5CD0078F19D /* HUBContentOperationFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBContentOperationFactoryMock.m; sourceTree = "<group>"; };
 		8AA97C1F1C60D8270078F19D /* HUBComponentImageDataJSONSchema.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentImageDataJSONSchema.h; sourceTree = "<group>"; };
+		8AA989491DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBContentOperationExecutionInfo.h; sourceTree = "<group>"; };
+		8AA9894A1DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBContentOperationExecutionInfo.m; sourceTree = "<group>"; };
 		8ACA8C7F1D1805420015310F /* HUBComponentFactoryShowcaseNameProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactoryShowcaseNameProvider.h; sourceTree = "<group>"; };
 		8ACA8C801D180EC80015310F /* HUBComponentShowcaseManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentShowcaseManager.h; sourceTree = "<group>"; };
 		8ACA8C841D1816C90015310F /* HUBComponentShowcaseShapshotGenerator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentShowcaseShapshotGenerator.h; sourceTree = "<group>"; };
@@ -790,6 +794,7 @@
 				8A40B12F1CAAAF8F00EBDDE2 /* HUBContentOperationFactory.h */,
 				8A40B12D1CAAA71500EBDDE2 /* HUBContentOperation.h */,
 				8AF82D831D12EEFA00D1B933 /* HUBContentOperationWithInitialContent.h */,
+				8A07A51F1DC8C48500CDBE9C /* HUBContentOperationWithPaginatedContent.h */,
 				8A6525371D815F4C007B1A15 /* HUBContentOperationActionObserver.h */,
 				8AD585B91DB4F49600DB7606 /* HUBContentOperationActionPerformer.h */,
 				8A5D7A471CB7D2DB00B987BA /* HUBContentReloadPolicy.h */,
@@ -846,6 +851,8 @@
 				52977AC91DA7D0B40064629E /* HUBBlockContentOperationFactory.m */,
 				8A7B48EA1CD77C8200130C25 /* HUBContentOperationWrapper.h */,
 				8A7B48EB1CD77C8200130C25 /* HUBContentOperationWrapper.m */,
+				8AA989491DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.h */,
+				8AA9894A1DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.m */,
 			);
 			name = Content;
 			sourceTree = "<group>";
@@ -1196,6 +1203,7 @@
 				8AA97C141C60BD6D0078F19D /* HUBFeatureRegistration.m in Sources */,
 				8AF9FA071C5254F5003F3D6C /* HUBViewModelImplementation.m in Sources */,
 				8AD00A091CC77C950012A9AF /* HUBIconImplementation.m in Sources */,
+				8AA9894B1DD1E3C1006CA6AA /* HUBContentOperationExecutionInfo.m in Sources */,
 				8A786BAB1C5A326300B2AB9E /* HUBJSONSchemaImplementation.m in Sources */,
 				8A2A72EB1D4B726800141619 /* HUBComponentTargetJSONSchemaImplementation.m in Sources */,
 				8AD064561C64B6DB0086C081 /* HUBComponentModelJSONSchemaImplementation.m in Sources */,

--- a/include/HubFramework/HUBContentOperationWithPaginatedContent.h
+++ b/include/HubFramework/HUBContentOperationWithPaginatedContent.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBContentOperation.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/include/HubFramework/HUBContentOperationWithPaginatedContent.h
+++ b/include/HubFramework/HUBContentOperationWithPaginatedContent.h
@@ -1,0 +1,44 @@
+#import "HUBContentOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  Extended content operation protocol that adds the ability to append paginated content to a view
+ *
+ *  Use this protocol in case you want to handle large datasets in your feature, which are not practical
+ *  to load up front. Content operations conforming to this protocol will be called and asked to append
+ *  content to an existing view model builder in either of 3 scenarios:
+ *
+ *  - If the `loadNextPageForCurrentViewModel` method was called on a `HUBViewModelLoader`.
+ *  - If the initially displayed content is not enough to cover the height of the view controller.
+ *  - If the user is about to reach the bottom of the view's content when scrolling.
+ */
+@protocol HUBContentOperationWithPaginatedContent <HUBContentOperation>
+
+/**
+ *  Append content for a certain page index to an existing view model builder
+ *
+ *  @param pageIndex The index of the page to add content for. Since the main content set is considered
+ *         index number 0, this will always be at least 1 or greater. Incremented on each paginated content
+ *         loading chain.
+ *  @param viewModelBuilder The builder to use to append content to the view. If this content operation is
+ *         first in the appended content loading chain, this builder will be a snapshot of the last rendered
+ *         view state. If it's subsequent in the chain, it will instead be a snapshot of the previous operation's
+ *         finished state.
+ *  @param viewURI The URI of the view that content should be appended for
+ *  @param featureInfo Info about the feature that the operation is being performed for
+ *  @param connectivityState The current connectivity state of the application (as it was when the content loading
+ *         chain that this operation is part of was started).
+ *  @param previousError Any previous error that was encountered during the content loading chain that this operation
+ *         is a part of.
+ */
+- (void)appendContentForPageIndex:(NSUInteger)pageIndex
+               toViewModelBuilder:(id<HUBViewModelBuilder>)viewModelBuilder
+                          viewURI:(NSURL *)viewURI
+                      featureInfo:(id<HUBFeatureInfo>)featureInfo
+                connectivityState:(HUBConnectivityState)connectivityState
+                    previousError:(nullable NSError *)previousError;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBViewModelLoader.h
+++ b/include/HubFramework/HUBViewModelLoader.h
@@ -94,6 +94,25 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)loadViewModel;
 
+/**
+ *  Load the next set of paginated content for the current view model this loader is for
+ *
+ *  Use this method to extend the current view model with additional paginated content. The view model loader
+ *  automatically manages the current state of the view and the page index for you, so all you have to do is to
+ *  call this method whenever additional content should be loaded.
+ *
+ *  Content loaded this way will be appended to the current view model, so if it already contains 2 component
+ *  models (A & B), and a new one (C) is added through this mechanism - the resulting view model will now contain
+ *  A, B & C.
+ *
+ *  Calling this method invokes content operations conforming to `HUBContentOperationWithPaginatedContent`.
+ *
+ *  The same delegate methods are called for success/error when the view model loader finishes this task.
+ *
+ *  Calling this method before first loading a view model using `loadViewModel` does nothing.
+ */
+- (void)loadNextPageForCurrentViewModel;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBContentOperationExecutionInfo.h
+++ b/sources/HUBContentOperationExecutionInfo.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBHeaderMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sources/HUBContentOperationExecutionInfo.h
+++ b/sources/HUBContentOperationExecutionInfo.h
@@ -1,0 +1,38 @@
+#import "HUBHeaderMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Enum describing various mode in which a content operation may be executed
+typedef enum : NSUInteger {
+    /// The content operation is executed as part of the main content loading chain
+    HUBContentOperationExecutionModeMain,
+    /// The content operation is executed when loading additional paginated content
+    HUBContentOperationExecutionModePagination
+} HUBContentOperationExecutionMode;
+
+/**
+ *  Info class used to describe how to execute a certain content operation
+ *
+ *  This class is used by `HUBViewModelLoaderImplementation` to determine in which mode,
+ *  and for which index, to execute a content operation as part of its internal queue.
+ */
+@interface HUBContentOperationExecutionInfo : NSObject
+
+/// The index of the content operation this info object is for
+@property (nonatomic, assign, readonly) NSUInteger contentOperationIndex;
+
+/// The execution mode to use when performing the content operation with this info object
+@property (nonatomic, assign, readonly) HUBContentOperationExecutionMode executionMode;
+
+/**
+ *  Initialize an instance of this class
+ *
+ *  @param contentOperationIndex The index of the content operation that this object is for
+ *  @param executionMode The mode to execute the content operation in
+ */
+- (instancetype)initWithContentOperationIndex:(NSUInteger)contentOperationIndex
+                                executionMode:(HUBContentOperationExecutionMode)executionMode HUB_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBContentOperationExecutionInfo.m
+++ b/sources/HUBContentOperationExecutionInfo.m
@@ -1,0 +1,22 @@
+#import "HUBContentOperationExecutionInfo.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation HUBContentOperationExecutionInfo
+
+- (instancetype)initWithContentOperationIndex:(NSUInteger)contentOperationIndex
+                                executionMode:(HUBContentOperationExecutionMode)executionMode
+{
+    self = [super init];
+    
+    if (self) {
+        _contentOperationIndex = contentOperationIndex;
+        _executionMode = executionMode;
+    }
+    
+    return self;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBContentOperationExecutionInfo.m
+++ b/sources/HUBContentOperationExecutionInfo.m
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBContentOperationExecutionInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/sources/HUBContentOperationWrapper.h
+++ b/sources/HUBContentOperationWrapper.h
@@ -82,6 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param featureInfo An object containing information about the feature that the operation is used in
  *  @param connectivityState The current connectivity state, as resolved by `HUBConnectivityStateResolver`
  *  @param viewModelBuilder The builder that should be used to add, change or remove content to/from the view
+ *  @param pageIndex The index of the page of content to load. If non-nil, the pagination API will be used
  *  @param previousError Any error encountered by a previous content operation, that the wrapper's operation
  *         may attempt to recover.
  */
@@ -89,6 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
                        featureInfo:(id<HUBFeatureInfo>)featureInfo
                  connectivityState:(HUBConnectivityState)connectivityState
                   viewModelBuilder:(id<HUBViewModelBuilder>)viewModelBuilder
+                         pageIndex:(nullable NSNumber *)pageIndex
                      previousError:(nullable NSError *)previousError;
 
 @end

--- a/sources/HUBContentOperationWrapper.m
+++ b/sources/HUBContentOperationWrapper.m
@@ -20,8 +20,7 @@
  */
 
 #import "HUBContentOperationWrapper.h"
-
-#import "HUBContentOperation.h"
+#import "HUBContentOperationWithPaginatedContent.h"
 
 @interface HUBContentOperationWrapper () <HUBContentOperationDelegate>
 
@@ -53,9 +52,27 @@
                        featureInfo:(id<HUBFeatureInfo>)featureInfo
                  connectivityState:(HUBConnectivityState)connectivityState
                   viewModelBuilder:(id<HUBViewModelBuilder>)viewModelBuilder
+                         pageIndex:(nullable NSNumber *)pageIndex
                      previousError:(nullable NSError *)previousError
 {
     self.isExecuting = YES;
+    
+    if (pageIndex != nil) {
+        if ([self.contentOperation conformsToProtocol:@protocol(HUBContentOperationWithPaginatedContent)]) {
+            id<HUBContentOperationWithPaginatedContent> const paginatedOperation = (id<HUBContentOperationWithPaginatedContent>)self.contentOperation;
+            
+            [paginatedOperation appendContentForPageIndex:pageIndex.unsignedIntegerValue
+                                       toViewModelBuilder:viewModelBuilder
+                                                  viewURI:viewURI
+                                              featureInfo:featureInfo
+                                        connectivityState:connectivityState
+                                            previousError:previousError];
+        } else {
+            [self finishWithError:previousError];
+        }
+        
+        return;
+    }
     
     [self.contentOperation performForViewURI:viewURI
                                  featureInfo:featureInfo

--- a/tests/mocks/HUBContentOperationMock.h
+++ b/tests/mocks/HUBContentOperationMock.h
@@ -20,6 +20,7 @@
  */
 
 #import "HUBContentOperationWithInitialContent.h"
+#import "HUBContentOperationWithPaginatedContent.h"
 #import "HUBContentOperationActionObserver.h"
 #import "HUBContentOperationActionPerformer.h"
 
@@ -28,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Mocked content operation, for use in tests only
 @interface HUBContentOperationMock : NSObject <
     HUBContentOperationWithInitialContent,
+    HUBContentOperationWithPaginatedContent,
     HUBContentOperationActionObserver,
     HUBContentOperationActionPerformer
 >
@@ -38,7 +40,18 @@ NS_ASSUME_NONNULL_BEGIN
 /// A block that gets called whenever the content operation is performed. Return whether the operation should call its delegate.
 @property (nonatomic, copy, nullable) BOOL(^contentLoadingBlock)(id<HUBViewModelBuilder> builder);
 
-/// The number of times this operation has been performed
+/**
+ *  A block that gets called whenever the content operation is asked to load paginated content
+ *
+ *  If nil, the content operation will act like it's not conforming to the `HUBContentOperationWithPaginatedContent` protocol.
+ *  Setting this to non-nil will enable the paginated content API on this mock.
+ *
+ *  Any block assigned to this property takes the current view model builder, as well as the current page index, and should return
+ *  whether the operation should call its delegate
+ */
+@property (nonatomic, copy, nullable) BOOL(^paginatedContentLoadingBlock)(id<HUBViewModelBuilder> builder, NSUInteger pageIndex);
+
+/// The number of times this operation has been performed (not including appending paginated content)
 @property (nonatomic, assign, readonly) NSUInteger performCount;
 
 /// The feature info that was most recently sent to this operation


### PR DESCRIPTION
This change introduces an API for appending paginated content to a view model. By making a content operation conform to `HUBContentOperationWithPaginatedContent`, new content can now be added to an existing view model builder.

To support the declarative nature of the Hub Framework, content operations are always guaranteed to execute from a “clean state”. `HUBViewModelLoader` keeps snapshots of previous view model builders & errors, to be able to make this guarantee.

However, with pagination, we don’t want to execute from a clean state. Instead, we want to append content to the **current** state, which imposes some interesting challenges on the content loading code.

To accommodate these 2 different uses cases, a new `HUBContentOperationExecutionInfo` is introduced. Instead of enqueueing operations directly, instances of this class is now used to keep track of a view model loader’s operation queue. This enables us to reference the same content operation using different modes, and to use different snapshots depending on what mode an operation is being executed in.

Went all in with the tests this time, to make sure that A) this doesn’t break any existing content loading code, and B) that all the edge cases around managing both replacing and appended state changes at the same time.

Note that the documentation for `HUBContentOperationWithPaginatedContent` is lying a bit at the moment, since the view controller hasn't been wired up to using this yet - but wanted to save that for a subsequent PR.

Provides the model layer side of https://github.com/spotify/HubFramework/issues/28