### PR TITLE
Add margin instead of content inset for header component

### DIFF
--- a/demo/sources/HeaderComponent.swift
+++ b/demo/sources/HeaderComponent.swift
@@ -72,13 +72,9 @@ class HeaderComponent: NSObject, HUBComponentContentOffsetObserver, HUBComponent
         guard let view = view else {
             return
         }
-        
-        if contentOffset.y > -minimumHeight {
-            view.frame.size.height = minimumHeight;
-        } else {
-            view.frame.size.height = abs(contentOffset.y);
-        }
-        
+
+        view.frame.size.height = max(maximumHeight - contentOffset.y, minimumHeight)
+
         let relativeHeight = view.frame.height / maximumHeight
         
         if relativeHeight > 1 {

--- a/demo/tests/HeaderComponentUITests.swift
+++ b/demo/tests/HeaderComponentUITests.swift
@@ -80,7 +80,7 @@ class HeaderComponentUITests: UITestCase {
         XCTAssertTrue(header.exists)
         
         // Go to the top of the view
-        (0..<numberOfSwipes).forEach { _ in
+        (0..<numberOfSwipes + 1).forEach { _ in
             collectionView.swipeDown()
         }
         

--- a/sources/HUBCollectionViewLayout.h
+++ b/sources/HUBCollectionViewLayout.h
@@ -45,11 +45,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param collectionViewSize The size of the collection view that will use this layout
  *  @param viewModel The view model used to compute the layout with
- *  @param diff The diff between the previous and current data model.
+ *  @param diff The diff between the previous and current data model
+ *  @param addHeaderMargin Whether margin should be added to account for any header component
  */
 - (void)computeForCollectionViewSize:(CGSize)collectionViewSize
                            viewModel:(id<HUBViewModel>)viewModel
-                                diff:(nullable HUBViewModelDiff *)diff;
+                                diff:(nullable HUBViewModelDiff *)diff
+                     addHeaderMargin:(BOOL)addHeaderMargin;
 
 @end
 

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -97,9 +97,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                           currentPoint:currentPoint
                                                     collectionViewSize:collectionViewSize];
 
-        UIEdgeInsets margins = [self defaultMarginsForComponent:component
-                                                     isInTopRow:componentIsInTopRow
-                                         componentsOnCurrentRow:componentsOnCurrentRow];
+        UIEdgeInsets margins = [self defaultMarginsForComponent:component isInTopRow:componentIsInTopRow
+                                         componentsOnCurrentRow:componentsOnCurrentRow
+                                             collectionViewSize:collectionViewSize];
 
         componentViewFrame.origin.x = currentPoint.x + margins.left;
 
@@ -304,16 +304,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIEdgeInsets)defaultMarginsForComponent:(id<HUBComponent>)component
                                 isInTopRow:(BOOL)componentIsInTopRow
                     componentsOnCurrentRow:(NSArray<id<HUBComponent>> *)componentsOnCurrentRow
+                        collectionViewSize:(CGSize)collectionViewSize
 {
     NSSet<HUBComponentLayoutTrait> * const componentLayoutTraits = component.layoutTraits;
     UIEdgeInsets margins = UIEdgeInsetsZero;
     
     if (componentIsInTopRow) {
         id<HUBComponentModel> const headerComponentModel = self.viewModel.headerComponentModel;
-        
+
         if (headerComponentModel != nil) {
             id<HUBComponent> const headerComponent = [self componentForModel:headerComponentModel];
-            margins.top = [self.componentLayoutManager verticalMarginBetweenComponentWithLayoutTraits:componentLayoutTraits
+            CGSize headerSize = [headerComponent preferredViewSizeForDisplayingModel:headerComponentModel containerViewSize:collectionViewSize];
+            margins.top = headerSize.height + [self.componentLayoutManager verticalMarginBetweenComponentWithLayoutTraits:componentLayoutTraits
                                                                    andHeaderComponentWithLayoutTraits:headerComponent.layoutTraits];
         } else {
             margins.top = [self.componentLayoutManager marginBetweenComponentWithLayoutTraits:componentLayoutTraits

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -68,6 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)computeForCollectionViewSize:(CGSize)collectionViewSize
                            viewModel:(id<HUBViewModel>)viewModel
                                 diff:(nullable HUBViewModelDiff *)diff
+                     addHeaderMargin:(BOOL)addHeaderMargin
 {
     self.lastViewModelDiff = diff;
     self.viewModel = viewModel;
@@ -97,9 +98,11 @@ NS_ASSUME_NONNULL_BEGIN
                                                           currentPoint:currentPoint
                                                     collectionViewSize:collectionViewSize];
 
-        UIEdgeInsets margins = [self defaultMarginsForComponent:component isInTopRow:componentIsInTopRow
+        UIEdgeInsets margins = [self defaultMarginsForComponent:component
+                                                     isInTopRow:componentIsInTopRow
                                          componentsOnCurrentRow:componentsOnCurrentRow
-                                             collectionViewSize:collectionViewSize];
+                                             collectionViewSize:collectionViewSize
+                                                addHeaderMargin:addHeaderMargin];
 
         componentViewFrame.origin.x = currentPoint.x + margins.left;
 
@@ -305,6 +308,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 isInTopRow:(BOOL)componentIsInTopRow
                     componentsOnCurrentRow:(NSArray<id<HUBComponent>> *)componentsOnCurrentRow
                         collectionViewSize:(CGSize)collectionViewSize
+                           addHeaderMargin:(BOOL)addHeaderMargin
 {
     NSSet<HUBComponentLayoutTrait> * const componentLayoutTraits = component.layoutTraits;
     UIEdgeInsets margins = UIEdgeInsetsZero;
@@ -313,10 +317,12 @@ NS_ASSUME_NONNULL_BEGIN
         id<HUBComponentModel> const headerComponentModel = self.viewModel.headerComponentModel;
 
         if (headerComponentModel != nil) {
-            id<HUBComponent> const headerComponent = [self componentForModel:headerComponentModel];
-            CGSize headerSize = [headerComponent preferredViewSizeForDisplayingModel:headerComponentModel containerViewSize:collectionViewSize];
-            margins.top = headerSize.height + [self.componentLayoutManager verticalMarginBetweenComponentWithLayoutTraits:componentLayoutTraits
-                                                                   andHeaderComponentWithLayoutTraits:headerComponent.layoutTraits];
+            if (addHeaderMargin) {
+                id<HUBComponent> const headerComponent = [self componentForModel:headerComponentModel];
+                CGSize headerSize = [headerComponent preferredViewSizeForDisplayingModel:headerComponentModel containerViewSize:collectionViewSize];
+                margins.top = headerSize.height + [self.componentLayoutManager verticalMarginBetweenComponentWithLayoutTraits:componentLayoutTraits
+                                                                                           andHeaderComponentWithLayoutTraits:headerComponent.layoutTraits];
+            }
         } else {
             margins.top = [self.componentLayoutManager marginBetweenComponentWithLayoutTraits:componentLayoutTraits
                                                                                andContentEdge:HUBComponentLayoutContentEdgeTop];

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -903,9 +903,12 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     [self configureOverlayComponents];
     [self adjustCollectionViewContentInsetWithProposedTopValue:[self calculateTopContentInset]];
     
+    BOOL const shouldAddHeaderMargin = [self shouldAutomaticallyManageTopContentInset];
+    
     [self.viewModelRenderer renderViewModel:viewModel
                           usingBatchUpdates:self.viewHasAppeared
                                    animated:animated
+                            addHeaderMargin:shouldAddHeaderMargin
                                  completion:^{
         id<HUBViewControllerDelegate> delegate = self.delegate;
 
@@ -973,9 +976,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 
 - (CGFloat)calculateTopContentInset
 {
-    id<HUBViewControllerDelegate> delegate = self.delegate;
-
-    if (delegate && ![delegate viewControllerShouldAutomaticallyManageTopContentInset:self]) {
+    if (![self shouldAutomaticallyManageTopContentInset]) {
         return 0;
     }
 
@@ -989,6 +990,17 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     CGFloat const navigationBarHeight = CGRectGetHeight(self.navigationController.navigationBar.frame);
     CGFloat const topBarHeight = MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
     return topBarHeight;
+}
+
+- (BOOL)shouldAutomaticallyManageTopContentInset
+{
+    id<HUBViewControllerDelegate> delegate = self.delegate;
+    
+    if (delegate == nil) {
+        return YES;
+    }
+    
+    return [delegate viewControllerShouldAutomaticallyManageTopContentInset:self];
 }
 
 - (void)configureHeaderComponent

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -980,11 +980,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
 
     if (self.headerComponentWrapper != nil) {
-        HUBComponentWrapper * const headerComponentWrapper = self.headerComponentWrapper;
-        CGSize const defaultHeaderSize = [headerComponentWrapper preferredViewSizeForDisplayingModel:headerComponentWrapper.model
-                                                                                   containerViewSize:self.collectionView.frame.size];
-        
-        return defaultHeaderSize.height;
+        return 0;
     }
 
     CGFloat const statusBarWidth = CGRectGetWidth([UIApplication sharedApplication].statusBarFrame);

--- a/sources/HUBViewModelRenderer.h
+++ b/sources/HUBViewModelRenderer.h
@@ -26,28 +26,30 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * A class used to render view models in a collection view.
+ *  A class used to render view models in a collection view.
  */
 @interface HUBViewModelRenderer : NSObject
 
 /**
- * Initializes a @c HUBViewModelRenderer with a provided collection view.
+ *  Initializes a @c HUBViewModelRenderer with a provided collection view.
  *
- * @param collectionView The collection view to use for rendering.
+ *  @param collectionView The collection view to use for rendering.
  */
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView HUB_DESIGNATED_INITIALIZER;
 
 /** 
- * Renders the provided view model in the collection view.
+ *  Renders the provided view model in the collection view.
  * 
- * @param viewModel The view model to render.
- * @param usingBatchUpdates Whether the renderer should render using batch updates or not.
- * @param animated Whether the renderer should render with animations or not.
- * @param completionBlock The block to be called once the rendering is completed.
+ *  @param viewModel The view model to render.
+ *  @param usingBatchUpdates Whether the renderer should render using batch updates or not.
+ *  @param animated Whether the renderer should render with animations or not.
+ *  @param addHeaderMargin Whether margin should be added to account for any header component
+ *  @param completionBlock The block to be called once the rendering is completed.
  */
 - (void)renderViewModel:(id<HUBViewModel>)viewModel
       usingBatchUpdates:(BOOL)usingBatchUpdates
                animated:(BOOL)animated
+        addHeaderMargin:(BOOL)addHeaderMargin
              completion:(void(^)(void))completionBlock;
 
 @end

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)renderViewModel:(id<HUBViewModel>)viewModel
       usingBatchUpdates:(BOOL)usingBatchUpdates
                animated:(BOOL)animated
+        addHeaderMargin:(BOOL)addHeaderMargin
              completion:(void (^)(void))completionBlock
 {
     HUBViewModelDiff *diff;
@@ -59,7 +60,10 @@ NS_ASSUME_NONNULL_BEGIN
     if (!usingBatchUpdates || diff == nil) {
         [self.collectionView reloadData];
         
-        [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:diff];
+        [layout computeForCollectionViewSize:self.collectionView.frame.size
+                                   viewModel:viewModel
+                                        diff:diff
+                             addHeaderMargin:addHeaderMargin];
 
         /* Below is a workaround for an issue caused by UICollectionView not asking for numberOfItemsInSection
            before viewDidAppear is called or instantly after a call to reloadData. If reloadData is called
@@ -81,7 +85,11 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.collectionView deleteItemsAtIndexPaths:diff.deletedBodyComponentIndexPaths];
                 [self.collectionView reloadItemsAtIndexPaths:diff.reloadedBodyComponentIndexPaths];
                 
-                [layout computeForCollectionViewSize:self.collectionView.frame.size viewModel:viewModel diff:diff];
+                [layout computeForCollectionViewSize:self.collectionView.frame.size
+                                           viewModel:viewModel
+                                                diff:diff
+                                     addHeaderMargin:addHeaderMargin];
+                
             } completion:^(BOOL finished) {
                 completionBlock();
             }];

--- a/tests/HUBCollectionViewLayoutTests.m
+++ b/tests/HUBCollectionViewLayoutTests.m
@@ -128,7 +128,7 @@
     CGSize const componentSize = self.compactComponent.preferredViewSize;
     self.componentLayoutManager.contentEdgeMarginsForLayoutTraits[self.compactComponent.layoutTraits] = @(edgeMargin);
     
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
     
     NSIndexPath * const componentIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame = [layout layoutAttributesForItemAtIndexPath:componentIndexPath].frame;
@@ -146,7 +146,7 @@
     CGFloat const edgeMargin = 20;
     self.componentLayoutManager.contentEdgeMarginsForLayoutTraits[self.compactComponent.layoutTraits] = @(edgeMargin);
     
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
     
     NSIndexPath * const componentIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame = [layout layoutAttributesForItemAtIndexPath:componentIndexPath].frame;
@@ -169,7 +169,7 @@
     CGSize const componentSize = self.fullWidthComponent.preferredViewSize;
     self.componentLayoutManager.headerMarginsForLayoutTraits[self.fullWidthComponent.layoutTraits] = @(headerMargin);
     
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:YES];
     
     NSIndexPath * const componentIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame = [layout layoutAttributesForItemAtIndexPath:componentIndexPath].frame;
@@ -192,7 +192,7 @@
     CGSize const centeredComponentSize = self.centeredComponent.preferredViewSize;
     self.componentLayoutManager.contentEdgeMarginsForLayoutTraits[self.centeredComponent.layoutTraits] = @(bottomContentEdgeMargin);
     
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
     
     CGSize const expectedCollectionViewContentSize = CGSizeMake(
         self.collectionViewSize.width,
@@ -214,7 +214,7 @@
     self.componentLayoutManager.verticalComponentMarginsForLayoutTraits[self.compactComponent.layoutTraits] = @(componentVerticalMargin);
     self.componentLayoutManager.contentEdgeMarginsForLayoutTraits[self.compactComponent.layoutTraits] = @(componentContentEdgeMargin);
 
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
 
     // H:|-15-[c1(100)][c2(100)][c3(100)]-15-|
     // but total width (330) > collectionView width (320) so component 3 have to be moved to a new row
@@ -241,7 +241,7 @@
     self.componentLayoutManager.verticalComponentMarginsForLayoutTraits[self.compactComponent.layoutTraits] = @(componentVerticalMargin);
     self.componentLayoutManager.horizontalComponentMarginsForLayoutTraits[self.compactComponent.layoutTraits] = @(CGFLOAT_MAX);
 
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
 
     // Check that the second component is on new row because it is not centered and the first one is
     NSIndexPath * const secondComponentIndexPath = [NSIndexPath indexPathForItem:1 inSection:0];
@@ -262,7 +262,7 @@
     NSArray *componentsLayoutTraits = @[self.centeredComponent.layoutTraits, self.centeredComponent.layoutTraits];
     self.componentLayoutManager.horizontalComponentOffsetsForArrayOfLayoutTraits[componentsLayoutTraits] = @(110);
 
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
 
     NSIndexPath * const componentIndexPath1 = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame1 = [layout layoutAttributesForItemAtIndexPath:componentIndexPath1].frame;
@@ -279,7 +279,7 @@
         [self addBodyComponentWithIdentifier:self.fullWidthComponentIdentifier];
     }
 
-    HUBCollectionViewLayout * const layout = [self computeLayout];
+    HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
 
     CGPoint const proposedOffset = CGPointMake(0.0, 1200.0);
     XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:proposedOffset].y, proposedOffset.y, 0.001);
@@ -297,7 +297,7 @@
     collectionView.mockedIndexPathsForVisibleItems = @[];
     
     id<HUBViewModel> const viewModelA = [self.viewModelBuilder build];
-    [layout computeForCollectionViewSize:collectionViewFrame.size viewModel:viewModelA diff:nil];
+    [layout computeForCollectionViewSize:collectionViewFrame.size viewModel:viewModelA diff:nil addHeaderMargin:YES];
     
     for (NSUInteger componentIndex = 0; componentIndex < 20; componentIndex++) {
         NSString * const componentIdentifier = [NSString stringWithFormat:@"%@", @(componentIndex)];
@@ -306,7 +306,7 @@
     
     id<HUBViewModel> const viewModelB = [self.viewModelBuilder build];
     HUBViewModelDiff * const diff = [HUBViewModelDiff diffFromViewModel:viewModelA toViewModel:viewModelB];
-    [layout computeForCollectionViewSize:collectionViewFrame.size viewModel:viewModelB diff:diff];
+    [layout computeForCollectionViewSize:collectionViewFrame.size viewModel:viewModelB diff:diff addHeaderMargin:YES];
     
     CGPoint const targetContentOffset = [layout targetContentOffsetForProposedContentOffset:CGPointZero];
     XCTAssertTrue(CGPointEqualToPoint(targetContentOffset, CGPointZero));
@@ -326,7 +326,7 @@
     HUBCollectionViewMock * const collectionView = [[HUBCollectionViewMock alloc] initWithFrame:collectionViewFrame
                                                                            collectionViewLayout:layout];
 
-    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:viewModel diff:nil];
+    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:viewModel diff:nil addHeaderMargin:YES];
 
     NSUInteger const currentIndex = 25;
     
@@ -363,7 +363,7 @@
     CGPoint const contentOffset = CGPointMake(0.0, CGRectGetMinY(topmostAttribute.frame));
     collectionView.contentOffset = contentOffset;
 
-    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:newViewModel diff:diff];
+    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:newViewModel diff:diff addHeaderMargin:YES];
 
     CGFloat expectedOffset = contentOffset.y - deletionHeight + insertionHeight;
     
@@ -380,7 +380,7 @@
     collectionView.contentInset = UIEdgeInsetsMake(27.0, 0.0, 34.0, 0.0);
 
     id<HUBViewModel> const firstViewModel = [self.viewModelBuilder build];
-    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:firstViewModel diff:nil];
+    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:firstViewModel diff:nil addHeaderMargin:YES];
     
     for (NSUInteger i = 0; i < 10; i++) {
         [self addBodyComponentWithIdentifier:self.fullWidthComponentIdentifier preferredIndex:i];
@@ -391,7 +391,7 @@
     
     collectionView.mockedIndexPathsForVisibleItems = @[[NSIndexPath indexPathForItem:9 inSection:0]];
     collectionView.contentOffset = CGPointMake(0.0, 400.0);
-    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:secondViewModel diff:firstDiff];
+    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:secondViewModel diff:firstDiff addHeaderMargin:YES];
 
     CGFloat expectedOffset = layout.collectionViewContentSize.height + collectionView.contentInset.bottom - self.collectionViewSize.height;
     XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset, 0.001);
@@ -405,7 +405,7 @@
 
     collectionView.mockedIndexPathsForVisibleItems = @[[NSIndexPath indexPathForItem:9 inSection:0]];
     collectionView.contentOffset = CGPointZero;
-    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:newViewModel diff:secondDiff];
+    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:newViewModel diff:secondDiff addHeaderMargin:YES];
 
     expectedOffset = -collectionView.contentInset.top;
     XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset, 0.001);
@@ -439,13 +439,13 @@
     }
 }
 
-- (HUBCollectionViewLayout *)computeLayout
+- (HUBCollectionViewLayout *)computeLayoutWithHeaderMargin:(BOOL)addHeaderMargin
 {
     id<HUBViewModel> const viewModel = [self.viewModelBuilder build];
     HUBCollectionViewLayout * const layout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
                                                                                  componentLayoutManager:self.componentLayoutManager];
     
-    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:viewModel diff:nil];
+    [layout computeForCollectionViewSize:self.collectionViewSize viewModel:viewModel diff:nil addHeaderMargin:addHeaderMargin];
     
     return layout;
 }

--- a/tests/HUBCollectionViewLayoutTests.m
+++ b/tests/HUBCollectionViewLayoutTests.m
@@ -173,7 +173,7 @@
     
     NSIndexPath * const componentIndexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame = [layout layoutAttributesForItemAtIndexPath:componentIndexPath].frame;
-    CGRect const expectedComponentViewFrame = CGRectMake(0, headerMargin, componentSize.width, componentSize.height);
+    CGRect const expectedComponentViewFrame = CGRectMake(0, headerMargin + componentSize.height, componentSize.width, componentSize.height);
     
     XCTAssertTrue(CGRectEqualToRect(componentViewFrame, expectedComponentViewFrame));
 }

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -2093,7 +2093,9 @@
     self.scrollHandler.shouldShowScrollIndicators = YES;
     self.scrollHandler.shouldAutomaticallyAdjustContentInsets = YES;
     self.scrollHandler.scrollDecelerationRate = UIScrollViewDecelerationRateNormal;
-    self.scrollHandler.contentInsets = UIEdgeInsetsMake(100, 30, 40, 200);
+    self.scrollHandler.contentInsetHandler = ^(HUBViewController *viewController, UIEdgeInsets proposedContentInset) {
+        return UIEdgeInsetsMake(100, 30, 40, 200);
+    };
     
     [self simulateViewControllerLayoutCycle];
     
@@ -2600,8 +2602,10 @@
 
         return YES;
     };
-
-    self.scrollHandler.contentInsets = UIEdgeInsetsMake(100, 30, 40, 200);
+    
+    self.scrollHandler.contentInsetHandler = ^(HUBViewController *viewController, UIEdgeInsets proposedContentInset) {
+        return UIEdgeInsetsMake(100, 30, 40, 200);
+    };
 
     __weak HUBViewControllerTests *weakSelf = self;
     __block CGPoint expectedOffset = CGPointZero;
@@ -2609,7 +2613,7 @@
         HUBViewControllerTests *strongSelf = weakSelf;
         CGRect componentFrame = [strongSelf.viewController frameForBodyComponentAtIndex:3];
         CGPoint offset = CGPointMake(0.0, CGRectGetMinY(componentFrame));
-        expectedOffset = CGPointMake(offset.x, offset.y - strongSelf.scrollHandler.contentInsets.top);
+        expectedOffset = CGPointMake(offset.x, offset.y - 100);
         [strongSelf.viewController scrollToContentOffset:offset animated:NO];
     };
 

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.h
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.h
@@ -35,9 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// The scroll deceleration rate that the handler should return
 @property (nonatomic, assign) CGFloat scrollDecelerationRate;
 
-/// The content insets that the handler should return
-@property (nonatomic, assign) UIEdgeInsets contentInsets;
-
 /// The target content offset that the handler should return
 @property (nonatomic, assign) CGPoint targetContentOffset;
 

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -53,9 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self.contentInsetHandler) {
         return self.contentInsetHandler(viewController, proposedContentInsets);
-    } else {
-        return self.contentInsets;
     }
+    
+    return proposedContentInsets;
 }
 
 - (void)scrollingWillStartInViewController:(HUBViewController *)viewController


### PR DESCRIPTION
Currently, when a header component is being used, the default behavior is to add top `contentInset` to account for its height. This brings some problems in non-Hub powered code, that can make assumptions about content inset that are no longer true. A more correct way of handling this (thanks @mhallendal for bringing this up!), would be to add proper top margin when we compute our `UICollectionViewLayout` - so that's what we now do!

A lot of tests were also making assumptions about `contentInset` that no longer are true, so those tests needed to be refactored to use component frames, insted of insets.

This is a step towards https://github.com/spotify/HubFramework/issues/181