### PR TITLE
Expose HUBViewController as a concrete class

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -90,7 +90,7 @@
 		8AD0645E1C64F45A0086C081 /* HUBConnectivityStateResolverMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0645C1C64F4510086C081 /* HUBConnectivityStateResolverMock.m */; };
 		8AD064601C64F5460086C081 /* HUBViewModelLoaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0645F1C64F5460086C081 /* HUBViewModelLoaderTests.m */; };
 		8AD064661C64F7C30086C081 /* HUBContentOperationMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD064651C64F7C30086C081 /* HUBContentOperationMock.m */; };
-		8AD064691C68DEA10086C081 /* HUBViewControllerImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD064681C68DEA10086C081 /* HUBViewControllerImplementation.m */; };
+		8AD064691C68DEA10086C081 /* HUBViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD064681C68DEA10086C081 /* HUBViewController.m */; };
 		8AD0646C1C68E7B00086C081 /* HUBComponentCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0646B1C68E7B00086C081 /* HUBComponentCollectionViewCell.m */; };
 		8AD064701C68EDA20086C081 /* HUBViewControllerFactoryImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD0646F1C68EDA20086C081 /* HUBViewControllerFactoryImplementation.m */; };
 		8AD064741C68F0820086C081 /* HUBViewModelLoaderFactoryImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD064731C68F0820086C081 /* HUBViewModelLoaderFactoryImplementation.m */; };
@@ -258,7 +258,6 @@
 		8A69DBAC1C7DF9D300F5EFC6 /* HUBCollectionViewFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionViewFactoryMock.m; sourceTree = "<group>"; };
 		8A69DBAE1C7DFA1A00F5EFC6 /* HUBCollectionViewMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBCollectionViewMock.h; sourceTree = "<group>"; };
 		8A69DBAF1C7DFA1A00F5EFC6 /* HUBCollectionViewMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionViewMock.m; sourceTree = "<group>"; };
-		8A69DBB91C7F0FC400F5EFC6 /* HUBViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBViewController.h; sourceTree = "<group>"; };
 		8A6ACAB21D7D893400102EA9 /* HUBActionContextImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBActionContextImplementation.m; sourceTree = "<group>"; };
 		8A6ACAB51D7D89CE00102EA9 /* HUBActionContextImplementation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBActionContextImplementation.h; sourceTree = "<group>"; };
 		8A6BA04F1C899E1C0057485D /* HUBCollectionViewLayoutTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionViewLayoutTests.m; sourceTree = "<group>"; };
@@ -298,6 +297,8 @@
 		8A9383BF1D1ADF3C0085A2D5 /* HUBJSONCompatibleBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBJSONCompatibleBuilder.h; sourceTree = "<group>"; };
 		8A9C9CFD1DDC71930070258F /* HUBAsyncActionWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBAsyncActionWrapper.h; sourceTree = "<group>"; };
 		8A9C9CFE1DDC71930070258F /* HUBAsyncActionWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBAsyncActionWrapper.m; sourceTree = "<group>"; };
+		8A9CA05E1DDDC3D70070258F /* HUBViewController+Initializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "HUBViewController+Initializer.h"; sourceTree = "<group>"; };
+		8A9CA05F1DDDD3230070258F /* HUBViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewController.h; sourceTree = "<group>"; };
 		8A9ED75B1D4A049C006B27D8 /* HUBComponentReusePool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentReusePool.h; sourceTree = "<group>"; };
 		8A9ED75C1D4A049C006B27D8 /* HUBComponentReusePool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentReusePool.m; sourceTree = "<group>"; };
 		8A9ED75E1D4A24C2006B27D8 /* HUBComponentModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentModelTests.m; sourceTree = "<group>"; };
@@ -350,8 +351,7 @@
 		8AD0645F1C64F5460086C081 /* HUBViewModelLoaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelLoaderTests.m; sourceTree = "<group>"; };
 		8AD064641C64F7C30086C081 /* HUBContentOperationMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBContentOperationMock.h; sourceTree = "<group>"; };
 		8AD064651C64F7C30086C081 /* HUBContentOperationMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBContentOperationMock.m; sourceTree = "<group>"; };
-		8AD064671C68DEA10086C081 /* HUBViewControllerImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerImplementation.h; sourceTree = "<group>"; };
-		8AD064681C68DEA10086C081 /* HUBViewControllerImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewControllerImplementation.m; sourceTree = "<group>"; };
+		8AD064681C68DEA10086C081 /* HUBViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewController.m; sourceTree = "<group>"; };
 		8AD0646B1C68E7B00086C081 /* HUBComponentCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentCollectionViewCell.m; sourceTree = "<group>"; };
 		8AD0646E1C68EDA20086C081 /* HUBViewControllerFactoryImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerFactoryImplementation.h; sourceTree = "<group>"; };
 		8AD0646F1C68EDA20086C081 /* HUBViewControllerFactoryImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewControllerFactoryImplementation.m; sourceTree = "<group>"; };
@@ -1063,8 +1063,8 @@
 				8AD064751C68FCAD0086C081 /* HUBViewModelLoader.h */,
 				8AD064761C69069A0086C081 /* HUBViewModelLoaderFactory.h */,
 				8A786B911C57D53600B2AB9E /* HUBViewModelBuilder.h */,
