### PR TITLE
Use HUBActionHandlerWrapper as HUBActionHandler protocol

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		8A8808A01C21AD0900ADB737 /* HUBComponentRegistryImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A88089F1C21AD0900ADB737 /* HUBComponentRegistryImplementation.m */; };
 		8A89EFE81C7C866500A27EE9 /* HUBImageLoaderFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89EFE71C7C866500A27EE9 /* HUBImageLoaderFactoryMock.m */; };
 		8A89EFE91C7C866D00A27EE9 /* HUBImageLoaderMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89EFE41C7C728100A27EE9 /* HUBImageLoaderMock.m */; };
+		8A9C9CFF1DDC71930070258F /* HUBAsyncActionWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9C9CFE1DDC71930070258F /* HUBAsyncActionWrapper.m */; };
 		8A9ED75D1D4A049C006B27D8 /* HUBComponentReusePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9ED75C1D4A049C006B27D8 /* HUBComponentReusePool.m */; };
 		8A9ED75F1D4A24C2006B27D8 /* HUBComponentModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9ED75E1D4A24C2006B27D8 /* HUBComponentModelTests.m */; };
 		8AA29C851C4FAA9200E972B7 /* HUBComponentModelImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA29C841C4FAA9200E972B7 /* HUBComponentModelImplementation.m */; };
@@ -295,6 +296,8 @@
 		8A89EFE61C7C866500A27EE9 /* HUBImageLoaderFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBImageLoaderFactoryMock.h; sourceTree = "<group>"; };
 		8A89EFE71C7C866500A27EE9 /* HUBImageLoaderFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBImageLoaderFactoryMock.m; sourceTree = "<group>"; };
 		8A9383BF1D1ADF3C0085A2D5 /* HUBJSONCompatibleBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBJSONCompatibleBuilder.h; sourceTree = "<group>"; };
+		8A9C9CFD1DDC71930070258F /* HUBAsyncActionWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBAsyncActionWrapper.h; sourceTree = "<group>"; };
+		8A9C9CFE1DDC71930070258F /* HUBAsyncActionWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBAsyncActionWrapper.m; sourceTree = "<group>"; };
 		8A9ED75B1D4A049C006B27D8 /* HUBComponentReusePool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentReusePool.h; sourceTree = "<group>"; };
 		8A9ED75C1D4A049C006B27D8 /* HUBComponentReusePool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentReusePool.m; sourceTree = "<group>"; };
 		8A9ED75E1D4A24C2006B27D8 /* HUBComponentModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentModelTests.m; sourceTree = "<group>"; };
@@ -615,6 +618,8 @@
 				8A6ACAB21D7D893400102EA9 /* HUBActionContextImplementation.m */,
 				8A6529F71D82DC33007B1A15 /* HUBActionHandlerWrapper.h */,
 				8A6529F81D82DC33007B1A15 /* HUBActionHandlerWrapper.m */,
+				8A9C9CFD1DDC71930070258F /* HUBAsyncActionWrapper.h */,
+				8A9C9CFE1DDC71930070258F /* HUBAsyncActionWrapper.m */,
 				8A6529FA1D82DF18007B1A15 /* HUBSelectionAction.h */,
 				8A6529FB1D82DF18007B1A15 /* HUBSelectionAction.m */,
 			);
