### PR TITLE
Update to Danger 4.0.1 and Fastlane 1.110

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'danger', '~> 4.0'
 gem 'danger-junit'
 gem 'danger-xcode_summary'
-gem 'fastlane', '~> 1.106'
+gem 'fastlane', '~> 1.110'
 gem 'jazzy', '~> 0.7.2'
 gem 'xcpretty-json-formatter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       commander (>= 4.3.5)
       highline (>= 1.7.1)
       security
-    danger (4.0.0)
+    danger (4.0.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       xcpretty (>= 0.2.4, < 1.0.0)
     fastlane-plugin-trainer (0.2.0)
       trainer (>= 0.2.0)
-    fastlane_core (0.56.0)
+    fastlane_core (0.57.0)
       babosa
       colored
       commander (>= 4.4.0, <= 5.0.0)
@@ -172,8 +172,8 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    gym (1.12.0)
-      fastlane_core (>= 0.53.0, < 1.0.0)
+    gym (1.12.1)
+      fastlane_core (>= 0.57.0, < 1.0.0)
       plist (>= 3.1.0, < 4.0.0)
       rubyzip (>= 1.1.7)
       terminal-table (>= 1.4.5, < 2.0.0)
@@ -237,7 +237,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
     netrc (0.7.8)
-    octokit (4.6.1)
+    octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     os (0.9.6)
@@ -265,8 +265,8 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    scan (0.14.1)
-      fastlane_core (>= 0.53.0, < 1.0.0)
+    scan (0.14.2)
+      fastlane_core (>= 0.57.0, < 1.0.0)
       slack-notifier (~> 1.3)
       terminal-table (>= 1.4.5, < 2.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)
@@ -284,9 +284,9 @@ GEM
       jwt (~> 1.5)
       multi_json (~> 1.10)
     slack-notifier (1.5.1)
-    snapshot (1.16.3)
+    snapshot (1.16.4)
       fastimage (~> 1.6.3)
-      fastlane_core (>= 0.53.0, < 1.0.0)
+      fastlane_core (>= 0.57.0, < 1.0.0)
       plist (>= 3.1.0, < 4.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)
     spaceship (0.37.0)
@@ -342,7 +342,7 @@ DEPENDENCIES
   danger (~> 4.0)
   danger-junit
   danger-xcode_summary
-  fastlane (~> 1.106)
+  fastlane (~> 1.110)
   fastlane-plugin-trainer
   jazzy (~> 0.7.2)
   xcpretty-json-formatter


### PR DESCRIPTION
This PR fixes the malformed PR comments from Danger by updating the 4.0.1 which contains a fix for the issue.

As a “good thing to do” it also updates Fastlane to ~> 1.100 bringing in many fixes since 1.106.

@spotify/objc-dev 