### PR TITLE
Remove forward declaration of removed class

### DIFF
--- a/sources/HUBCollectionViewLayout.h
+++ b/sources/HUBCollectionViewLayout.h
@@ -25,7 +25,6 @@
 @protocol HUBViewModel;
 @protocol HUBComponentLayoutManager;
 @protocol HUBComponentRegistry;
-@class HUBScrollBehaviorWrapper;
 @class HUBViewModelDiff;
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Seems to be a left over and couldn't find any other usage of the `HUBScrollBehaviorwrapper` class.