### PR TITLE
View controller: Add API to disable scrolling

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		8A48F2FF1C7C94EC00B1467C /* HUBViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A48F2FE1C7C94EC00B1467C /* HUBViewControllerTests.m */; };
 		8A49BAF81C777FB1005F7453 /* HUBComponentImageLoadingContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A49BAF71C777FB0005F7453 /* HUBComponentImageLoadingContext.m */; };
 		8A4C28171DB5120400152429 /* HUBComponentGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4C28161DB5120400152429 /* HUBComponentGestureRecognizer.m */; };
+		8A5035221DD473040008B499 /* HUBCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A5035211DD473030008B499 /* HUBCollectionView.m */; };
 		8A58E0E31C5A77C700F41A5C /* HUBJSONPathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A58E0E21C5A77C700F41A5C /* HUBJSONPathTests.m */; };
 		8A58E1471C5B79A900F41A5C /* HUBMutableJSONPathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A58E1461C5B79A900F41A5C /* HUBMutableJSONPathTests.m */; };
 		8A58E1491C5FA62E00F41A5C /* HUBComponentImageDataBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A58E1481C5FA62E00F41A5C /* HUBComponentImageDataBuilderTests.m */; };
@@ -214,6 +215,8 @@
 		8A4C28161DB5120400152429 /* HUBComponentGestureRecognizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentGestureRecognizer.m; sourceTree = "<group>"; };
 		8A4C28191DB6464B00152429 /* HUBComponentWithSelectionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentWithSelectionState.h; sourceTree = "<group>"; };
 		8A4EB8B01DBA47E90004588C /* HUBAsyncAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBAsyncAction.h; sourceTree = "<group>"; };
+		8A5035201DD473030008B499 /* HUBCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBCollectionView.h; sourceTree = "<group>"; };
+		8A5035211DD473030008B499 /* HUBCollectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionView.m; sourceTree = "<group>"; };
 		8A58E0E21C5A77C700F41A5C /* HUBJSONPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBJSONPathTests.m; sourceTree = "<group>"; };
 		8A58E1461C5B79A900F41A5C /* HUBMutableJSONPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBMutableJSONPathTests.m; sourceTree = "<group>"; };
 		8A58E1481C5FA62E00F41A5C /* HUBComponentImageDataBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentImageDataBuilderTests.m; sourceTree = "<group>"; };
@@ -1067,6 +1070,8 @@
 				8AD0646F1C68EDA20086C081 /* HUBViewControllerFactoryImplementation.m */,
 				8A69DBA81C7DF8C000F5EFC6 /* HUBCollectionViewFactory.h */,
 				8A69DBA91C7DF8C000F5EFC6 /* HUBCollectionViewFactory.m */,
+				8A5035201DD473030008B499 /* HUBCollectionView.h */,
+				8A5035211DD473030008B499 /* HUBCollectionView.m */,
 				8AFF0F981C85C73300D5535B /* HUBCollectionViewLayout.h */,
 				8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */,
 				8A0E4B791CB562140019DE71 /* HUBViewURIPredicate.m */,
@@ -1202,6 +1207,7 @@
 				8A2A72F31D4B75DA00141619 /* HUBActionRegistryImplementation.m in Sources */,
 				8A6529F91D82DC33007B1A15 /* HUBActionHandlerWrapper.m in Sources */,
 				8A786BB21C5A383800B2AB9E /* HUBViewModelJSONSchemaImplementation.m in Sources */,
+				8A5035221DD473040008B499 /* HUBCollectionView.m in Sources */,
 				8AF5B57F1C64B59E001FF228 /* HUBViewModelLoaderImplementation.m in Sources */,
 				8A9ED75D1D4A049C006B27D8 /* HUBComponentReusePool.m in Sources */,
 				8AA97C141C60BD6D0078F19D /* HUBFeatureRegistration.m in Sources */,

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -84,6 +84,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewControllerDidFinishRendering:(UIViewController<HUBViewController> *)viewController;
 
 /**
+ *  Sent to a Hub Framework view controller's delegate to ask it whenever the view controller should start scrolling
+ *
+ *  @param viewController The view controller that is about to start scrolling
+ *
+ *  This method can be used to veto a scroll event from being started. It will be called every time the user starts
+ *  scrolling the view that is rendering body components.
+ */
+- (BOOL)viewControllerShouldStartScrolling:(UIViewController<HUBViewController> *)viewController;
+
+/**
  *  Sent to a Hub Framework view controller's delegate when a component is about to appear on the screen
  *
  *  @param viewController The view controller in which a component is about to appear

--- a/sources/HUBCollectionView.h
+++ b/sources/HUBCollectionView.h
@@ -25,11 +25,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Factory used to create collection views for use in a `HUBViewController`
-@interface HUBCollectionViewFactory : NSObject
+/// Delegate protocol used by `HUBCollectionView`. Extends the system-provided `UICollectionViewDelegate`.
+@protocol HUBCollectionViewDelegate <UICollectionViewDelegate>
 
-/// Create a collection view. It will be setup with a default layout.
-- (HUBCollectionView *)createCollectionView;
+/**
+ *  Return whether the collection view should start scrolling
+ *
+ *  @param collectionView The collection view that is about to start scrolling
+ *
+ *  This method will be called every time the collection view is about to start scrolling, returning `NO`
+ *  will stop the event from happening.
+ */
+- (BOOL)collectionViewShouldBeginScrolling:(HUBCollectionView *)collectionView;
+
+@end
+
+/// Collection view subclass used by the Hub Framework to render body components
+@interface HUBCollectionView : UICollectionView
+
+/// The collection view's delegate. See `HUBCollectionViewDelegate` for more information.
+@property (nonatomic, weak, nullable) id <HUBCollectionViewDelegate> delegate;
 
 @end
 

