### PR TITLE
View controller: Recognize pan gestures on a view level

### DIFF
--- a/sources/HUBContainerView.h
+++ b/sources/HUBContainerView.h
@@ -29,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Collection view contained by the container.
  *
- *  @discussion When collectionView is set it's also added as a subview.
+ *  When a collectionView is set it's also added as a subview, and its pan gesture
+ *  recognizer is added to this view.
  */
 @property (nonatomic, strong, nullable) UICollectionView *collectionView;
 

--- a/sources/HUBContainerView.m
+++ b/sources/HUBContainerView.m
@@ -34,9 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
     [_collectionView removeFromSuperview];
     _collectionView = nil;
 
-    if (collectionView) {
-        _collectionView = collectionView;
-        [self insertSubview:(UICollectionView *)collectionView atIndex:0];
+    if (collectionView != nil) {
+        UICollectionView * const nonNilCollectionView = collectionView;
+        _collectionView = nonNilCollectionView;
+        [self insertSubview:nonNilCollectionView atIndex:0];
+        [self addGestureRecognizer:nonNilCollectionView.panGestureRecognizer];
     }
 }
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -258,8 +258,14 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    [self.collectionView removeFromSuperview];
-    self.collectionView = nil;
+    if (self.collectionView != nil) {
+        UICollectionView * const collectionView = self.collectionView;
+        [collectionView removeFromSuperview];
+        [self.view removeGestureRecognizer:collectionView.panGestureRecognizer];
+        
+        self.collectionView = nil;
+    }
+    
     self.viewModel = nil;
 }
 
@@ -864,6 +870,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     collectionView.dataSource = self;
     collectionView.delegate = self;
     
+    [self.view addGestureRecognizer:collectionView.panGestureRecognizer];
     [self.view insertSubview:collectionView atIndex:0];
 }
 


### PR DESCRIPTION
This change moves the gesture recognizer used for pan (scroll) events in the collection view to the view level. This is done in order to support scrolling on a header or overlay component, without having to resort to manual -pointInside checks.