### PR TITLE
Update components parent wrapper when it is reused

### DIFF
--- a/sources/HUBComponentReusePool.m
+++ b/sources/HUBComponentReusePool.m
@@ -77,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (existingWrappers.count > 0) {
         HUBComponentWrapper * const wrapper = [existingWrappers anyObject];
         wrapper.delegate = delegate;
+        wrapper.parent = parent;
         [existingWrappers removeObject:wrapper];
         return wrapper;
     }

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -150,7 +150,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
 @property (nonatomic, weak, nullable) id<HUBComponentWrapperDelegate> delegate;
 
 /// The components parent wrapper if it is a child component
-@property (nonatomic, weak, nullable, readonly) HUBComponentWrapper *parent;
+@property (nonatomic, weak, nullable) HUBComponentWrapper *parent;
 
 /// Whether the wrapper is for a root component, or for a child component
 @property (nonatomic, readonly) BOOL isRootComponent;


### PR DESCRIPTION
This fixes a bug that component wrapper's parent wrapper was not updated when component is reused, which led to inconsistency in visible views.