--- a/sources/HUBCollectionView.m
+++ b/sources/HUBCollectionView.m
@@ -19,17 +19,24 @@
  *  under the License.
  */
 
-#import <UIKit/UIKit.h>
-
-@class HUBCollectionView;
+#import "HUBCollectionView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Factory used to create collection views for use in a `HUBViewController`
-@interface HUBCollectionViewFactory : NSObject
+@implementation HUBCollectionView
 
-/// Create a collection view. It will be setup with a default layout.
-- (HUBCollectionView *)createCollectionView;
+@dynamic delegate;
+
+- (void)setContentOffset:(CGPoint)contentOffset
+{
+    if (![self.delegate collectionViewShouldBeginScrolling:self]) {
+        self.panGestureRecognizer.enabled = NO;
+        self.panGestureRecognizer.enabled = YES;
+        return;
+    }
+    
+    [super setContentOffset:contentOffset];
+}
 
 @end
 

--- a/sources/HUBCollectionView.m
+++ b/sources/HUBCollectionView.m
@@ -29,10 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setContentOffset:(CGPoint)contentOffset
 {
-    if (![self.delegate collectionViewShouldBeginScrolling:self]) {
-        self.panGestureRecognizer.enabled = NO;
-        self.panGestureRecognizer.enabled = YES;
-        return;
+    id<HUBCollectionViewDelegate> const delegate = self.delegate;
+    
+    if (delegate != nil) {
+        if (![delegate collectionViewShouldBeginScrolling:self]) {
+            self.panGestureRecognizer.enabled = NO;
+            self.panGestureRecognizer.enabled = YES;
+            return;
+        }
     }
     
     [super setContentOffset:contentOffset];

--- a/sources/HUBCollectionViewFactory.m
+++ b/sources/HUBCollectionViewFactory.m
@@ -20,15 +20,16 @@
  */
 
 #import "HUBCollectionViewFactory.h"
+#import "HUBCollectionView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBCollectionViewFactory
 
-- (UICollectionView *)createCollectionView
+- (HUBCollectionView *)createCollectionView
 {
-    return [[UICollectionView alloc] initWithFrame:CGRectZero
-                              collectionViewLayout:[UICollectionViewLayout new]];
+    return [[HUBCollectionView alloc] initWithFrame:CGRectZero
+                               collectionViewLayout:[UICollectionViewLayout new]];
 }
 
 @end

--- a/sources/HUBCollectionViewFactory.m
+++ b/sources/HUBCollectionViewFactory.m
@@ -28,10 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (HUBCollectionView *)createCollectionView
 {
-    UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero
-                                                          collectionViewLayout:[UICollectionViewLayout new]];
+    HUBCollectionView *collectionView = [[HUBCollectionView alloc] initWithFrame:CGRectZero
+                                                            collectionViewLayout:[UICollectionViewLayout new]];
+    
     collectionView.accessibilityIdentifier = @"collectionView";
-
     return collectionView;
 }
 @end

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -38,6 +38,7 @@
 #import "HUBImageLoader.h"
 #import "HUBComponentImageLoadingContext.h"
 #import "HUBCollectionViewFactory.h"
+#import "HUBCollectionView.h"
 #import "HUBCollectionViewLayout.h"
 #import "HUBContainerView.h"
 #import "HUBContentReloadPolicy.h"
@@ -64,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
     HUBActionPerformer,
     HUBActionHandlerWrapperDelegate,
     UICollectionViewDataSource,
-    UICollectionViewDelegate
+    HUBCollectionViewDelegate
 >
 
 @property (nonatomic, copy, readonly) NSURL *viewURI;
@@ -735,7 +736,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     return cell;
 }
 
