### PR TITLE
Update content inset once the view model finishes rendering

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -914,6 +914,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                    animated:animated
                                  completion:^{
         [self headerAndOverlayComponentViewsWillAppear];
+        [self adjustCollectionViewContentInsetWithProposedTopValue:[self defaultTopContentInset]];
         [self.delegate viewControllerDidFinishRendering:self];
     }];
     
@@ -974,21 +975,22 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     return self.componentWrappersByCellIdentifier[cell.identifier];
 }
 
+- (CGFloat)defaultTopContentInset
+{
+    CGFloat const statusBarWidth = CGRectGetWidth([UIApplication sharedApplication].statusBarFrame);
+    CGFloat const statusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame);
+    CGFloat const navigationBarWidth = CGRectGetWidth(self.navigationController.navigationBar.frame);
+    CGFloat const navigationBarHeight = CGRectGetHeight(self.navigationController.navigationBar.frame);
+    return MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
+}
+
 - (void)configureHeaderComponent
 {
     id<HUBComponentModel> const componentModel = self.viewModel.headerComponentModel;
     
     if (componentModel == nil) {
         [self removeHeaderComponent];
-        
-        CGFloat const statusBarWidth = CGRectGetWidth([UIApplication sharedApplication].statusBarFrame);
-        CGFloat const statusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame);
-        CGFloat const navigationBarWidth = CGRectGetWidth(self.navigationController.navigationBar.frame);
-        CGFloat const navigationBarHeight = CGRectGetHeight(self.navigationController.navigationBar.frame);
-        CGFloat const proposedTopInset = MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
-
-        [self adjustCollectionViewContentInsetWithProposedTopValue:proposedTopInset];
-        
+        [self adjustCollectionViewContentInsetWithProposedTopValue:[self defaultTopContentInset]];
         return;
     }
     

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1511,6 +1511,33 @@
     XCTAssertTrue(self.collectionView.appliedScrollViewOffsetAnimatedFlag);
 }
 
+- (void)testRenderingUpdatesContentInsetBeforeAndAfterRendering
+{
+    UIEdgeInsets const firstInsets = UIEdgeInsetsMake(100, 30, 40, 200);
+    UIEdgeInsets const secondInsets = UIEdgeInsetsMake(50, 0, 0, 0);
+
+    __weak HUBViewControllerTests *weakSelf = self;
+    void (^assertInsetsEqualToCollectionViewInsets)(UIEdgeInsets insets) = ^(UIEdgeInsets insets) {
+        HUBViewControllerTests *strongSelf = weakSelf;
+        XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(strongSelf.collectionView.contentInset, insets));
+    };
+    
+    __block NSUInteger numberOfContentInsetCalls = 0;
+    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(UIViewController<HUBViewController> *controller, UIEdgeInsets insets) {
+        numberOfContentInsetCalls += 1;
+        if (numberOfContentInsetCalls == 1) {
+            assertInsetsEqualToCollectionViewInsets(UIEdgeInsetsZero);
+            return firstInsets;
+        } else {
+            assertInsetsEqualToCollectionViewInsets(firstInsets);
+            return secondInsets;
+        }
+    };
+    
+    [self simulateViewControllerLayoutCycle];
+    assertInsetsEqualToCollectionViewInsets(secondInsets);
+}
+
 - (void)testScrollingToRootComponentUsesScrollHandler
 {
     [self registerAndGenerateComponentsWithNamespace:@"scrollToComponent"

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.h
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// A block that is called when the scroll handler is notified that scrolling has ended.
 @property (nonatomic, copy) void (^ _Nullable scrollingDidEndHandler)(CGRect contentRect);
 
+/// A block that can be used instead of the @c contentInset property to determine the content inset.
+@property (nonatomic, copy) UIEdgeInsets (^ _Nullable contentInsetHandler)(UIViewController<HUBViewController> *controller, UIEdgeInsets proposedOffset);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -51,7 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIEdgeInsets)contentInsetsForViewController:(UIViewController<HUBViewController> *)viewController
                          proposedContentInsets:(UIEdgeInsets)proposedContentInsets
 {
-    return self.contentInsets;
+    if (self.contentInsetHandler) {
+        return self.contentInsetHandler(viewController, proposedContentInsets);
+    } else {
+        return self.contentInsets;
+    }
 }
 
 - (void)scrollingWillStartInViewController:(UIViewController<HUBViewController> *)viewController


### PR DESCRIPTION
Adds another check for the content inset once the view model finishes rendering, as the recent move of header configuration introduced an inconcistency for scroll handlers where the content inset was dependant on the size of content (e.g. component frames).

@spotify/objc-dev, @cerihughes, @JohnSundell 