### PR TITLE
Notify delegate when overlay and header components appear

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -1160,13 +1160,29 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 
 - (void)headerAndOverlayComponentViewsWillAppear
 {
+    id<HUBViewControllerDelegate> const delegate = self.delegate;
+
     if (self.headerComponentWrapper != nil) {
         HUBComponentWrapper * const headerComponentWrapper = self.headerComponentWrapper;
         [self componentWrapperWillAppear:headerComponentWrapper];
+
+        UIView * const componentView = HUBComponentLoadViewIfNeeded(headerComponentWrapper);
+
+        [delegate viewController:self
+              componentWithModel:headerComponentWrapper.model
+                    layoutTraits:headerComponentWrapper.layoutTraits
+                willAppearInView:componentView];
     }
     
     for (HUBComponentWrapper * const overlayComponentWrapper in self.overlayComponentWrappers) {
         [self componentWrapperWillAppear:overlayComponentWrapper];
+
+        UIView * const componentView = HUBComponentLoadViewIfNeeded(overlayComponentWrapper);
+
+        [delegate viewController:self
+              componentWithModel:overlayComponentWrapper.model
+                    layoutTraits:overlayComponentWrapper.layoutTraits
+                willAppearInView:componentView];
     }
 }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -2553,6 +2553,34 @@
     XCTAssertEqualWithAccuracy(self.collectionView.contentOffset.y, 500, 0.0001);
 }
 
+- (void)testThatDelegateIsNotifiedWhenOverlayAppears
+{
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForOverlayComponentModelWithIdentifier:@"id"].title = @"Overlay";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    XCTAssertEqual(self.componentModelsFromAppearanceDelegateMethod.count, 1u);
+    XCTAssertEqualObjects(self.componentModelsFromAppearanceDelegateMethod[0].title, @"Overlay");
+    XCTAssertEqualObjects(self.componentViewsFromApperanceDelegateMethod, @[self.component.view]);
+}
+
+- (void)testThatDelegateIsNotifiedWhenHeaderAppears
+{
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        viewModelBuilder.headerComponentModelBuilder.title = @"Header";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    XCTAssertEqual(self.componentModelsFromAppearanceDelegateMethod.count, 1u);
+    XCTAssertEqualObjects(self.componentModelsFromAppearanceDelegateMethod[0].title, @"Header");
+    XCTAssertEqualObjects(self.componentViewsFromApperanceDelegateMethod, @[self.component.view]);
+}
+
 #pragma mark - HUBViewControllerDelegate
 
 - (void)viewController:(UIViewController<HUBViewController> *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel


### PR DESCRIPTION
I noticed that the appearance delegate is notified only when body components are displayed. I added the same logic for other types of components like headers and overlays.