### PR TITLE
Fixes a potential crash in `frameForBodyComponentAtIndex:`

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -387,7 +387,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGRect)frameForBodyComponentAtIndex:(NSUInteger)index
 {
-    if (index >= self.viewModel.bodyComponentModels.count) {
+    if (index >= (NSUInteger)[self.collectionView numberOfItemsInSection:0]) {
         return CGRectZero;
     }
     


### PR DESCRIPTION
Fixes a potential crash in the `frameForBodyComponentAtIndex:`-call as the bounds checking was done with the number of components in the view model rather than the collection view.

@spotify/objc-dev, @JohnSundell, @cerihughes 