+				8A9CA05F1DDDD3230070258F /* HUBViewController.h */,
 				8AD064771C6906B00086C081 /* HUBViewControllerFactory.h */,
-				8A69DBB91C7F0FC400F5EFC6 /* HUBViewController.h */,
 				8A0E4B761CB561DE0019DE71 /* HUBViewURIPredicate.h */,
 				8AED9F8F1D77090D00BEFD66 /* HUBViewControllerScrollHandler.h */,
 			);
@@ -1074,6 +1074,8 @@
 		8AF9FA041C5254E8003F3D6C /* View */ = {
 			isa = PBXGroup;
 			children = (
+				8A9CA05E1DDDC3D70070258F /* HUBViewController+Initializer.h */,
+				8AD064681C68DEA10086C081 /* HUBViewController.m */,
 				8AF9FA051C5254F5003F3D6C /* HUBViewModelImplementation.h */,
 				8AF9FA061C5254F5003F3D6C /* HUBViewModelImplementation.m */,
 				F64C5C2B1DB82CA30077E619 /* HUBViewModelRenderer.h */,
@@ -1086,8 +1088,6 @@
 				8A786B931C57D62100B2AB9E /* HUBViewModelBuilderImplementation.m */,
 				8AFDCAC31C8DD5920068DECC /* HUBInitialViewModelRegistry.h */,
 				8AFDCAC41C8DD5920068DECC /* HUBInitialViewModelRegistry.m */,
-				8AD064671C68DEA10086C081 /* HUBViewControllerImplementation.h */,
-				8AD064681C68DEA10086C081 /* HUBViewControllerImplementation.m */,
 				8AD0646E1C68EDA20086C081 /* HUBViewControllerFactoryImplementation.h */,
 				8AD0646F1C68EDA20086C081 /* HUBViewControllerFactoryImplementation.m */,
 				8A69DBA81C7DF8C000F5EFC6 /* HUBCollectionViewFactory.h */,
@@ -1242,7 +1242,7 @@
 				8A2A72EB1D4B726800141619 /* HUBComponentTargetJSONSchemaImplementation.m in Sources */,
 				8AD064561C64B6DB0086C081 /* HUBComponentModelJSONSchemaImplementation.m in Sources */,
 				8A15729B1D9E735C00E9DD4D /* HUBLiveServiceImplementation.m in Sources */,
-				8AD064691C68DEA10086C081 /* HUBViewControllerImplementation.m in Sources */,
+				8AD064691C68DEA10086C081 /* HUBViewController.m in Sources */,
 				8A786BA81C5A2E8F00B2AB9E /* HUBJSONSchemaRegistryImplementation.m in Sources */,
 				8A2A72E61D4B6F1700141619 /* HUBComponentTargetBuilderImplementation.m in Sources */,
 				8ADA48571D784C1400C27F21 /* HUBAutoEquatable.m in Sources */,

--- a/demo/sources/AppDelegate.swift
+++ b/demo/sources/AppDelegate.swift
@@ -66,7 +66,7 @@ import HubFramework
     
     // MARK: - HUBLiveServiceDelegate
     
-    func liveService(_ liveService: HUBLiveService, didCreateViewController viewController: UIViewController) {
+    func liveService(_ liveService: HUBLiveService, didCreateViewController viewController: HUBViewController) {
         prepareAndPush(viewController: viewController, animated: true)
     }
     

--- a/documentation/Live editing guide.md
+++ b/documentation/Live editing guide.md
@@ -36,7 +36,7 @@ Once the live service has created a view controller, push that view controller o
 
 ```objective-c
 - (void)liveService:(id<HUBLiveService>)liveService
-        didCreateViewController:(UIViewController<HUBViewController> *)viewController
+        didCreateViewController:(HUBViewController *)viewController
 {
     [self.navigationController pushViewController:viewController animated:YES];
 }

--- a/include/HubFramework/HUBLiveService.h
+++ b/include/HubFramework/HUBLiveService.h
@@ -24,7 +24,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol HUBLiveService;
-@protocol HUBViewController;
+@class HUBViewController;
 
 /**
  *  Delegate protocol for `HUBLiveService`
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  navigation stack.
  */
 - (void)liveService:(id<HUBLiveService>)liveService
-        didCreateViewController:(UIViewController<HUBViewController> *)viewController;
+        didCreateViewController:(HUBViewController *)viewController;
 
 @end
 

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -19,16 +19,24 @@
  *  under the License.
  */
 
-#import <UIKit/UIKit.h>
-
-#import "HUBComponentType.h"
+#import "HUBHeaderMacros.h"
 #import "HUBComponentLayoutTraits.h"
+#import "HUBComponentType.h"
 #import "HUBScrollPosition.h"
 
-@protocol HUBViewController;
 @protocol HUBViewModel;
-@protocol HUBComponent;
 @protocol HUBComponentModel;
+@protocol HUBImageLoader;
+@protocol HUBContentReloadPolicy;
+@protocol HUBComponentLayoutManager;
+@protocol HUBActionHandler;
+@protocol HUBViewControllerScrollHandler;
+@protocol HUBComponentRegistry;
+@class HUBViewController;
+@class HUBViewModelLoaderImplementation;
+@class HUBCollectionViewFactory;
+@class HUBInitialViewModelRegistry;
+@class HUBActionRegistryImplementation;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  You can use this method to perform any custom UI operations on the whole view controller right before
  *  a new model will be rendered.
  */
-- (void)viewController:(UIViewController<HUBViewController> *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel;
+- (void)viewController:(HUBViewController *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel;
 
 /**
  *  Sent to a Hub Framework view controller's delegate when it was updated with a new view model
@@ -58,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  You can use this method to perform any custom UI operations on the whole view controller when a new
  *  view model has been rendered.
  */
-- (void)viewControllerDidUpdate:(UIViewController<HUBViewController> *)viewController;
+- (void)viewControllerDidUpdate:(HUBViewController *)viewController;
 
 /**
  *  Sent to a Hub Framework view controller's delegate when it failed to be updated because of an error
@@ -71,17 +79,17 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Note that you can also use content operations (`HUBContentOperation`) to react to errors, and adjust the UI.
  */
-- (void)viewController:(UIViewController<HUBViewController> *)viewController didFailToUpdateWithError:(NSError *)error;
+- (void)viewController:(HUBViewController *)viewController didFailToUpdateWithError:(NSError *)error;
 
 /**
  *  Sent to a Hub Framework view controller's delegate when the view finished rendering, due to a view model update.
-
+ 
  *  @param viewController The view controller that finished rendering.
  *
  *  You can use this method to perform any custom UI operations on the whole view controller right after
  *  a new view model was rendered.
  */
-- (void)viewControllerDidFinishRendering:(UIViewController<HUBViewController> *)viewController;
+- (void)viewControllerDidFinishRendering:(HUBViewController *)viewController;
 
 /**
  *  Sent to a Hub Framework view controller's delegate to ask it whenever the view controller should start scrolling
@@ -91,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This method can be used to veto a scroll event from being started. It will be called every time the user starts
  *  scrolling the view that is rendering body components.
  */
-- (BOOL)viewControllerShouldStartScrolling:(UIViewController<HUBViewController> *)viewController;
+- (BOOL)viewControllerShouldStartScrolling:(HUBViewController *)viewController;
 
 /**
  *  Sent to a Hub Framework view controller's delegate when a component is about to appear on the screen
@@ -101,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param layoutTraits The layout traits of the component that is about to appear
  *  @param componentView The view that the component is about to appear in
  */
-- (void)viewController:(UIViewController<HUBViewController> *)viewController
+- (void)viewController:(HUBViewController *)viewController
     componentWithModel:(id<HUBComponentModel>)componentModel
           layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
       willAppearInView:(UIView *)componentView;
@@ -114,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param layoutTraits The layout traits of the component that disappeared
  *  @param componentView The view that the component disappeared from
  */
-- (void)viewController:(UIViewController<HUBViewController> *)viewController
+- (void)viewController:(HUBViewController *)viewController
     componentWithModel:(id<HUBComponentModel>)componentModel
           layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
   didDisappearFromView:(UIView *)componentView;
@@ -125,17 +133,19 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param viewController The view controller in which the component was selected
  *  @param componentModel The model of the component that was selected
  */
-- (void)viewController:(UIViewController<HUBViewController> *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel;
+- (void)viewController:(HUBViewController *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel;
 
 @end
 
 /**
- *  Protocol defining the public API of a Hub Framework view controller
+ *  View controller used to render a Hub Framework-powered view
  *
- *  You don't conform to this protocol yourself, instead the Hub Framework will create view controllers conforming
- *  to this protocol through `HUBViewControllerFactory`.
+ *  You don't create instances of this class directly. Instead, you use `HUBViewControllerFactory` to do so.
+ *
+ *  This view controller renders `HUBComponent` instances using a collection view. What components that are rendered
+ *  are determined by `HUBContentOperation`s that build a `HUBViewModel`.
  */
-@protocol HUBViewController <NSObject>
+@interface HUBViewController : UIViewController
 
 /// The view controller's delegate. See `HUBViewControllerDelegate` for more information.
 @property (nonatomic, weak, nullable) id<HUBViewControllerDelegate> delegate;
@@ -250,6 +260,21 @@ NS_ASSUME_NONNULL_BEGIN
  *  If no component is currently being selected, this method does nothing.
  */
 - (void)cancelComponentSelection;
+
+#pragma mark - Unavailable initializers
+
+/// Use `HUBViewControllerFactory` to create instances of this class
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Use `HUBViewControllerFactory` to create instances of this class
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Use `HUBViewControllerFactory` to create instances of this class
+- (instancetype)initWithCoder:(NSCoder *)decoder NS_UNAVAILABLE;
+
+/// Use `HUBViewControllerFactory` to create instances of this class
+- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
+                         bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
 @end
 

--- a/include/HubFramework/HUBViewControllerFactory.h
+++ b/include/HubFramework/HUBViewControllerFactory.h
@@ -21,7 +21,7 @@
 
 #import <UIKIt/UIKit.h>
 
-@protocol HUBViewController;
+@class HUBViewController;
 @protocol HUBContentOperation;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  To be able to create a view controller without creating a feature, you can use the other view controller
  *  creation method available on this protocol.
  */
-- (nullable UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI;
+- (nullable HUBViewController *)createViewControllerForViewURI:(NSURL *)viewURI;
 
 /**
  *  Create a view controller without a feature registration
@@ -73,10 +73,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param featureTitle The title of the feature that the view controller will belong to. Used for its
  *         default title, and also made available to contnet operations as part of `HUBFeatureInfo`.
  */
-- (UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
-                                                      contentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
-                                                      featureIdentifier:(NSString *)featureIdentifier
-                                                           featureTitle:(NSString *)featureTitle;
+- (HUBViewController *)createViewControllerForViewURI:(NSURL *)viewURI
+                                    contentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
+                                    featureIdentifier:(NSString *)featureIdentifier
+                                         featureTitle:(NSString *)featureTitle;
 
 @end
 

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -22,7 +22,7 @@
 #import <UIKit/UIKit.h>
 #import "HUBScrollPosition.h"
 
-@protocol HUBViewController;
+@class HUBViewController;
 
 /**
  *  Protocol used to define custom scroll handlers for Hub Framework view controllers
@@ -41,7 +41,7 @@
  *  The Hub Framework will call this method when a view controller is being set up. The returned
  *  value will be used for both horizontal & vertical scroll indicators.
  */
-- (BOOL)shouldShowScrollIndicatorsInViewController:(UIViewController<HUBViewController> *)viewController;
+- (BOOL)shouldShowScrollIndicatorsInViewController:(HUBViewController *)viewController;
 
 /**
  *  Return whether the system's automatic adjustment of content insets should be used for a view controller
@@ -52,7 +52,7 @@
  *  assigned to its `automaticallyAdjustsScrollViewInsets` property, so see the documentation for that property
  *  on `UIViewController` for more information.
  */
-- (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(UIViewController<HUBViewController> *)viewController;
+- (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(HUBViewController *)viewController;
 
 /**
  *  Return the deceleration rate to use for scrolling in a view controller
@@ -62,7 +62,7 @@
  *  The Hub Framework will call this method when a view controller is being set up. The returned value will be
  *  assied to the `decelerationRate` property of its internal scroll view.
  */
-- (CGFloat)scrollDecelerationRateForViewController:(UIViewController<HUBViewController> *)viewController;
+- (CGFloat)scrollDecelerationRateForViewController:(HUBViewController *)viewController;
 
 /**
  *  Return the content insets to use for a view controller
@@ -75,7 +75,7 @@
  *  response to that its view model has been changed. The returned value will be assigned to the `contentInset`
  *  property of its internal scroll view.
  */
-- (UIEdgeInsets)contentInsetsForViewController:(UIViewController<HUBViewController> *)viewController
+- (UIEdgeInsets)contentInsetsForViewController:(HUBViewController *)viewController
                          proposedContentInsets:(UIEdgeInsets)proposedContentInsets;
 
 /**
@@ -84,7 +84,7 @@
  *  @param viewController The view controller in question
  *  @param currentContentRect The rectangle of the currently visible content in the view controller's scroll view
  */
-- (void)scrollingWillStartInViewController:(UIViewController<HUBViewController> *)viewController
+- (void)scrollingWillStartInViewController:(HUBViewController *)viewController
                         currentContentRect:(CGRect)currentContentRect;
 
 /**
@@ -93,7 +93,7 @@
  *  @param viewController The view controller in question
  *  @param currentContentRect The rectangle of the currently visible content in the view controller's scroll view
  */
-- (void)scrollingDidEndInViewController:(UIViewController<HUBViewController> *)viewController
+- (void)scrollingDidEndInViewController:(HUBViewController *)viewController
                      currentContentRect:(CGRect)currentContentRect;
 
 /**
@@ -105,7 +105,7 @@
  *  @param currentContentOffset The current scrolling content offset
  *  @param proposedContentOffset The target content offset that the Hub Framework is proposing will be used
  */
-- (CGPoint)targetContentOffsetForEndedScrollInViewController:(UIViewController<HUBViewController> *)viewController
+- (CGPoint)targetContentOffsetForEndedScrollInViewController:(HUBViewController *)viewController
                                                     velocity:(CGVector)velocity
                                                 contentInset:(UIEdgeInsets)contentInset
                                         currentContentOffset:(CGPoint)currentContentOffset
@@ -124,6 +124,6 @@
                                        scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
-                                       viewController:(UIViewController<HUBViewController> *)viewController;
+                                       viewController:(HUBViewController *)viewController;
 
 @end

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite, nullable) NSNetService *netService;
 @property (nonatomic, strong, readonly) id<HUBViewControllerFactory> viewControllerFactory;
 @property (nonatomic, strong, nullable) NSInputStream *stream;
-@property (nonatomic, weak, nullable) UIViewController<HUBViewController> *viewController;
+@property (nonatomic, weak, nullable) HUBViewController *viewController;
 @property (nonatomic, strong, nullable) HUBLiveContentOperation *contentOperation;
 
 @end
@@ -139,10 +139,10 @@ NS_ASSUME_NONNULL_BEGIN
     HUBLiveContentOperation * const contentOperation = [[HUBLiveContentOperation alloc] initWithJSONData:data];
     self.contentOperation = contentOperation;
     
-    UIViewController<HUBViewController> * const viewController = [self.viewControllerFactory createViewControllerForViewURI:viewURI
-                                                                                                          contentOperations:@[contentOperation]
-                                                                                                          featureIdentifier:@"live"
-                                                                                                               featureTitle:@"Hub Framework Live"];
+    HUBViewController * const viewController = [self.viewControllerFactory createViewControllerForViewURI:viewURI
+                                                                                        contentOperations:@[contentOperation]
+                                                                                        featureIdentifier:@"live"
+                                                                                             featureTitle:@"Hub Framework Live"];
     
     self.viewController = viewController;
     [self.delegate liveService:self didCreateViewController:viewController];

--- a/sources/HUBViewController+Initializer.h
+++ b/sources/HUBViewController+Initializer.h
@@ -20,23 +20,11 @@
  */
 
 #import "HUBViewController.h"
-#import "HUBHeaderMacros.h"
-
-@protocol HUBImageLoader;
-@protocol HUBContentReloadPolicy;
-@protocol HUBComponentLayoutManager;
-@protocol HUBActionHandler;
-@protocol HUBViewControllerScrollHandler;
-@protocol HUBComponentRegistry;
-@class HUBViewModelLoaderImplementation;
-@class HUBCollectionViewFactory;
-@class HUBInitialViewModelRegistry;
-@class HUBActionRegistryImplementation;
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// View controller that manages a Hub Framework-powered User Interface with a collection view of components
-@interface HUBViewControllerImplementation : UIViewController <HUBViewController>
+/// Extension enabling a HUBViewController instance to be initialized by the framework
+@interface HUBViewController ()
 
 /**
  *  Initialize an instance of this class with its required dependencies
@@ -60,12 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader HUB_DESIGNATED_INITIALIZER;
-
-#pragma mark - Unavailable initializers
-
-/// This class cannot be used with Interface Builder
-- (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil
-                         bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
 @end
 

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -19,7 +19,7 @@
  *  under the License.
  */
 
-#import "HUBViewControllerImplementation.h"
+#import "HUBViewController.h"
 
 #import "HUBIdentifier.h"
 #import "HUBViewModelLoaderImplementation.h"
@@ -58,7 +58,7 @@ static NSTimeInterval const HUBImageDownloadTimeThreshold = 0.07;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface HUBViewControllerImplementation () <
+@interface HUBViewController () <
     HUBViewModelLoaderDelegate,
     HUBImageLoaderDelegate,
     HUBComponentWrapperDelegate,
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation HUBViewControllerImplementation
+@implementation HUBViewController
 
 @synthesize delegate = _delegate;
 @synthesize featureIdentifier = _featureIdentifier;
@@ -1433,9 +1433,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                  @(childIndex), componentWrapper.model.identifier, @(componentWrapper.model.children.count));
     }
 
-    __weak HUBViewControllerImplementation *weakSelf = self;
+    __weak HUBViewController *weakSelf = self;
     void (^stepCompletionHandler)() = ^{
-        HUBViewControllerImplementation *strongSelf = weakSelf;
+        HUBViewController *strongSelf = weakSelf;
 
         HUBComponentWrapper *childComponentWrapper = nil;
         if (startPosition == 0) {

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -28,39 +28,39 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerDefaultScrollHandler
 
-- (BOOL)shouldShowScrollIndicatorsInViewController:(id<HUBViewController>)viewController
+- (BOOL)shouldShowScrollIndicatorsInViewController:(HUBViewController *)viewController
 {
     return YES;
 }
 
-- (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(id<HUBViewController>)viewController
+- (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(HUBViewController *)viewController
 {
     return YES;
 }
 
-- (CGFloat)scrollDecelerationRateForViewController:(id<HUBViewController>)viewController
+- (CGFloat)scrollDecelerationRateForViewController:(HUBViewController *)viewController
 {
     return UIScrollViewDecelerationRateNormal;
 }
 
-- (UIEdgeInsets)contentInsetsForViewController:(UIViewController<HUBViewController> *)viewController
+- (UIEdgeInsets)contentInsetsForViewController:(HUBViewController *)viewController
                          proposedContentInsets:(UIEdgeInsets)proposedContentInsets
 {
     return proposedContentInsets;
 }
 
-- (void)scrollingWillStartInViewController:(id<HUBViewController>)viewController
+- (void)scrollingWillStartInViewController:(HUBViewController *)viewController
                         currentContentRect:(CGRect)currentContentRect
 {
     // No-op
 }
 
-- (void)scrollingDidEndInViewController:(UIViewController<HUBViewController> *)viewController currentContentRect:(CGRect)currentContentRect
+- (void)scrollingDidEndInViewController:(HUBViewController *)viewController currentContentRect:(CGRect)currentContentRect
 {
     // No-op
 }
 
-- (CGPoint)targetContentOffsetForEndedScrollInViewController:(UIViewController<HUBViewController> *)viewController
+- (CGPoint)targetContentOffsetForEndedScrollInViewController:(HUBViewController *)viewController
                                                     velocity:(CGVector)velocity
                                                 contentInset:(UIEdgeInsets)contentInset
                                         currentContentOffset:(CGPoint)currentContentOffset
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
                                        scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
-                                       viewController:(UIViewController<HUBViewController> *)viewController
+                                       viewController:(HUBViewController *)viewController
 {
     CGRect const componentFrame = [viewController frameForBodyComponentAtIndex:componentIndex];
     CGFloat const viewHeight = CGRectGetHeight(viewController.view.frame);

--- a/sources/HUBViewControllerFactoryImplementation.m
+++ b/sources/HUBViewControllerFactoryImplementation.m
@@ -26,7 +26,7 @@
 #import "HUBComponentRegistryImplementation.h"
 #import "HUBImageLoaderFactory.h"
 #import "HUBFeatureRegistration.h"
-#import "HUBViewControllerImplementation.h"
+#import "HUBViewController+Initializer.h"
 #import "HUBCollectionViewFactory.h"
 #import "HUBInitialViewModelRegistry.h"
 #import "HUBViewControllerDefaultScrollHandler.h"
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.viewModelLoaderFactory canCreateViewModelLoaderForViewURI:viewURI];
 }
 
-- (nullable UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
+- (nullable HUBViewController *)createViewControllerForViewURI:(NSURL *)viewURI
 {
     HUBFeatureRegistration * const featureRegistration = [self.featureRegistry featureRegistrationForViewURI:viewURI];
     
@@ -102,10 +102,10 @@ NS_ASSUME_NONNULL_BEGIN
     return [self createViewControllerForViewURI:viewURI featureRegistration:featureRegistration];
 }
 
-- (UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
-                                                      contentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
-                                                      featureIdentifier:(NSString *)featureIdentifier
-                                                           featureTitle:(NSString *)featureTitle
+- (HUBViewController *)createViewControllerForViewURI:(NSURL *)viewURI
+                                    contentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
+                                    featureIdentifier:(NSString *)featureIdentifier
+                                         featureTitle:(NSString *)featureTitle
 {
     HUBViewURIPredicate * const viewURIPredicate = [HUBViewURIPredicate predicateWithViewURI:viewURI];
     id<HUBContentOperationFactory> const contentOperationFactory = [[HUBBlockContentOperationFactory alloc] initWithBlock:^NSArray<id<HUBContentOperation>> *(NSURL *_) {
@@ -123,8 +123,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Private utilities
 
-- (UIViewController<HUBViewController> *)createViewControllerForViewURI:(NSURL *)viewURI
-                                                    featureRegistration:(HUBFeatureRegistration *)featureRegistration
+- (HUBViewController *)createViewControllerForViewURI:(NSURL *)viewURI
+                                  featureRegistration:(HUBFeatureRegistration *)featureRegistration
 {
     HUBViewModelLoaderImplementation * const viewModelLoader = [self.viewModelLoaderFactory createViewModelLoaderForViewURI:viewURI
                                                                                                         featureRegistration:featureRegistration];
@@ -140,15 +140,15 @@ NS_ASSUME_NONNULL_BEGIN
     
     id<HUBViewControllerScrollHandler> const scrollHandlerToUse = featureRegistration.viewControllerScrollHandler ?: [HUBViewControllerDefaultScrollHandler new];
     
-    return [[HUBViewControllerImplementation alloc] initWithViewURI:viewURI
-                                                  featureIdentifier:featureRegistration.featureIdentifier
-                                                    viewModelLoader:viewModelLoader
-                                              collectionViewFactory:collectionViewFactory
-                                                  componentRegistry:self.componentRegistry
-                                             componentLayoutManager:self.componentLayoutManager
-                                                      actionHandler:actionHandlerWrapper
-                                                      scrollHandler:scrollHandlerToUse
-                                                        imageLoader:imageLoader];
+    return [[HUBViewController alloc] initWithViewURI:viewURI
+                                    featureIdentifier:featureRegistration.featureIdentifier
+                                      viewModelLoader:viewModelLoader
+                                collectionViewFactory:collectionViewFactory
+                                    componentRegistry:self.componentRegistry
+                               componentLayoutManager:self.componentLayoutManager
+                                        actionHandler:actionHandlerWrapper
+                                        scrollHandler:scrollHandlerToUse
+                                          imageLoader:imageLoader];
 }
 
 @end

--- a/tests/HUBLiveServiceTests.m
+++ b/tests/HUBLiveServiceTests.m
@@ -37,7 +37,7 @@
 
 @property (nonatomic, strong) HUBManager *hubManager;
 @property (nonatomic, strong) HUBLiveServiceImplementation *service;
-@property (nonatomic, strong) UIViewController<HUBViewController> *viewController;
+@property (nonatomic, strong) HUBViewController *viewController;
 
 @end
 
@@ -108,7 +108,7 @@
     
     [stream.delegate stream:stream handleEvent:NSStreamEventHasBytesAvailable];
     
-    UIViewController<HUBViewController> * const viewController = self.viewController;
+    HUBViewController * const viewController = self.viewController;
     XCTAssertNotNil(viewController);
     
     [viewController viewWillAppear:YES];
@@ -134,7 +134,7 @@
 
 #pragma mark - HUBLiveServiceDelegate
 
-- (void)liveService:(id<HUBLiveService>)liveService didCreateViewController:(UIViewController<HUBViewController> *)viewController
+- (void)liveService:(id<HUBLiveService>)liveService didCreateViewController:(HUBViewController *)viewController
 {
     XCTAssertEqual(self.service, liveService);
     self.viewController = viewController;

--- a/tests/HUBViewControllerFactoryTests.m
+++ b/tests/HUBViewControllerFactoryTests.m
@@ -115,10 +115,10 @@
         return YES;
     };
     
-    UIViewController<HUBViewController> * const viewController = [self.manager.viewControllerFactory createViewControllerForViewURI:viewURI
-                                                                                                                  contentOperations:@[contentOperation]
-                                                                                                                  featureIdentifier:@"identifier"
-                                                                                                                       featureTitle:@"Title"];
+    HUBViewController * const viewController = [self.manager.viewControllerFactory createViewControllerForViewURI:viewURI
+                                                                                                contentOperations:@[contentOperation]
+                                                                                                featureIdentifier:@"identifier"
+                                                                                                     featureTitle:@"Title"];
     
     [viewController viewWillAppear:NO];
     
@@ -177,7 +177,7 @@
         return YES;
     };
     
-    UIViewController<HUBViewController> * const viewController = [self.manager.viewControllerFactory createViewControllerForViewURI:viewURI];
+    HUBViewController * const viewController = [self.manager.viewControllerFactory createViewControllerForViewURI:viewURI];
     [viewController viewWillAppear:YES];
     
     id<HUBComponentModel> const componentModel = viewController.viewModel.bodyComponentModels[0];

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -21,7 +21,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "HUBViewControllerImplementation.h"
+#import "HUBViewController+Initializer.h"
 #import "HUBViewModelLoaderImplementation.h"
 #import "HUBContentOperationMock.h"
 #import "HUBComponentRegistryImplementation.h"
@@ -78,7 +78,7 @@
 @property (nonatomic, strong) HUBActionMock *selectionAction;
 @property (nonatomic, strong) HUBActionRegistryImplementation *actionRegistry;
 @property (nonatomic, strong) NSURL *viewURI;
-@property (nonatomic, strong) HUBViewControllerImplementation *viewController;
+@property (nonatomic, strong) HUBViewController *viewController;
 @property (nonatomic, strong) id<HUBViewModel> viewModelFromDelegateMethod;
 @property (nonatomic, strong) NSError *errorFromDelegateMethod;
 @property (nonatomic, strong) NSMutableArray<id<HUBComponentModel>> *componentModelsFromAppearanceDelegateMethod;
@@ -161,15 +161,15 @@
                                                                              initialViewModelRegistry:self.initialViewModelRegistry
                                                                                       viewModelLoader:self.viewModelLoader];
     
-    self.viewController = [[HUBViewControllerImplementation alloc] initWithViewURI:self.viewURI
-                                                                 featureIdentifier:featureInfo.identifier
-                                                                   viewModelLoader:self.viewModelLoader
-                                                             collectionViewFactory:self.collectionViewFactory
-                                                                 componentRegistry:self.componentRegistry
-                                                            componentLayoutManager:componentLayoutManager
-                                                                     actionHandler:actionHandler
-                                                                     scrollHandler:self.scrollHandler
-                                                                       imageLoader:self.imageLoader];
+    self.viewController = [[HUBViewController alloc] initWithViewURI:self.viewURI
+                                                   featureIdentifier:featureInfo.identifier
+                                                     viewModelLoader:self.viewModelLoader
+                                               collectionViewFactory:self.collectionViewFactory
+                                                   componentRegistry:self.componentRegistry
+                                              componentLayoutManager:componentLayoutManager
+                                                       actionHandler:actionHandler
+                                                       scrollHandler:self.scrollHandler
+                                                         imageLoader:self.imageLoader];
     
     self.viewController.delegate = self;
     
@@ -1567,7 +1567,7 @@
     };
     
     __block NSUInteger numberOfContentInsetCalls = 0;
-    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(UIViewController<HUBViewController> *controller, UIEdgeInsets insets) {
+    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(HUBViewController *controller, UIEdgeInsets insets) {
         numberOfContentInsetCalls += 1;
         if (numberOfContentInsetCalls == 1) {
             assertInsetsEqualToCollectionViewInsets(UIEdgeInsetsZero);
@@ -1597,7 +1597,7 @@
 
     __block NSUInteger numberOfInsetCalls = 0;
     __weak XCTestExpectation * const expectation = [self expectationWithDescription:@"The content inset handler should be asked for the content inset"];
-    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(UIViewController<HUBViewController> *controller, UIEdgeInsets proposedInsets) {
+    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(HUBViewController *controller, UIEdgeInsets proposedInsets) {
         assertInsetsEqualToCollectionViewInsets(proposedInsets, expectedInsets);
         numberOfInsetCalls += 1;
         if (numberOfInsetCalls == 2) {
@@ -1638,7 +1638,7 @@
 
     __block NSUInteger numberOfInsetCalls = 0;
     __weak XCTestExpectation * const expectation = [self expectationWithDescription:@"The content inset handler should be asked for the content inset"];
-    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(UIViewController<HUBViewController> *controller, UIEdgeInsets proposedInsets) {
+    self.scrollHandler.contentInsetHandler = ^UIEdgeInsets(HUBViewController *controller, UIEdgeInsets proposedInsets) {
         assertInsetsEqualToCollectionViewInsets(proposedInsets, expectedInsets);
         numberOfInsetCalls += 1;
         if (numberOfInsetCalls == 2) {
@@ -2586,25 +2586,25 @@
 
 #pragma mark - HUBViewControllerDelegate
 
-- (void)viewController:(UIViewController<HUBViewController> *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel
+- (void)viewController:(HUBViewController *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel
 {
     XCTAssertEqual(viewController, self.viewController);
     self.viewModelFromDelegateMethod = viewModel;
 }
 
-- (void)viewControllerDidUpdate:(UIViewController<HUBViewController> *)viewController
+- (void)viewControllerDidUpdate:(HUBViewController *)viewController
 {
     XCTAssertEqual(viewController, self.viewController);
     XCTAssertEqual(self.viewModelFromDelegateMethod, viewController.viewModel);
 }
 
-- (void)viewController:(UIViewController<HUBViewController> *)viewController didFailToUpdateWithError:(NSError *)error
+- (void)viewController:(HUBViewController *)viewController didFailToUpdateWithError:(NSError *)error
 {
     XCTAssertEqual(viewController, self.viewController);
     self.errorFromDelegateMethod = error;
 }
 
-- (void)viewControllerDidFinishRendering:(UIViewController<HUBViewController> *)viewController
+- (void)viewControllerDidFinishRendering:(HUBViewController *)viewController
 {
     XCTAssertEqual(viewController, self.viewController);
     self.didReceiveViewControllerDidFinishRendering = YES;
@@ -2614,12 +2614,12 @@
     }
 }
 
-- (BOOL)viewControllerShouldStartScrolling:(UIViewController<HUBViewController> *)viewController
+- (BOOL)viewControllerShouldStartScrolling:(HUBViewController *)viewController
 {
     return self.viewControllerShouldStartScrollingBlock();
 }
 
-- (void)viewController:(UIViewController<HUBViewController> *)viewController
+- (void)viewController:(HUBViewController *)viewController
     componentWithModel:(id<HUBComponentModel>)componentModel
           layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
       willAppearInView:(nonnull UIView *)componentView
@@ -2632,7 +2632,7 @@
     [self.componentLayoutTraitsFromAppearanceDelegateMethod addObject:layoutTraits];
 }
 
-- (void)viewController:(UIViewController<HUBViewController> *)viewController
+- (void)viewController:(HUBViewController *)viewController
     componentWithModel:(id<HUBComponentModel>)componentModel
           layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
   didDisappearFromView:(UIView *)componentView
@@ -2643,7 +2643,7 @@
     [self.componentLayoutTraitsFromDisapperanceDelegateMethod addObject:layoutTraits];
 }
 
-- (void)viewController:(UIViewController<HUBViewController> *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel
+- (void)viewController:(HUBViewController *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel
 {
     XCTAssertEqual(viewController, self.viewController);
     [self.componentModelsFromSelectionDelegateMethod addObject:componentModel];

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.h
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) void (^ _Nullable scrollingDidEndHandler)(CGRect contentRect);
 
 /// A block that can be used instead of the @c contentInset property to determine the content inset.
-@property (nonatomic, copy) UIEdgeInsets (^ _Nullable contentInsetHandler)(UIViewController<HUBViewController> *controller, UIEdgeInsets proposedOffset);
+@property (nonatomic, copy) UIEdgeInsets (^ _Nullable contentInsetHandler)(HUBViewController *controller, UIEdgeInsets proposedOffset);
 
 @end
 

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -33,22 +33,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerScrollHandlerMock
 
-- (BOOL)shouldShowScrollIndicatorsInViewController:(UIViewController<HUBViewController> *)viewController
+- (BOOL)shouldShowScrollIndicatorsInViewController:(HUBViewController *)viewController
 {
     return self.shouldShowScrollIndicators;
 }
 
-- (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(UIViewController<HUBViewController> *)viewController
+- (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(HUBViewController *)viewController
 {
     return self.shouldAutomaticallyAdjustContentInsets;
 }
 
-- (CGFloat)scrollDecelerationRateForViewController:(UIViewController<HUBViewController> *)viewController
+- (CGFloat)scrollDecelerationRateForViewController:(HUBViewController *)viewController
 {
     return self.scrollDecelerationRate;
 }
 
-- (UIEdgeInsets)contentInsetsForViewController:(UIViewController<HUBViewController> *)viewController
+- (UIEdgeInsets)contentInsetsForViewController:(HUBViewController *)viewController
                          proposedContentInsets:(UIEdgeInsets)proposedContentInsets
 {
     if (self.contentInsetHandler) {
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)scrollingWillStartInViewController:(UIViewController<HUBViewController> *)viewController
+- (void)scrollingWillStartInViewController:(HUBViewController *)viewController
                         currentContentRect:(CGRect)currentContentRect
 {
     self.startContentRect = currentContentRect;
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)scrollingDidEndInViewController:(UIViewController<HUBViewController> *)viewController
+- (void)scrollingDidEndInViewController:(HUBViewController *)viewController
                      currentContentRect:(CGRect)currentContentRect
 {
     self.endContentRect = currentContentRect;
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (CGPoint)targetContentOffsetForEndedScrollInViewController:(UIViewController<HUBViewController> *)viewController
+- (CGPoint)targetContentOffsetForEndedScrollInViewController:(HUBViewController *)viewController
                                                     velocity:(CGVector)velocity
                                                 contentInset:(UIEdgeInsets)contentInset
                                         currentContentOffset:(CGPoint)currentContentOffset
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
                                        scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
-                                       viewController:(UIViewController<HUBViewController> *)viewController
+                                       viewController:(HUBViewController *)viewController
 {
     return self.targetContentOffset;
 }


### PR DESCRIPTION
This change makes `HUBViewController` a concrete class (instead of an API protocol/implementation class pair) and exposes it as part of the public API. The initializer is still kept private (for now), since it relies on some dependencies being passed down from `HUBViewControllerFactory`.

This change is made to be more compatible with Swift, where currently `HUBViewControllerFactory` returns `UIViewController` as a type (for more info - see https://github.com/spotify/HubFramework/issues/158).