### PR TITLE
Pagination: Integrate with view controller

### DIFF
--- a/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
+++ b/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6510FD791DD1D182002FA2DC /* PrettyPicturesActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6510FD781DD1D182002FA2DC /* PrettyPicturesActionHandler.swift */; };
-		657DFE1B1DC8E21700F20C0E /* HubFrameworkDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657DFE191DC8E21700F20C0E /* HubFrameworkDemoUITests.swift */; };
+		657DFE1B1DC8E21700F20C0E /* SelectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657DFE191DC8E21700F20C0E /* SelectionUITests.swift */; };
 		657DFE1C1DC8E21700F20C0E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 657DFE1A1DC8E21700F20C0E /* Info.plist */; };
 		8A27299A1D9546BB00EF43FC /* RootContentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2729991D9546BB00EF43FC /* RootContentOperationFactory.swift */; };
 		8A27299E1D9546ED00EF43FC /* RootContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A27299D1D9546ED00EF43FC /* RootContentOperation.swift */; };
@@ -23,6 +23,7 @@
 		8A42E1F71D8C468C004FAC33 /* ComponentLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E1F61D8C468C004FAC33 /* ComponentLayoutManager.swift */; };
 		8A42E1F91D8C476C004FAC33 /* ComponentFallbackHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E1F81D8C476C004FAC33 /* ComponentFallbackHandler.swift */; };
 		8A42E1FB1D8C4CEB004FAC33 /* RowComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A42E1FA1D8C4CEB004FAC33 /* RowComponent.swift */; };
+		8AA98C451DD3778B006CA6AA /* PaginationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA98C441DD3778B006CA6AA /* PaginationUITests.swift */; };
 		8AB850961DBF9DE300AFAFD0 /* CarouselComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB850951DBF9DE300AFAFD0 /* CarouselComponent.swift */; };
 		8ABCCEAA1D9D1AC3005113B5 /* ReallyLongListContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCCEA91D9D1AC3005113B5 /* ReallyLongListContentOperation.swift */; };
 		8ABCCEAC1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABCCEAB1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift */; };
@@ -78,7 +79,7 @@
 /* Begin PBXFileReference section */
 		6510FD781DD1D182002FA2DC /* PrettyPicturesActionHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrettyPicturesActionHandler.swift; sourceTree = "<group>"; };
 		657DFE0F1DC8E1B600F20C0E /* HubFrameworkDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HubFrameworkDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		657DFE191DC8E21700F20C0E /* HubFrameworkDemoUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HubFrameworkDemoUITests.swift; path = tests/HubFrameworkDemoUITests.swift; sourceTree = SOURCE_ROOT; };
+		657DFE191DC8E21700F20C0E /* SelectionUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SelectionUITests.swift; path = tests/SelectionUITests.swift; sourceTree = SOURCE_ROOT; };
 		657DFE1A1DC8E21700F20C0E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = tests/Info.plist; sourceTree = SOURCE_ROOT; };
 		8A2729991D9546BB00EF43FC /* RootContentOperationFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootContentOperationFactory.swift; sourceTree = "<group>"; };
 		8A27299D1D9546ED00EF43FC /* RootContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootContentOperation.swift; sourceTree = "<group>"; };
@@ -95,6 +96,7 @@
 		8A42E1F61D8C468C004FAC33 /* ComponentLayoutManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentLayoutManager.swift; sourceTree = "<group>"; };
 		8A42E1F81D8C476C004FAC33 /* ComponentFallbackHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComponentFallbackHandler.swift; sourceTree = "<group>"; };
 		8A42E1FA1D8C4CEB004FAC33 /* RowComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowComponent.swift; sourceTree = "<group>"; };
+		8AA98C441DD3778B006CA6AA /* PaginationUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PaginationUITests.swift; path = tests/PaginationUITests.swift; sourceTree = SOURCE_ROOT; };
 		8AB850951DBF9DE300AFAFD0 /* CarouselComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarouselComponent.swift; sourceTree = "<group>"; };
 		8ABCCEA91D9D1AC3005113B5 /* ReallyLongListContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReallyLongListContentOperation.swift; sourceTree = "<group>"; };
 		8ABCCEAB1D9D1AE4005113B5 /* ReallyLongListContentOperationFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReallyLongListContentOperationFactory.swift; sourceTree = "<group>"; };
@@ -139,7 +141,8 @@
 		657DFE101DC8E1B600F20C0E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				657DFE191DC8E21700F20C0E /* HubFrameworkDemoUITests.swift */,
