### PR TITLE
Make it possible for body component to start behind header component.

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -135,6 +135,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)viewController:(HUBViewController *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel;
 
+/**
+ *  Sent to a Hub Framework view controller's delegate to ask if content inset for header
+ *  component should be ignored
+ *
+ *  @param viewController The view controller which displays header component
+ */
+- (BOOL)viewControllerShouldIgnoreHeaderComponentContentInset:(HUBViewController *)viewController;
+
 @end
 
 /**

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Sent to a Hub Framework view controller's delegate to ask if content inset for header
  *  component should be ignored
  *
- *  @param viewController The view controller which displays header component
+ *  @param viewController The view controller which displays a header component
  */
 - (BOOL)viewControllerShouldIgnoreHeaderComponentContentInset:(HUBViewController *)viewController;
 

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -894,10 +894,18 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                           usingBatchUpdates:self.viewHasAppeared
                                    animated:animated
                                  completion:^{
+        id<HUBViewControllerDelegate> delegate = self.delegate;
+
         [self headerAndOverlayComponentViewsWillAppear];
-        CGFloat const topInset = (self.headerComponentWrapper != nil) ? CGRectGetHeight(self.headerComponentWrapper.view.frame) : [self defaultTopContentInset];
+
+        CGFloat topInset = [self defaultTopContentInset];
+        if (self.headerComponentWrapper != nil) {
+            BOOL ignoreHeaderComponentInset = [delegate viewControllerShouldIgnoreHeaderComponentContentInset:self];
+            topInset = ignoreHeaderComponentInset ? 0 : CGRectGetHeight(self.headerComponentWrapper.view.frame);
+        }
+
         [self adjustCollectionViewContentInsetWithProposedTopValue:topInset];
-        [self.delegate viewControllerDidFinishRendering:self];
+        [delegate viewControllerDidFinishRendering:self];
     }];
     
     self.viewModelHasChangedSinceLastLayoutUpdate = NO;

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -90,6 +90,7 @@
 @property (nonatomic, assign) BOOL didReceiveViewControllerDidFinishRendering;
 @property (nonatomic, copy) void (^viewControllerDidFinishRenderingBlock)(void);
 @property (nonatomic, copy) BOOL (^viewControllerShouldStartScrollingBlock)(void);
+@property (nonatomic, copy) BOOL (^viewControllerShouldIgnoreHeaderComponentInset)(void);
 
 @end
 
@@ -181,6 +182,7 @@
     self.componentModelsFromSelectionDelegateMethod = [NSMutableArray new];
     self.componentViewsFromApperanceDelegateMethod = [NSMutableArray new];
     self.viewControllerShouldStartScrollingBlock = ^{ return YES; };
+    self.viewControllerShouldIgnoreHeaderComponentInset = ^{ return NO; };
 }
 
 #pragma mark - Tests
@@ -1717,6 +1719,20 @@
     [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)testThatViewControllerCanIgnoreHeaderContentInsets
+{
+    self.viewControllerShouldIgnoreHeaderComponentInset = ^{ return YES; };
+
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        viewModelBuilder.headerComponentModelBuilder.title = @"Header";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    XCTAssertEqualWithAccuracy(self.collectionView.contentInset.top, 0, 0.001);
+}
+
 - (void)testScrollingToRootComponentUsesScrollHandler
 {
     [self registerAndGenerateComponentsWithNamespace:@"scrollToComponent"
@@ -2718,6 +2734,12 @@
 {
     XCTAssertEqual(viewController, self.viewController);
     [self.componentModelsFromSelectionDelegateMethod addObject:componentModel];
+}
+
+- (BOOL)viewControllerShouldIgnoreHeaderComponentContentInset:(HUBViewController *)viewController
+{
+    XCTAssertEqual(viewController, self.viewController);
+    return self.viewControllerShouldIgnoreHeaderComponentInset();
 }
 
 #pragma mark - Utilities


### PR DESCRIPTION
Extend HUBViewController delegate with a method that asks if we should ignore content insets for header component.