### PR TITLE
Changes how the completion handler in the scrolling method is called.

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -193,7 +193,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param indexPath The index path of the component to scroll to.
  *  @param scrollPosition The preferred position of the component after scrolling.
  *  @param animated Whether or not the scrolling should be animated.
- *  @param completion A block that is called once the component at the provided index path is visible.
+ *  @param completion A block that is called for each step of the scrolling, providing the index path of the component 
+ *         that became visible.
  *
  *  @seealso HUBComponentWithScrolling
  */
@@ -201,7 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
                       indexPath:(NSIndexPath *)indexPath
                  scrollPosition:(HUBScrollPosition)scrollPosition
                        animated:(BOOL)animated
-                     completion:(void (^ _Nullable)(void))completion;
+                     completion:(void (^ _Nullable)(NSIndexPath *))completion;
 
 /**
  *  Returns the views of the components of the given type that are currently visible on screen, keyed by their index path

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -420,7 +420,7 @@ NS_ASSUME_NONNULL_BEGIN
                       indexPath:(NSIndexPath *)indexPath
                  scrollPosition:(HUBScrollPosition)scrollPosition
                        animated:(BOOL)animated
-                     completion:(void (^ _Nullable)(void))completion
+                     completion:(void (^ _Nullable)(NSIndexPath *))completion
 {
     if (componentType == HUBComponentTypeBody) {
         NSAssert([indexPath indexAtPosition:0] < (NSUInteger)[self.collectionView numberOfItemsInSection:0],
@@ -1442,7 +1442,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                 component:(nullable HUBComponentWrapper *)componentWrapper
                            scrollPosition:(HUBScrollPosition)scrollPosition
                                  animated:(BOOL)animated
-                               completion:(void (^ _Nullable)())completionHandler
+                               completion:(void (^ _Nullable)(NSIndexPath *))completionHandler
 {
     NSUInteger const childIndex = [indexPath indexAtPosition:startPosition];
 
@@ -1471,6 +1471,14 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
             childComponentWrapper = [componentWrapper visibleChildComponentAtIndex:childIndex];
         }
 
+        if (completionHandler != nil) {
+            NSUInteger const currentIndexPathLength = startPosition + 1;
+            NSUInteger currentIndexes[currentIndexPathLength];
+            [indexPath getIndexes:currentIndexes range:NSMakeRange(0, currentIndexPathLength)];
+            NSIndexPath * const currentIndexPath = [NSIndexPath indexPathWithIndexes:currentIndexes length:currentIndexPathLength];
+            completionHandler(currentIndexPath);
+        }
+
         NSUInteger const nextPosition = startPosition + 1;
         if (childComponentWrapper != nil && nextPosition < indexPath.length) {
             [strongSelf scrollToRemainingComponentsOfType:componentType
@@ -1480,8 +1488,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                            scrollPosition:scrollPosition
                                                  animated:animated
                                                completion:completionHandler];
-        } else if (completionHandler != nil) {
-            completionHandler();
         }
     };
 

--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -60,7 +60,7 @@ HF_IGNORED_WARNINGS_0800 = $(HF_IGNORED_WARNINGS_0730)
 HF_IGNORED_WARNINGS_0810 = $(HF_IGNORED_WARNINGS_0800)
 HF_IGNORED_WARNINGS_0820 = $(HF_IGNORED_WARNINGS_0810)
 
-WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Werror $(HF_IGNORED_WARNINGS_$(XCODE_VERSION_MINOR))
+WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Wno-vla -Werror $(HF_IGNORED_WARNINGS_$(XCODE_VERSION_MINOR))
 
 // Apple LLVM 7.0 - Warnings - All languages
 GCC_WARN_CHECK_SWITCH_STATEMENTS = YES

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1773,13 +1773,16 @@
         XCTAssertEqual([indexPath indexAtPosition:1], childIndex);
     };
 
-    __weak XCTestExpectation * const scrollingCompletedExpectation = [self expectationWithDescription:@"Scrolling should complete and call the handler"];
+    __weak XCTestExpectation * const scrollingToFirstExpectation = [self expectationWithDescription:@"Scrolling to the root component should complete and call the handler"];
+    __weak XCTestExpectation * const scrollingCompletedExpectation = [self expectationWithDescription:@"Scrolling to the nested component should complete and call the handler"];
     [self.viewController scrollToComponentOfType:HUBComponentTypeBody
                                        indexPath:indexPath
                                   scrollPosition:HUBScrollPositionTop
                                         animated:YES
                                       completion:^(NSIndexPath *visibleIndexPath) {
-        if ([visibleIndexPath isEqual:indexPath]) {
+        if (visibleIndexPath.length == 1 && [visibleIndexPath indexAtPosition:0] == 6) {
+            [scrollingToFirstExpectation fulfill];
+        } else if ([visibleIndexPath isEqual:indexPath]) {
             [scrollingCompletedExpectation fulfill];
         }
     }];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1670,7 +1670,7 @@
                                        indexPath:indexPath
                                   scrollPosition:HUBScrollPositionTop
                                         animated:YES
-                                      completion:^{
+                                      completion:^(NSIndexPath *visibleIndexPath) {
         [scrollingCompletedExpectation fulfill];
         XCTAssertTrue(CGPointEqualToPoint(self.scrollHandler.targetContentOffset, self.collectionView.contentOffset));
     }];
@@ -1707,7 +1707,7 @@
                                        indexPath:indexPath
                                   scrollPosition:HUBScrollPositionTop
                                         animated:YES
-                                      completion:^{
+                                      completion:^(NSIndexPath *visibleIndexPath) {
         XCTAssertFalse(willStartScrollHandlerNotified);
         XCTAssertFalse(didEndScrollHandlerNotified);
         [expectation fulfill];
@@ -1778,8 +1778,10 @@
                                        indexPath:indexPath
                                   scrollPosition:HUBScrollPositionTop
                                         animated:YES
-                                      completion:^{
-        [scrollingCompletedExpectation fulfill];
+                                      completion:^(NSIndexPath *visibleIndexPath) {
+        if ([visibleIndexPath isEqual:indexPath]) {
+            [scrollingCompletedExpectation fulfill];
+        }
     }];
 
     [self waitForExpectationsWithTimeout:5 handler:nil];


### PR DESCRIPTION
Changes the callback in the `scrollToComponentOfType:indexPath:scrollPosition:animated:completion:` so that it is called when each step of the scrolling is completed, rather than once after all the steps.

@spotify/objc-dev 