+				657DFE191DC8E21700F20C0E /* SelectionUITests.swift */,
+				8AA98C441DD3778B006CA6AA /* PaginationUITests.swift */,
 				657DFE1A1DC8E21700F20C0E /* Info.plist */,
 			);
 			name = Tests;
@@ -432,7 +435,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				657DFE1B1DC8E21700F20C0E /* HubFrameworkDemoUITests.swift in Sources */,
+				657DFE1B1DC8E21700F20C0E /* SelectionUITests.swift in Sources */,
+				8AA98C451DD3778B006CA6AA /* PaginationUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/demo/tests/PaginationUITests.swift
+++ b/demo/tests/PaginationUITests.swift
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import XCTest
+
+class PaginationUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        
+        continueAfterFailure = false
+        XCUIApplication().launch()
+        
+        XCUIDevice.shared().orientation = .portrait
+    }
+    
+    func testScrollingToBottomOfViewLoadsPaginatedContent() {
+        XCUIApplication().collectionViews.staticTexts["Really long list"].tap()
+        
+        let collectionView = XCUIApplication().collectionViews.element(boundBy: 0)
+        var numberOfSwipes = 0
+        
+        // Load 100 rows (page size = 50), which should be done in under 20 swipes
+        while !collectionView.staticTexts["Row number 100"].exists {
+            collectionView.swipeUp()
+            numberOfSwipes += 1
+            
+            if numberOfSwipes > 20 {
+                XCTFail("Should not have taken over 20 swipes to load paginated content")
+                break
+            }
+        }
+        
+        // Test succeeded
+    }
+}

--- a/demo/tests/SelectionUITests.swift
+++ b/demo/tests/SelectionUITests.swift
@@ -21,8 +21,7 @@
 
 import XCTest
 
-class HubFrameworkDemoUITests: XCTestCase {
-
+class SelectionUITests: XCTestCase {
     override func setUp() {
         super.setUp()
         

--- a/include/HubFramework/HUBContentOperationWithPaginatedContent.h
+++ b/include/HubFramework/HUBContentOperationWithPaginatedContent.h
@@ -31,7 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  content to an existing view model builder in either of 3 scenarios:
  *
  *  - If the `loadNextPageForCurrentViewModel` method was called on a `HUBViewModelLoader`.
- *  - If the initially displayed content is not enough to cover the height of the view controller.
  *  - If the user is about to reach the bottom of the view's content when scrolling.
  */
 @protocol HUBContentOperationWithPaginatedContent <HUBContentOperation>

--- a/include/HubFramework/HUBContentOperationWithPaginatedContent.h
+++ b/include/HubFramework/HUBContentOperationWithPaginatedContent.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
                           viewURI:(NSURL *)viewURI
                       featureInfo:(id<HUBFeatureInfo>)featureInfo
                 connectivityState:(HUBConnectivityState)connectivityState
-                    previousError:(nullable NSError *)previousError;
+                    previousError:(nullable NSError *)previousError NS_SWIFT_NAME(appendContent(pageIndex:viewModelBuilder:viewURI:featureInfo:connectivityState:previousError:));
 
 @end
 

