### PR TITLE
Add HUBViewController delegate method for reused

### DIFF
--- a/demo/sources/NavigationController.swift
+++ b/demo/sources/NavigationController.swift
@@ -54,6 +54,10 @@ class NavigationController: UINavigationController, HUBViewControllerDelegate {
     func viewController(_ viewController: HUBViewController, componentWith componentModel: HUBComponentModel, layoutTraits: Set<HUBComponentLayoutTrait>, didDisappearFrom componentView: UIView) {
         // No-op
     }
+
+    func viewController(_ viewController: HUBViewController, willReuseComponentWith componentView: UIView) {
+        // No-op
+    }
     
     func viewController(_ viewController: HUBViewController, componentSelectedWith componentModel: HUBComponentModel) {
         // No-op

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -128,6 +128,15 @@ NS_ASSUME_NONNULL_BEGIN
   didDisappearFromView:(UIView *)componentView;
 
 /**
+ *  Sent to a Hub Framework view controller's delegate when a component view will be reused
+ *
+ *  @param viewController The view controller in which a component view will be reused
+ *  @param componentView The component view that will be reused
+ */
+- (void)viewController:(HUBViewController *)viewController
+        willReuseComponentWithView:(UIView *)componentView;
+
+/**
  *  Sent to a Hub Framework view controller's delegate when a component was selected
  *
  *  @param viewController The view controller in which the component was selected

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -664,6 +664,11 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     if (!componentWrapper.isRootComponent) {
         [self.childComponentReusePool addComponentWrappper:componentWrapper];
     }
+
+    if (componentWrapper.view) {
+        UIView *componentView = componentWrapper.view;
+        [self.delegate viewController:self willReuseComponentWithView:componentView];
+    }
 }
 
 #pragma mark - HUBActionPerformer

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -87,6 +87,7 @@
 @property (nonatomic, strong) NSMutableArray<NSSet<HUBComponentLayoutTrait> *> *componentLayoutTraitsFromDisapperanceDelegateMethod;
 @property (nonatomic, strong) NSMutableArray<id<HUBComponentModel>> *componentModelsFromSelectionDelegateMethod;
 @property (nonatomic, strong) NSMutableArray<UIView *> *componentViewsFromApperanceDelegateMethod;
+@property (nonatomic, strong) NSMutableArray<UIView *> *componentViewsFromReuseDelegateMethod;
 @property (nonatomic, assign) BOOL didReceiveViewControllerDidFinishRendering;
 @property (nonatomic, copy) void (^viewControllerDidFinishRenderingBlock)(void);
 @property (nonatomic, copy) BOOL (^viewControllerShouldStartScrollingBlock)(void);
@@ -181,6 +182,7 @@
     self.componentLayoutTraitsFromDisapperanceDelegateMethod = [NSMutableArray new];
     self.componentModelsFromSelectionDelegateMethod = [NSMutableArray new];
     self.componentViewsFromApperanceDelegateMethod = [NSMutableArray new];
+    self.componentViewsFromReuseDelegateMethod = [NSMutableArray new];
     self.viewControllerShouldStartScrollingBlock = ^{ return YES; };
     self.viewControllerShouldIgnoreHeaderComponentInset = ^{ return NO; };
 }
@@ -1468,6 +1470,25 @@
     
     // Make sure that the component was actually reused
     XCTAssertEqual(self.component.numberOfReuses, (NSUInteger)2);
+}
+
+- (void)testViewControllerDelegateIsNotifiedWhenComponentIsReused
+{
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"one"].title = @"One";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+    UICollectionViewCell * const cell = [self.collectionView.dataSource collectionView:self.collectionView cellForItemAtIndexPath:indexPath];
+
+    XCTAssertEqualObjects(self.componentViewsFromReuseDelegateMethod, @[]);
+
+    [cell prepareForReuse];
+
+    XCTAssertEqualObjects(self.componentViewsFromReuseDelegateMethod, @[self.component.view]);
 }
 
 - (void)testSettingBackgroundColorOfViewAlsoUpdatesCollectionView
@@ -2762,6 +2783,13 @@
     
     [self.componentModelsFromDisapperanceDelegateMethod addObject:componentModel];
     [self.componentLayoutTraitsFromDisapperanceDelegateMethod addObject:layoutTraits];
+}
+
+- (void)viewController:(HUBViewController *)viewController willReuseComponentWithView:(UIView *)componentView
+{
+    XCTAssertEqual(viewController, self.viewController);
+
+    [self.componentViewsFromReuseDelegateMethod addObject:componentView];
 }
 
 - (void)viewController:(HUBViewController *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel


### PR DESCRIPTION
Extend the delegete interface to notify when a component view is being reused to allow the delegate to clean up the view before it's being reused.