### PR TITLE
Fix layout crash when a hub feature is presented while backgrounded

### DIFF
--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -392,7 +392,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:(NSInteger)index inSection:0];
-    return [self.collectionView layoutAttributesForItemAtIndexPath:indexPath].frame;
+    return [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
 }
 
 - (NSUInteger)indexOfBodyComponentAtPoint:(CGPoint)point


### PR DESCRIPTION
Solves that when a hub view controller is presented while an app is in the background, the collectionview layout asserts on app foregrounding.

@Goos @JohnSundell