### PR TITLE
Add accessibility identifier to the collection view

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		8AFF0F321C846DA700D5535B /* HUBComponentWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F311C846DA700D5535B /* HUBComponentWrapper.m */; };
 		8AFF0F9A1C85C73300D5535B /* HUBCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */; };
 		8AFF10071C87105C00D5535B /* HUBComponentFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */; };
+		B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */; };
 		DDBCF36C1C68DD2300693038 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36B1C68DD2300693038 /* UIKit.framework */; };
 		DDBCF36E1C68DE2C00693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
 		DDBCF36F1C68DE4900693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
@@ -403,6 +404,7 @@
 		8AFF0F9B1C85C89100D5535B /* HUBComponentLayoutManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentLayoutManager.h; sourceTree = "<group>"; };
 		8AFF10061C87015A00D5535B /* HUBComponentLayoutTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentLayoutTraits.h; sourceTree = "<group>"; };
 		9996E9691C6A42E000231D22 /* HUBComponentFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactory.h; sourceTree = "<group>"; };
+		B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionViewFactoryTests.m; sourceTree = "<group>"; };
 		DD13758E1C68C76000AD3499 /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
 		DD13758F1C68C76000AD3499 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
 		DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBKeyPath.h; sourceTree = "<group>"; };
@@ -670,6 +672,7 @@
 				F6AC23C11DA2863A001B1A6A /* HUBComponentWrapperTests.m */,
 				8A0E4B7B1CB568D50019DE71 /* HUBViewURIPredicateTests.m */,
 				8A1A19A51D8813DB0022438F /* HUBInitialViewModelRegistryTests.m */,
+				B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */,
 			);
 			name = View;
 			sourceTree = "<group>";
@@ -1257,6 +1260,7 @@
 				8AD1517E1D9963120008E182 /* HUBDefaultImageLoaderTests.m in Sources */,
 				8AA29CF81C4FE59100E972B7 /* HUBComponentModelBuilderTests.m in Sources */,
 				8A6BA0561C89A00F0057485D /* HUBComponentLayoutManagerMock.m in Sources */,
+				B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */,
 				8A1513311DB7B5B100DE8C7A /* HUBTouchMock.m in Sources */,
 				8A9ED75F1D4A24C2006B27D8 /* HUBComponentModelTests.m in Sources */,
 				5284988B1DC4FC1300291C0C /* HUBInputStreamMock.m in Sources */,

--- a/sources/HUBCollectionViewFactory.m
+++ b/sources/HUBCollectionViewFactory.m
@@ -27,10 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UICollectionView *)createCollectionView
 {
-    return [[UICollectionView alloc] initWithFrame:CGRectZero
-                              collectionViewLayout:[UICollectionViewLayout new]];
-}
+    UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero
+                                                          collectionViewLayout:[UICollectionViewLayout new]];
+    collectionView.accessibilityIdentifier = @"collectionView";
 
+    return collectionView;
+}
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/HUBCollectionViewFactoryTests.m
+++ b/tests/HUBCollectionViewFactoryTests.m
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "HUBCollectionViewFactory.h"
+
+@interface HUBCollectionViewFactoryTests : XCTestCase
+
+@end
+
+@implementation HUBCollectionViewFactoryTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testThatTheFactoryCreatesNonNilInstances
+{
+    HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
+    UICollectionView *collectionView = [factory createCollectionView];
+
+    XCTAssertNotNil(collectionView);
+}
+
+- (void)testThatTheCollectionViewHasAccessibilityId
+{
+    HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
+    UICollectionView *collectionView = [factory createCollectionView];
+
+    XCTAssertNotNil(collectionView.accessibilityIdentifier);
+}
+
+- (void)testThatTheFactoryCreatesNewCollectionViewInstances
+{
+    HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
+    UICollectionView *collectionView1 = [factory createCollectionView];
+    UICollectionView *collectionView2 = [factory createCollectionView];
+
+    XCTAssertNotEqual(collectionView1, collectionView2);
+}
+
+@end


### PR DESCRIPTION
The collection view factory is used to provide collection view to the`HUBViewControllerImplementation` class. The accessibility identifier could be used for automated UI tests.