### PR TITLE
Add a UI test for navigation items

### DIFF
--- a/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
+++ b/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6510FD791DD1D182002FA2DC /* PrettyPicturesActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6510FD781DD1D182002FA2DC /* PrettyPicturesActionHandler.swift */; };
 		657DFE1B1DC8E21700F20C0E /* SelectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657DFE191DC8E21700F20C0E /* SelectionUITests.swift */; };
 		657DFE1C1DC8E21700F20C0E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 657DFE1A1DC8E21700F20C0E /* Info.plist */; };
+		65A790361DDDA8FC00AD4078 /* NavigationItemUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A790351DDDA8FC00AD4078 /* NavigationItemUITests.swift */; };
 		8A27299A1D9546BB00EF43FC /* RootContentOperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2729991D9546BB00EF43FC /* RootContentOperationFactory.swift */; };
 		8A27299E1D9546ED00EF43FC /* RootContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A27299D1D9546ED00EF43FC /* RootContentOperation.swift */; };
 		8A2729A21D95486A00EF43FC /* URL+ViewURIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2729A11D95486A00EF43FC /* URL+ViewURIs.swift */; };
@@ -81,6 +82,7 @@
 		657DFE0F1DC8E1B600F20C0E /* HubFrameworkDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HubFrameworkDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		657DFE191DC8E21700F20C0E /* SelectionUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SelectionUITests.swift; path = tests/SelectionUITests.swift; sourceTree = SOURCE_ROOT; };
 		657DFE1A1DC8E21700F20C0E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = tests/Info.plist; sourceTree = SOURCE_ROOT; };
+		65A790351DDDA8FC00AD4078 /* NavigationItemUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationItemUITests.swift; path = tests/NavigationItemUITests.swift; sourceTree = SOURCE_ROOT; };
 		8A2729991D9546BB00EF43FC /* RootContentOperationFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootContentOperationFactory.swift; sourceTree = "<group>"; };
 		8A27299D1D9546ED00EF43FC /* RootContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootContentOperation.swift; sourceTree = "<group>"; };
 		8A2729A11D95486A00EF43FC /* URL+ViewURIs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+ViewURIs.swift"; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 			children = (
 				657DFE191DC8E21700F20C0E /* SelectionUITests.swift */,
 				8AA98C441DD3778B006CA6AA /* PaginationUITests.swift */,
+				65A790351DDDA8FC00AD4078 /* NavigationItemUITests.swift */,
 				657DFE1A1DC8E21700F20C0E /* Info.plist */,
 			);
 			name = Tests;
@@ -436,6 +439,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				657DFE1B1DC8E21700F20C0E /* SelectionUITests.swift in Sources */,
+				65A790361DDDA8FC00AD4078 /* NavigationItemUITests.swift in Sources */,
 				8AA98C451DD3778B006CA6AA /* PaginationUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/demo/tests/NavigationItemUITests.swift
+++ b/demo/tests/NavigationItemUITests.swift
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import XCTest
+
+class NavigationItemUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+
+        continueAfterFailure = false
+        XCUIApplication().launch()
+
+        XCUIDevice.shared().orientation = .portrait
+    }
+
+    func testRightBarButtonItem() {
+        let app = XCUIApplication()
+
+        // Tap "Todo list" and make sure we navigate to that page.
+        app.collectionViews["collectionView"].staticTexts["Todo list"].tap()
+        XCTAssertTrue(app.navigationBars["Todo List"].exists)
+
+        // Make sure the "Add" button is tappable, and that an action is fired from it.
+        let alert = app.alerts["Add an item"]
+        XCTAssertFalse(alert.exists)
+        app.navigationBars["Todo List"].buttons["Add"].tap()
+        XCTAssertTrue(alert.exists)
+
+        // Dismiss the alert
+        alert.buttons["Cancel"].tap()
+        XCTAssertFalse(alert.exists)
+    }
+}


### PR DESCRIPTION
Tests that `rightBarButtonItem`s that are configured through the model builder appear and are tappable.