### PR TITLE
View controller: Use component registry as HUBComponentRegistry protocol

### DIFF
--- a/include/HubFramework/HUBComponentRegistry.h
+++ b/include/HubFramework/HUBComponentRegistry.h
@@ -22,6 +22,8 @@
 #import <Foundation/Foundation.h>
 
 @protocol HUBComponentFactory;
+@protocol HUBComponent;
+@protocol HUBComponentModel;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -59,6 +61,21 @@ NS_ASSUME_NONNULL_BEGIN
  *  method does nothing.
  */
 - (void)unregisterComponentFactoryForNamespace:(NSString *)componentNamespace;
+
+/**
+ *  Create a new component instance for a model
+ *
+ *  @param model The model to create a component for
+ *
+ *  @return A newly created component that is ready to use. The component registry will first attempt
+ *          to resolve a component factory for the model's `componentNamespace`, and ask it to create
+ *          a component. However, if this fails, the registry will use its fallback handler to create
+ *          a fallback component for the model's `componentCategory`.
+ *
+ *  Normally, you don't have to call this method yourself. Instead, the Hub Framework automatically
+ *  creates component instances for the models you delcare in a content operation.
+ */
+- (id<HUBComponent>)createComponentForModel:(id<HUBComponentModel>)model;
 
 @end
 

--- a/sources/HUBCollectionViewLayout.h
+++ b/sources/HUBCollectionViewLayout.h
@@ -24,7 +24,7 @@
 
 @protocol HUBViewModel;
 @protocol HUBComponentLayoutManager;
-@class HUBComponentRegistryImplementation;
+@protocol HUBComponentRegistry;
 @class HUBScrollBehaviorWrapper;
 @class HUBViewModelDiff;
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param componentRegistry The registry to use to retrieve components for calculations
  *  @param componentLayoutManager The manager responsible for component layout
  */
-- (instancetype)initWithComponentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
                    componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager HUB_DESIGNATED_INITIALIZER;
 /**
  *  Compute this layout for a given collection view size

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -23,7 +23,7 @@
 
 #import "HUBViewModel.h"
 #import "HUBComponentModel.h"
-#import "HUBComponentRegistryImplementation.h"
+#import "HUBComponentRegistry.h"
 #import "HUBComponent.h"
 #import "HUBComponentWithChildren.h"
 #import "HUBIdentifier.h"
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface HUBCollectionViewLayout () <HUBComponentChildDelegate>
 
 @property (nonatomic, strong, nullable) id<HUBViewModel> viewModel;
-@property (nonatomic, strong, readonly) HUBComponentRegistryImplementation *componentRegistry;
+@property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
 @property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
 @property (nonatomic, strong, readonly) NSMutableDictionary<HUBIdentifier *, id<HUBComponent>> *componentCache;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *layoutAttributesByIndexPath;
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBCollectionViewLayout
 
-- (instancetype)initWithComponentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
                    componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
 {
     self = [super init];

--- a/sources/HUBComponentRegistryImplementation.h
+++ b/sources/HUBComponentRegistryImplementation.h
@@ -48,18 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
                      JSONSchemaRegistry:(HUBJSONSchemaRegistryImplementation *)JSONSchemaRegistry
                       iconImageResolver:(nullable id<HUBIconImageResolver>)iconImageResolver HUB_DESIGNATED_INITIALIZER;
 
-/**
- *  Create a new component instance for a model
- *
- *  @param model The model to create a component for
- *
- *  @return A newly created component that is ready to use. The component registry will first attempt
- *          to resolve a component factory for the model's `componentNamespace`, and ask it to create
- *          a component. However, if this fails, the registry will use its fallback handler to create
- *          a fallback component for the model's `componentCategory`.
- */
-- (id<HUBComponent>)createComponentForModel:(id<HUBComponentModel>)model;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBComponentReusePool.h
+++ b/sources/HUBComponentReusePool.h
@@ -23,7 +23,7 @@
 
 @protocol HUBComponentModel;
 @protocol HUBComponentWrapperDelegate;
