### PR TITLE
Removes the calls to the scroll handler when scrolling manually

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -1392,15 +1392,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                                                                      contentSize:self.collectionView.contentSize
                                                                                   viewController:self];
 
-    UICollectionView * const nonnullCollectionView = self.collectionView;
-    CGRect const initialContentRect = [self contentRectForScrollView:nonnullCollectionView];
-    [self.scrollHandler scrollingWillStartInViewController:self currentContentRect:initialContentRect];
-
-    __weak HUBViewControllerImplementation *weakSelf = self;
     void (^completionWrapper)() = ^{
-        HUBViewControllerImplementation *strongSelf = weakSelf;
-        CGRect const destinationContentRect = [strongSelf contentRectForScrollView:nonnullCollectionView];
-        [strongSelf.scrollHandler scrollingDidEndInViewController:strongSelf currentContentRect:destinationContentRect];
         completion();
     };
     

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1538,7 +1538,7 @@
     [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
-- (void)testScrollingToRootComponentNotifiesScrollHandler
+- (void)testScrollingToRootComponentDoesNotNotifyScrollHandler
 {
     [self registerAndGenerateComponentsWithNamespace:@"scrollToComponent"
                                        componentSize:CGSizeMake(200.0, 200.0)
@@ -1551,23 +1551,26 @@
 
     self.scrollHandler.targetContentOffset = CGPointMake(0.0, 1400);
 
-    XCTestExpectation * const scrollingWillBeginExpectation = [self expectationWithDescription:@"scroll handler should be notified when scrolling starts"];
+    __block BOOL scrollHandlerNotified = NO;
     self.scrollHandler.scrollingWillStartHandler = ^(CGRect contentRect) {
-        [scrollingWillBeginExpectation fulfill];
+        scrollHandlerNotified = YES;
     };
 
-    XCTestExpectation * const scrollingDidEndExpectation = [self expectationWithDescription:@"scroll handler should be notified when scrolling ends"];
     self.scrollHandler.scrollingDidEndHandler = ^(CGRect contentRect) {
-        [scrollingDidEndExpectation fulfill];
+        scrollHandlerNotified = YES;
     };
-    
+
+    XCTestExpectation * const expectation = [self expectationWithDescription:@"Scrolling should complete and call the handler"];
     NSIndexPath * const indexPath = [NSIndexPath indexPathWithIndex:8];
     [self.viewController scrollToComponentOfType:HUBComponentTypeBody
                                        indexPath:indexPath
                                   scrollPosition:HUBScrollPositionTop
                                         animated:YES
-                                      completion:nil];
-    
+                                      completion:^{
+        XCTAssertFalse(scrollHandlerNotified);
+        [expectation fulfill];
+    }];
+
     [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 


### PR DESCRIPTION
Removes the calls to the scroll handler when scrolling programmatically with the `scrollToComponentOfType:...`-method. This is done to be more in line with the UICollectionView / UIScrollView interfaces, where the scrolling methods don't call the same delegate methods as scrolling by hand.

@spotify/objc-dev, @JohnSundell