### PR TITLE
Remove a component wrapper’s gesture recognizer when it’s deallocated

### DIFF
--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -97,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (void)dealloc
+{
+    [_gestureRecognizer.view removeGestureRecognizer:_gestureRecognizer];
+}
+
 #pragma mark - API
 
 - (void)viewDidMoveToSuperview:(UIView *)superview

--- a/tests/HUBComponentWrapperTests.m
+++ b/tests/HUBComponentWrapperTests.m
@@ -130,6 +130,22 @@
     XCTAssertEqual(self.selectionStateFromDidUpdateDelegateMethod, HUBComponentSelectionStateSelected);
 }
 
+- (void)testGestureRecognizerAddedAndRemovedFromSuperview
+{
+    UIView * const superview = [UIView new];
+    
+    HUBComponentMock * const component = [HUBComponentMock new];
+    id<HUBComponentModel> const model = [self componentModelWithIdentifier:@"model"];
+    HUBComponentWrapper *componentWrapper = [self componentWrapperForComponent:component model:model];
+    [componentWrapper viewDidMoveToSuperview:superview];
+    
+    XCTAssertEqualObjects(superview.gestureRecognizers, @[self.gestureRecognizer]);
+    
+    // When a component wrapper is deallocated, the gesture recognizer for it should automatically be removed
+    componentWrapper = nil;
+    XCTAssertEqualObjects(superview.gestureRecognizers, @[]);
+}
+
 #pragma mark - Utility
 
 - (HUBComponentWrapper *)componentWrapperForComponent:(id<HUBComponent>)component


### PR DESCRIPTION
This patch fixes a bug that would leave gesture recognizers orphaned in their component wrapper’s superview, because they were never removed when the wrapper was deallocated.