-@class HUBComponentRegistryImplementation;
+@protocol HUBComponentRegistry;
 @class HUBComponentWrapper;
 @class HUBComponentUIStateManager;
 
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param componentRegistry The component registry to use to create new component instances
  *  @param UIStateManager The manager keeping track of component UI states
  */
-- (instancetype)initWithComponentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
                            UIStateManager:(HUBComponentUIStateManager *)UIStateManager HUB_DESIGNATED_INITIALIZER;
 
 /**

--- a/sources/HUBComponentReusePool.m
+++ b/sources/HUBComponentReusePool.m
@@ -24,14 +24,14 @@
 #import "HUBComponentWrapper.h"
 #import "HUBIdentifier.h"
 #import "HUBComponentModel.h"
-#import "HUBComponentRegistryImplementation.h"
+#import "HUBComponentRegistry.h"
 #import "HUBComponentGestureRecognizer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBComponentReusePool ()
 
-@property (nonatomic, strong, readonly) HUBComponentRegistryImplementation *componentRegistry;
+@property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
 @property (nonatomic, strong, readonly) HUBComponentUIStateManager *UIStateManager;
 @property (nonatomic, strong, readonly) NSMutableDictionary<HUBIdentifier *, NSMutableSet<HUBComponentWrapper *> *> *componentWrappers;
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBComponentReusePool
 
-- (instancetype)initWithComponentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
                            UIStateManager:(HUBComponentUIStateManager *)UIStateManager
 {
     NSParameterAssert(componentRegistry != nil);

--- a/sources/HUBViewControllerImplementation.h
+++ b/sources/HUBViewControllerImplementation.h
@@ -26,9 +26,9 @@
 @protocol HUBContentReloadPolicy;
 @protocol HUBComponentLayoutManager;
 @protocol HUBViewControllerScrollHandler;
+@protocol HUBComponentRegistry;
 @class HUBViewModelLoaderImplementation;
 @class HUBCollectionViewFactory;
-@class HUBComponentRegistryImplementation;
 @class HUBInitialViewModelRegistry;
 @class HUBActionRegistryImplementation;
 @class HUBActionHandlerWrapper;
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
               featureIdentifier:(NSString *)featureIdentifier
                 viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
-              componentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
+              componentRegistry:(id<HUBComponentRegistry>)componentRegistry
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(HUBActionHandlerWrapper *)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -32,7 +32,7 @@
 #import "HUBComponentContentOffsetObserver.h"
 #import "HUBComponentViewObserver.h"
 #import "HUBComponentWrapper.h"
-#import "HUBComponentRegistryImplementation.h"
+#import "HUBComponentRegistry.h"
 #import "HUBComponentCollectionViewCell.h"
 #import "HUBUtilities.h"
 #import "HUBImageLoader.h"
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSURL *viewURI;
 @property (nonatomic, strong, readonly) id<HUBViewModelLoader> viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
-@property (nonatomic, strong, readonly) HUBComponentRegistryImplementation *componentRegistry;
+@property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
 @property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
 @property (nonatomic, strong, readonly) id<HUBActionHandler> actionHandler;
 @property (nonatomic, strong, readonly) id<HUBViewControllerScrollHandler> scrollHandler;
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
               featureIdentifier:(NSString *)featureIdentifier
                 viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
-              componentRegistry:(HUBComponentRegistryImplementation *)componentRegistry
+              componentRegistry:(id<HUBComponentRegistry>)componentRegistry
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(HUBActionHandlerWrapper *)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler


### PR DESCRIPTION
This change is part of the work for https://github.com/spotify/HubFramework/issues/158, which has the end goal of making `HUBViewController` publicly initializable. To do this, we need to remove all dependencies on concrete internal classes.

With this, the API to create new component instances has been moved from `HUBComponentRegistryImplementation` to the `HUBComponentRegistry` API. While it’s not expected that any API user will use this method directly, it enables the view controller to not rely on the concrete component registry implementation.