-#pragma mark - UICollectionViewDelegate
+#pragma mark - HUBCollectionViewDelegate
 
 - (void)collectionView:(UICollectionView *)collectionView
        willDisplayCell:(UICollectionViewCell *)cell
@@ -761,6 +762,15 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
              didDisappearFromView:cell];
 
     [self removeComponentWrapperFromLookupTables:componentWrapper];
+}
+
+- (BOOL)collectionViewShouldBeginScrolling:(HUBCollectionView *)collectionView
+{
+    if (self.delegate == nil) {
+        return YES;
+    }
+    
+    return [self.delegate viewControllerShouldStartScrolling:self];
 }
 
 #pragma mark - UIScrollViewDelegate
@@ -869,7 +879,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
         return;
     }
     
-    UICollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
+    HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
     self.collectionView = collectionView;
     collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -766,11 +766,13 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 
 - (BOOL)collectionViewShouldBeginScrolling:(HUBCollectionView *)collectionView
 {
-    if (self.delegate == nil) {
+    id<HUBViewControllerDelegate> const delegate = self.delegate;
+    
+    if (delegate == nil) {
         return YES;
     }
     
-    return [self.delegate viewControllerShouldStartScrolling:self];
+    return [delegate viewControllerShouldStartScrolling:self];
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/tests/HUBCollectionViewFactoryTests.m
+++ b/tests/HUBCollectionViewFactoryTests.m
@@ -20,7 +20,9 @@
  */
 
 #import <XCTest/XCTest.h>
+
 #import "HUBCollectionViewFactory.h"
+#import "HUBCollectionView.h"
 
 @interface HUBCollectionViewFactoryTests : XCTestCase
 
@@ -41,7 +43,7 @@
 - (void)testThatTheFactoryCreatesNonNilInstances
 {
     HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
-    UICollectionView *collectionView = [factory createCollectionView];
+    HUBCollectionView *collectionView = [factory createCollectionView];
 
     XCTAssertNotNil(collectionView);
 }
@@ -49,7 +51,7 @@
 - (void)testThatTheCollectionViewHasAccessibilityId
 {
     HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
-    UICollectionView *collectionView = [factory createCollectionView];
+    HUBCollectionView *collectionView = [factory createCollectionView];
 
     XCTAssertNotNil(collectionView.accessibilityIdentifier);
 }
@@ -57,8 +59,8 @@
 - (void)testThatTheFactoryCreatesNewCollectionViewInstances
 {
     HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
-    UICollectionView *collectionView1 = [factory createCollectionView];
-    UICollectionView *collectionView2 = [factory createCollectionView];
+    HUBCollectionView *collectionView1 = [factory createCollectionView];
+    HUBCollectionView *collectionView2 = [factory createCollectionView];
 
     XCTAssertNotEqual(collectionView1, collectionView2);
 }

--- a/tests/mocks/HUBCollectionViewFactoryMock.h
+++ b/tests/mocks/HUBCollectionViewFactoryMock.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param collectionView A collection view that this factory will always create
  */
-- (instancetype)initWithCollectionView:(UICollectionView *)collectionView HUB_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCollectionView:(HUBCollectionView *)collectionView HUB_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/tests/mocks/HUBCollectionViewFactoryMock.m
+++ b/tests/mocks/HUBCollectionViewFactoryMock.m
@@ -25,13 +25,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBCollectionViewFactoryMock ()
 
-@property (nonatomic, strong, readonly) UICollectionView *collectionView;
+@property (nonatomic, strong, readonly) HUBCollectionView *collectionView;
 
 @end
 
 @implementation HUBCollectionViewFactoryMock
 
-- (instancetype)initWithCollectionView:(UICollectionView *)collectionView
+- (instancetype)initWithCollectionView:(HUBCollectionView *)collectionView
 {
     self = [super init];
     
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (UICollectionView *)createCollectionView
+- (HUBCollectionView *)createCollectionView
 {
     return self.collectionView;
 }

--- a/tests/mocks/HUBCollectionViewMock.h
+++ b/tests/mocks/HUBCollectionViewMock.h
@@ -19,12 +19,12 @@
  *  under the License.
  */
 
-#import <UIKit/UIKit.h>
+#import "HUBCollectionView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Mocked collection view, for use in tests only
-@interface HUBCollectionViewMock : UICollectionView
+@interface HUBCollectionViewMock : HUBCollectionView
 
 /// The cells that the collection view will consider as being part of it
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSIndexPath *, UICollectionViewCell *> *cells;


### PR DESCRIPTION
This change adds a new delegate method for `HUBViewController` that gets called every time the user is about to start scrolling a view. The delegate then has an opportunity to veto wether the scroll event should start.