--- a/include/HubFramework/HUBViewModelLoader.h
+++ b/include/HubFramework/HUBViewModelLoader.h
@@ -83,6 +83,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) id<HUBViewModel> initialViewModel;
 
 /**
+ *  Whether the view model loader is currently loading
+ *
+ *  True whenever one or more content operations are currently in the process of loading content, either as part
+ *  of the main content loading chain, or as part of appending paginated content.
+ */
+@property (nonatomic, assign, readonly) BOOL isLoading;
+
+/**
  *  Load a view model using this loader
  *
  *  Depending on the current connectivity state (determined by the current `HUBConnectivityStateResolver`),

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -42,6 +42,7 @@
 #import "HUBContentOperationFactory.h"
 #import "HUBContentOperation.h"
 #import "HUBContentOperationWithInitialContent.h"
+#import "HUBContentOperationWithPaginatedContent.h"
 #import "HUBContentOperationActionObserver.h"
 #import "HUBContentOperationActionPerformer.h"
 #import "HUBContentReloadPolicy.h"

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -787,6 +787,12 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                                                                     contentInset:scrollView.contentInset
                                                                             currentContentOffset:scrollView.contentOffset
                                                                            proposedContentOffset:*targetContentOffset];
+    
+    if (targetContentOffset->y >= (scrollView.contentSize.height - CGRectGetHeight(scrollView.frame))) {
+        if (!self.viewModelLoader.isLoading) {
+            [self.viewModelLoader loadNextPageForCurrentViewModel];
+        }
+    }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView

--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -167,6 +167,11 @@ NS_ASSUME_NONNULL_BEGIN
     return initialViewModel;
 }
 
+- (BOOL)isLoading
+{
+    return self.contentOperationQueue.count > 0;
+}
+
 - (void)loadViewModel
 {
     if (self.contentReloadPolicy != nil) {

--- a/tests/HUBViewModelLoaderTests.m
+++ b/tests/HUBViewModelLoaderTests.m
@@ -922,6 +922,39 @@
     XCTAssertEqualObjects(componentModels[1].identifier, @"B-1");
 }
 
+- (void)testIsLoading
+{
+    HUBContentOperationMock * const contentOperation = [HUBContentOperationMock new];
+    
+    contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> builder) {
+        return NO;
+    };
+    
+    contentOperation.paginatedContentLoadingBlock = ^(id<HUBViewModelBuilder> builder, NSUInteger pageIndex) {
+        return NO;
+    };
+    
+    [self createLoaderWithContentOperations:@[contentOperation]
+                          connectivityState:HUBConnectivityStateOnline
+                           initialViewModel:nil];
+    
+    XCTAssertFalse(self.loader.isLoading);
+    
+    [self.loader loadViewModel];
+    XCTAssertTrue(self.loader.isLoading);
+    
+    id<HUBContentOperationDelegate> const contentOperationDelegate = contentOperation.delegate;
+    
+    [contentOperationDelegate contentOperationDidFinish:contentOperation];
+    XCTAssertFalse(self.loader.isLoading);
+    
+    [self.loader loadNextPageForCurrentViewModel];
+    XCTAssertTrue(self.loader.isLoading);
+    
+    [contentOperationDelegate contentOperationDidFinish:contentOperation];
+    XCTAssertFalse(self.loader.isLoading);
+}
+
 #pragma mark - HUBViewModelLoaderDelegate
 
 - (void)viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader didLoadViewModel:(id<HUBViewModel>)viewModel

--- a/tests/mocks/HUBComponentFactoryMock.h
+++ b/tests/mocks/HUBComponentFactoryMock.h
@@ -37,7 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSDictionary<NSString *, NSString *> *showcaseNamesForComponentNames;
 
 /// Initialize an instance of this class with a name:component dictionary of components to create
-- (instancetype)initWithComponents:(NSDictionary<NSString *, id<HUBComponent>> *)components HUB_DESIGNATED_INITIALIZER;
+- (instancetype)initWithComponents:(NSDictionary<NSString *, id<HUBComponent>> *)components;
+
+/// Initialize an instance of this class with a block that creates components
+- (instancetype)initWithBlock:(id<HUBComponent> _Nullable(^)(NSString *))block HUB_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/tests/mocks/HUBComponentFactoryMock.m
+++ b/tests/mocks/HUBComponentFactoryMock.m
@@ -23,14 +23,32 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface HUBComponentFactoryMock ()
+
+@property (nonatomic, copy) id<HUBComponent> _Nullable(^componentCreationBlock)(NSString *);
+
+@end
+
 @implementation HUBComponentFactoryMock
 
 - (instancetype)initWithComponents:(NSDictionary<NSString *, id<HUBComponent>> *)components
 {
+    self = [self initWithBlock:^id<HUBComponent> _Nullable(NSString *name) { return nil; }];
+    
+    if (self != nil) {
+        [self.components addEntriesFromDictionary:components];
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithBlock:(id<HUBComponent> _Nullable(^)(NSString *))block
+{
     self = [super init];
     
     if (self) {
-        _components = [components mutableCopy];
+        _componentCreationBlock = [block copy];
+        _components = [NSMutableDictionary new];
     }
     
     return self;
@@ -40,6 +58,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable id<HUBComponent>)createComponentForName:(NSString *)name
 {
+    id<HUBComponent> const component = self.componentCreationBlock(name);
+    
+    if (component != nil) {
+        return component;
+    }
+    
     return self.components[name];
 }
 


### PR DESCRIPTION
This pull request integrates the pagination mechanism introduced in https://github.com/spotify/HubFramework/pull/132 into `HUBViewController`. Whenever the user is about to scroll to the bottom of a view, the next page of content is automatically loaded.

The "Really Long List" feature in the demo app has also been rewritten to support this new pagination feature, instead of having to perform work on a background thread.

Implements the view controller part of https://github.com/spotify/HubFramework/issues/28. Will not close the issue until the content programming guide has been updated :)