### PR TITLE
View controller: Don’t reconfigure header/overlay components serving the same model

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -1065,6 +1065,10 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 - (HUBComponentWrapper *)configureHeaderOrOverlayComponentWrapperWithModel:(id<HUBComponentModel>)componentModel
                                                   previousComponentWrapper:(nullable HUBComponentWrapper *)previousComponentWrapper
 {
+    if ([previousComponentWrapper.model isEqual:componentModel]) {
+        return (HUBComponentWrapper *)previousComponentWrapper;
+    }
+    
     BOOL const shouldReuseCurrentComponent = [previousComponentWrapper.model.componentIdentifier isEqual:componentModel.componentIdentifier];
     HUBComponentWrapper *componentWrapper;
     

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -606,6 +606,28 @@
     XCTAssertEqual(self.component.numberOfReuses, (NSUInteger)2);
 }
 
+- (void)testHeaderComponentNotReconfiguredForSameModel
+{
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        viewModelBuilder.headerComponentModelBuilder.title = @"Header";
+        return YES;
+    };
+    
+    [self simulateViewControllerLayoutCycle];
+    
+    XCTAssertEqualObjects(self.component.model.title, @"Header");
+    
+    self.contentReloadPolicy.shouldReload = YES;
+    
+    [self.viewController viewWillAppear:YES];
+    [self.viewController viewDidLayoutSubviews];
+    [self.viewController viewWillAppear:YES];
+    [self.viewController viewDidLayoutSubviews];
+    
+    XCTAssertEqual(self.contentOperation.performCount, 3u);
+    XCTAssertEqual(self.component.numberOfReuses, 0u);
+}
+
 - (void)testHeaderComponentNotifiedOfViewWillAppear
 {
     self.component.isViewObserver = YES;
@@ -678,6 +700,28 @@
     
     XCTAssertEqual(componentA.numberOfReuses, (NSUInteger)2);
     XCTAssertEqual(componentB.numberOfReuses, (NSUInteger)1);
+}
+
+- (void)testOverlayComponentNotReconfiguredForSameModel
+{
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForOverlayComponentModelWithIdentifier:@"id"].title = @"Overlay";
+        return YES;
+    };
+    
+    [self simulateViewControllerLayoutCycle];
+    
+    XCTAssertEqualObjects(self.component.model.title, @"Overlay");
+    
+    self.contentReloadPolicy.shouldReload = YES;
+    
+    [self.viewController viewWillAppear:YES];
+    [self.viewController viewDidLayoutSubviews];
+    [self.viewController viewWillAppear:YES];
+    [self.viewController viewDidLayoutSubviews];
+    
+    XCTAssertEqual(self.contentOperation.performCount, 3u);
+    XCTAssertEqual(self.component.numberOfReuses, 0u);
 }
 
 - (void)testRemovedOverlayComponentsRemovedFromView


### PR DESCRIPTION
Similar to how we deal with body components (with diffing), there’s no need to reconfigure a header or overlay component if it’s going to serve the exact same model as its currently serving.