@@ -1152,6 +1157,7 @@
 				TargetAttributes = {
 					8A07549D1C21A79200AFAD38 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					8ADD42981C21CF6500D1A801 = {
 						CreatedOnToolsVersion = 7.1;
@@ -1250,6 +1256,7 @@
 				8A49BAF81C777FB1005F7453 /* HUBComponentImageLoadingContext.m in Sources */,
 				8AA29C8F1C4FAFC100E972B7 /* HUBComponentImageDataBuilderImplementation.m in Sources */,
 				8ACA8C871D1818920015310F /* HUBComponentModelBuilderShowcaseSnapshotGenerator.m in Sources */,
+				8A9C9CFF1DDC71930070258F /* HUBAsyncActionWrapper.m in Sources */,
 				8AE278A01C6236E400DFAF99 /* HUBComponentImageDataJSONSchemaImplementation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1352,20 +1359,27 @@
 		8A0754A81C21A79200AFAD38 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		8A0754A91C21A79200AFAD38 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/sources/HUBActionHandlerWrapper.h
+++ b/sources/HUBActionHandlerWrapper.h
@@ -30,27 +30,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Delegate protocol for `HUBActionHandlerWrapper`
-@protocol HUBActionHandlerWrapperDelegate <NSObject>
-
-/**
- *  Provide an action context for an action handler
- *
- *  @param actionHandler The handler to provide an action context for
- *  @param actionIdentifier The identifier of the action to return a context for
- *  @param customData Any custom data to include in the returned action context
- */
-- (id<HUBActionContext>)actionHandler:(HUBActionHandlerWrapper *)actionHandler
-                        provideContextForActionWithIdentifier:(HUBIdentifier *)actionIdentifier
-                        customData:(nullable NSDictionary<NSString *, id> *)customData;
-
-@end
-
 /// Class handling actions for a Hub Framework powered-view, while wrapping any user-specified action handler
 @interface HUBActionHandlerWrapper : NSObject <HUBActionHandler>
-
-/// The action handler's delegate. See `HUBActionHandlerWrapperDelegate` for more information.
-@property (nonatomic, weak, nullable) id<HUBActionHandlerWrapperDelegate> delegate;
 
 /**
  *  Initialize an instance of this class

--- a/sources/HUBActionHandlerWrapper.m
+++ b/sources/HUBActionHandlerWrapper.m
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)actionDidFinish:(HUBAsyncActionWrapper *)action
         withContext:(id<HUBActionContext>)context
         chainToActionWithIdentifier:(nullable HUBIdentifier *)nextActionIdentifier
-        customData:(nullable NSDictionary<NSString *,id> *)nextActionCustomData
+        customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData
 {
     [self.ongoingAsyncActions removeObject:action];
     

--- a/sources/HUBAsyncActionWrapper.h
+++ b/sources/HUBAsyncActionWrapper.h
@@ -19,9 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param nextActionCustomData Any custom data to pass to the chained action
  */
 - (void)actionDidFinish:(HUBAsyncActionWrapper *)action
-            withContext:(id<HUBActionContext>)context
+        withContext:(id<HUBActionContext>)context
         chainToActionWithIdentifier:(nullable HUBIdentifier *)nextActionIdentifier
-             customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData;
+        customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData;
 
 @end
 

--- a/sources/HUBAsyncActionWrapper.h
+++ b/sources/HUBAsyncActionWrapper.h
@@ -1,0 +1,53 @@
+#import "HUBHeaderMacros.h"
+
+@class HUBAsyncActionWrapper;
+@class HUBIdentifier;
+@protocol HUBAsyncAction;
+@protocol HUBActionContext;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Delegate protocol for `HUBAsyncActionWrapper`
+@protocol HUBAsyncActionWrapperDelegate <NSObject>
+
+/**
+ *  Notify an async action wrapper's delegate that it finished
+ *
+ *  @param action The action that finished
+ *  @param context The context that the action was performed using
+ *  @param nextActionIdentifier The identifier of any chained action to perform
+ *  @param nextActionCustomData Any custom data to pass to the chained action
+ */
+- (void)actionDidFinish:(HUBAsyncActionWrapper *)action
+            withContext:(id<HUBActionContext>)context
+        chainToActionWithIdentifier:(nullable HUBIdentifier *)nextActionIdentifier
+             customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData;
+
+@end
+
+/**
+ *  Wrapper class for async actions
+ *
+ *  Every async action (`HUBAsyncAction`) is wrapped using this class, and performed using it. The reason for that
+ *  is to be able to associate a certain context with an action, without requiring each action implementation to
+ *  synthesize a context property.
+ */
+@interface HUBAsyncActionWrapper : NSObject
+
+/// The action's delegate. See `HUBAsyncActionWrapperDelegate` for more info.
+@property (nonatomic, weak, nullable) id<HUBAsyncActionWrapperDelegate> delegate;
+
+/**
+ *  Initialize an instance of this class
+ *
+ *  @param action The action that this object should wrap
+ *  @param context The context that the action will be performed using
+ */
+- (instancetype)initWithAction:(id<HUBAsyncAction>)action context:(id<HUBActionContext>)context HUB_DESIGNATED_INITIALIZER;
+
+/// Perform the underlying action and return the result
+- (BOOL)perform;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBAsyncActionWrapper.h
+++ b/sources/HUBAsyncActionWrapper.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBHeaderMacros.h"
 
 @class HUBAsyncActionWrapper;

--- a/sources/HUBAsyncActionWrapper.m
+++ b/sources/HUBAsyncActionWrapper.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)actionDidFinish:(id<HUBAsyncAction>)action
         chainToActionWithIdentifier:(nullable HUBIdentifier *)nextActionIdentifier
-             customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData
+        customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData
 {
     [self.delegate actionDidFinish:self
                        withContext:self.context

--- a/sources/HUBAsyncActionWrapper.m
+++ b/sources/HUBAsyncActionWrapper.m
@@ -1,0 +1,55 @@
+#import "HUBAsyncActionWrapper.h"
+#import "HUBAsyncAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBAsyncActionWrapper () <HUBAsyncActionDelegate>
+
+@property (nonatomic, strong, readonly) id<HUBAsyncAction> action;
+@property (nonatomic, strong, readonly) id<HUBActionContext> context;
+
+@end
+
+@implementation HUBAsyncActionWrapper
+
+#pragma mark - Initializer
+
+- (instancetype)initWithAction:(id<HUBAsyncAction>)action context:(id<HUBActionContext>)context
+{
+    NSParameterAssert(action != nil);
+    NSParameterAssert(context != nil);
+    
+    self = [super init];
+    
+    if (self) {
+        _action = action;
+        _context = context;
+        
+        _action.delegate = self;
+    }
+    
+    return self;
+}
+
+#pragma mark - API
+
+- (BOOL)perform
+{
+    return [self.action performWithContext:self.context];
+}
+
+#pragma mark - HUBAsyncActionDelegate
+
+- (void)actionDidFinish:(id<HUBAsyncAction>)action
+        chainToActionWithIdentifier:(nullable HUBIdentifier *)nextActionIdentifier
+             customData:(nullable NSDictionary<NSString *, id> *)nextActionCustomData
+{
+    [self.delegate actionDidFinish:self
+                       withContext:self.context
+       chainToActionWithIdentifier:nextActionIdentifier
+                        customData:nextActionCustomData];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBAsyncActionWrapper.m
+++ b/sources/HUBAsyncActionWrapper.m
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBAsyncActionWrapper.h"
 #import "HUBAsyncAction.h"
 

--- a/sources/HUBViewControllerImplementation.h
+++ b/sources/HUBViewControllerImplementation.h
@@ -25,13 +25,13 @@
 @protocol HUBImageLoader;
 @protocol HUBContentReloadPolicy;
 @protocol HUBComponentLayoutManager;
+@protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
 @class HUBViewModelLoaderImplementation;
 @class HUBCollectionViewFactory;
 @class HUBComponentRegistryImplementation;
 @class HUBInitialViewModelRegistry;
 @class HUBActionRegistryImplementation;
-@class HUBActionHandlerWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
-                  actionHandler:(HUBActionHandlerWrapper *)actionHandler
+                  actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader HUB_DESIGNATED_INITIALIZER;
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -63,7 +63,6 @@ NS_ASSUME_NONNULL_BEGIN
     HUBImageLoaderDelegate,
     HUBComponentWrapperDelegate,
     HUBActionPerformer,
-    HUBActionHandlerWrapperDelegate,
     UICollectionViewDataSource,
     HUBCollectionViewDelegate
 >
@@ -114,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
-                  actionHandler:(HUBActionHandlerWrapper *)actionHandler
+                  actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader
 
@@ -157,7 +156,6 @@ NS_ASSUME_NONNULL_BEGIN
     viewModelLoader.delegate = self;
     viewModelLoader.actionPerformer = self;
     imageLoader.delegate = self;
-    actionHandler.delegate = self;
     
     self.automaticallyAdjustsScrollViewInsets = [_scrollHandler shouldAutomaticallyAdjustContentInsetsInViewController:self];
     
@@ -676,23 +674,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                         customIdentifier:identifier
                               customData:customData
                           componentModel:nil];
-}
-
-#pragma mark - HUBActionHandlerWrapperDelegate
-
-- (id<HUBActionContext>)actionHandler:(HUBActionHandlerWrapper *)actionHandler
-                        provideContextForActionWithIdentifier:(HUBIdentifier *)actionIdentifier
-                           customData:(nullable NSDictionary<NSString *, id> *)customData
-{
-    id<HUBViewModel> const viewModel = self.viewModel;
-    
-    return [[HUBActionContextImplementation alloc] initWithTrigger:HUBActionTriggerChained
-                                            customActionIdentifier:actionIdentifier
-                                                        customData:customData
-                                                           viewURI:self.viewURI
-                                                         viewModel:viewModel
-                                                    componentModel:nil
-                                                    viewController:self];
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -2288,49 +2288,52 @@
 
 - (void)testPerformingAsyncAction
 {
-    HUBActionMock *action = [[HUBActionMock alloc] initWithBlock:^(id<HUBActionContext> context) {
-        return YES;
-    }];
-    action.isAsync = YES;
-    
-    HUBActionFactoryMock *actionFactory = [[HUBActionFactoryMock alloc] initWithActions:@{@"name": action}];
-    [self.actionRegistry registerActionFactory:actionFactory forNamespace:@"namespace"];
-    
-    __weak HUBActionMock *actionWeakRef = action;
-    
-    [self simulateViewControllerLayoutCycle];
-    
-    HUBIdentifier * const actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];
-    BOOL const actionOutcome = [self.contentOperation.actionPerformer performActionWithIdentifier:actionIdentifier
-                                                                                       customData:nil];
-    
-    // Here we unregister the action factory, to release our mocked reference to the action
-    // We also nil out our local reference, to be able to assert that the Hub Framework is retaining it
-    [self.actionRegistry unregisterActionFactoryForNamespace:@"namespace"];
-    actionFactory = nil;
-    action = nil;
-    
-    XCTAssertTrue(actionOutcome);
-    XCTAssertNotNil(actionWeakRef);
-    
-    // Capture action strongly again, to avoid compiler error
-    action = actionWeakRef;
-    
-    __block id<HUBActionContext> chainedActionContext = nil;
-    
-    self.actionHandler.block = ^(id<HUBActionContext> context) {
-        chainedActionContext = context;
-        return YES;
-    };
+    __weak HUBActionMock *actionWeakRef;
+    __block id<HUBActionContext> chainedActionContext;
     
     HUBIdentifier * const chainedActionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"chained" name:@"action"];
     NSDictionary * const chainedActionCustomData = @{@"custom": @"data"};
-    [action.delegate actionDidFinish:action chainToActionWithIdentifier:chainedActionIdentifier customData:chainedActionCustomData];
     
-    // Action should now be fully released, since we are done with it
-    action = nil;
+    // Here we use an auto release pool to control the lifecycles of the objects locally
+    @autoreleasepool {
+        HUBActionMock *action = [[HUBActionMock alloc] initWithBlock:^(id<HUBActionContext> context) {
+            return YES;
+        }];
+        action.isAsync = YES;
+        
+        HUBActionFactoryMock *actionFactory = [[HUBActionFactoryMock alloc] initWithActions:@{@"name": action}];
+        [self.actionRegistry registerActionFactory:actionFactory forNamespace:@"namespace"];
+        
+        actionWeakRef = action;
+        
+        [self simulateViewControllerLayoutCycle];
+        
+        HUBIdentifier * const actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];
+        BOOL const actionOutcome = [self.contentOperation.actionPerformer performActionWithIdentifier:actionIdentifier
+                                                                                           customData:nil];
+        
+        // Here we unregister the action factory, to release our mocked reference to the action
+        // We also nil out our local reference, to be able to assert that the Hub Framework is retaining it
+        [self.actionRegistry unregisterActionFactoryForNamespace:@"namespace"];
+        actionFactory = nil;
+        action = nil;
+        
+        XCTAssertTrue(actionOutcome);
+        XCTAssertNotNil(actionWeakRef);
+        
+        // Capture action strongly again, to avoid compiler error
+        action = actionWeakRef;
+        
+        self.actionHandler.block = ^(id<HUBActionContext> context) {
+            chainedActionContext = context;
+            return YES;
+        };
+        
+        [action.delegate actionDidFinish:action chainToActionWithIdentifier:chainedActionIdentifier customData:chainedActionCustomData];
+    }
+    
+    // Make sure that the action has now been released, and that the chained action was performed
     XCTAssertNil(actionWeakRef);
-    
     XCTAssertNotNil(chainedActionContext);
     XCTAssertEqualObjects(chainedActionContext.customActionIdentifier, chainedActionIdentifier);
     XCTAssertEqualObjects(chainedActionContext.customData, chainedActionCustomData);


### PR DESCRIPTION
This change is part of the work for https://github.com/spotify/HubFramework/issues/158, which has the end goal of making `HUBViewController` publicly initializable. To do this, we need to remove all dependencies on concrete internal classes.

This is the first step, which makes `HUBViewController` take any `HUBActionHandler` as part of its initializer, rather than relying on the concrete `HUBActionHandlerWrapper` implementation. To make this happen, logic that was previously delegated to the view controller around chaining of async actions needed to be moved into the action handler wrapper itself.

The test change that was made in `HUBViewControllerTests` needed to make made to avoid implicit autorelease pools from taking over the lifecycle of objects.