### PR TITLE
Refactor the way component wrappers are managed (+ fix memory leak)

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		8A9C9CFF1DDC71930070258F /* HUBAsyncActionWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9C9CFE1DDC71930070258F /* HUBAsyncActionWrapper.m */; };
 		8A9ED75D1D4A049C006B27D8 /* HUBComponentReusePool.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9ED75C1D4A049C006B27D8 /* HUBComponentReusePool.m */; };
 		8A9ED75F1D4A24C2006B27D8 /* HUBComponentModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9ED75E1D4A24C2006B27D8 /* HUBComponentModelTests.m */; };
+		8AA124DD1DE8831B0076582D /* HUBComponentReusePoolMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA124DC1DE8831B0076582D /* HUBComponentReusePoolMock.m */; };
 		8AA29C851C4FAA9200E972B7 /* HUBComponentModelImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA29C841C4FAA9200E972B7 /* HUBComponentModelImplementation.m */; };
 		8AA29C881C4FAB6200E972B7 /* HUBComponentImageDataImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA29C871C4FAB6200E972B7 /* HUBComponentImageDataImplementation.m */; };
 		8AA29C8C1C4FAD6700E972B7 /* HUBComponentModelBuilderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA29C8B1C4FAD6700E972B7 /* HUBComponentModelBuilderImplementation.m */; };
@@ -302,6 +303,8 @@
 		8A9ED75B1D4A049C006B27D8 /* HUBComponentReusePool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentReusePool.h; sourceTree = "<group>"; };
 		8A9ED75C1D4A049C006B27D8 /* HUBComponentReusePool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentReusePool.m; sourceTree = "<group>"; };
 		8A9ED75E1D4A24C2006B27D8 /* HUBComponentModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentModelTests.m; sourceTree = "<group>"; };
+		8AA124DB1DE8831B0076582D /* HUBComponentReusePoolMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentReusePoolMock.h; sourceTree = "<group>"; };
+		8AA124DC1DE8831B0076582D /* HUBComponentReusePoolMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentReusePoolMock.m; sourceTree = "<group>"; };
 		8AA29C7F1C4FA5FE00E972B7 /* HUBComponentImageData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentImageData.h; sourceTree = "<group>"; };
 		8AA29C801C4FA7B600E972B7 /* HUBComponentModelBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentModelBuilder.h; sourceTree = "<group>"; };
 		8AA29C811C4FA8C400E972B7 /* HUBComponentImageDataBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentImageDataBuilder.h; sourceTree = "<group>"; };
@@ -751,6 +754,8 @@
 				8A5D7A711CBE5CA700B987BA /* HUBComponentFallbackHandlerMock.m */,
 				8A0F910B1D0EEBDD00C37FAE /* HUBActionHandlerMock.h */,
 				8A0F910C1D0EEBDD00C37FAE /* HUBActionHandlerMock.m */,
+				8AA124DB1DE8831B0076582D /* HUBComponentReusePoolMock.h */,
+				8AA124DC1DE8831B0076582D /* HUBComponentReusePoolMock.m */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -1295,6 +1300,7 @@
 				5284988B1DC4FC1300291C0C /* HUBInputStreamMock.m in Sources */,
 				8A89EFE81C7C866500A27EE9 /* HUBImageLoaderFactoryMock.m in Sources */,
 				8ACE24C71C6B650B0036240A /* HUBViewControllerFactoryTests.m in Sources */,
+				8AA124DD1DE8831B0076582D /* HUBComponentReusePoolMock.m in Sources */,
 				52E7FC671D9C78730053EECF /* HUBActionMock.m in Sources */,
 				8AA97C161C60C5320078F19D /* HUBFeatureRegistryTests.m in Sources */,
 				8AD00A0E1CC79F850012A9AF /* HUBIconTests.m in Sources */,

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -27,16 +27,7 @@
 @protocol HUBViewModel;
 @protocol HUBComponentModel;
 @protocol HUBImageLoader;
-@protocol HUBContentReloadPolicy;
-@protocol HUBComponentLayoutManager;
-@protocol HUBActionHandler;
-@protocol HUBViewControllerScrollHandler;
-@protocol HUBComponentRegistry;
 @class HUBViewController;
-@class HUBViewModelLoaderImplementation;
-@class HUBCollectionViewFactory;
-@class HUBInitialViewModelRegistry;
-@class HUBActionRegistryImplementation;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/sources/HUBComponentReusePool.h
+++ b/sources/HUBComponentReusePool.h
@@ -36,10 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  Initialize an instance of this class with a component registry and a UI state manager
  *
  *  @param componentRegistry The component registry to use to create new component instances
- *  @param UIStateManager The manager keeping track of component UI states
  */
-- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
-                           UIStateManager:(HUBComponentUIStateManager *)UIStateManager HUB_DESIGNATED_INITIALIZER;
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry HUB_DESIGNATED_INITIALIZER;
 
 /**
  *  Add a component wrapper to the reuse pool, enabling it to be used for other models

--- a/sources/HUBComponentReusePool.m
+++ b/sources/HUBComponentReusePool.m
@@ -22,6 +22,7 @@
 #import "HUBComponentReusePool.h"
 
 #import "HUBComponentWrapper.h"
+#import "HUBComponentUIStateManager.h"
 #import "HUBIdentifier.h"
 #import "HUBComponentModel.h"
 #import "HUBComponentRegistry.h"
@@ -40,16 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation HUBComponentReusePool
 
 - (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
-                           UIStateManager:(HUBComponentUIStateManager *)UIStateManager
 {
     NSParameterAssert(componentRegistry != nil);
-    NSParameterAssert(UIStateManager != nil);
     
     self = [super init];
     
     if (self) {
         _componentRegistry = componentRegistry;
-        _UIStateManager = UIStateManager;
+        _UIStateManager = [HUBComponentUIStateManager new];
         _componentWrappers = [NSMutableDictionary new];
     }
     

--- a/sources/HUBViewController+Initializer.h
+++ b/sources/HUBViewController+Initializer.h
@@ -21,6 +21,15 @@
 
 #import "HUBViewController.h"
 
+@protocol HUBComponentRegistry;
+@protocol HUBComponentLayoutManager;
+@protocol HUBActionHandler;
+@protocol HUBViewControllerScrollHandler;
+@protocol HUBImageLoader;
+@class HUBViewModelLoaderImplementation;
+@class HUBCollectionViewFactory;
+@class HUBComponentReusePool;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Extension enabling a HUBViewController instance to be initialized by the framework
@@ -33,7 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param featureIdentifier The identifier of the feature that this view controller is for
  *  @param viewModelLoader The object to use to load view models for the view controller
  *  @param collectionViewFactory The factory to use to create collection views
- *  @param componentRegistry The registry to use to retrieve components to render
+ *  @param componentRegistry The registry to use to lookup component information
+ *  @param componentReusePool The reuse pool to use to manage component wrappers
  *  @param componentLayoutManager The object that manages layout for components in the view controller
  *  @param actionHandler The object that will handle actions for this view controller
  *  @param scrollHandler The object that will handle scrolling for the view controller
@@ -44,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
                 viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(id<HUBComponentRegistry>)componentRegistry
+             componentReusePool:(HUBComponentReusePool *)componentReusePool
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -19,7 +19,7 @@
  *  under the License.
  */
 
-#import "HUBViewController.h"
+#import "HUBViewController+Initializer.h"
 
 #import "HUBIdentifier.h"
 #import "HUBViewModelLoaderImplementation.h"
@@ -42,7 +42,6 @@
 #import "HUBCollectionViewLayout.h"
 #import "HUBContainerView.h"
 #import "HUBContentReloadPolicy.h"
-#import "HUBComponentUIStateManager.h"
 #import "HUBViewControllerScrollHandler.h"
 #import "HUBComponentReusePool.h"
 #import "HUBActionContextImplementation.h"
@@ -71,6 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) HUBViewModelLoaderImplementation *viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
 @property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
+@property (nonatomic, strong, readonly) HUBComponentReusePool *componentReusePool;
 @property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
 @property (nonatomic, strong, readonly) id<HUBActionHandler> actionHandler;
 @property (nonatomic, strong, readonly) id<HUBViewControllerScrollHandler> scrollHandler;
@@ -88,8 +88,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSUUID *, HUBComponentWrapper *> *componentWrappersByIdentifier;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSUUID *, HUBComponentWrapper *> *componentWrappersByCellIdentifier;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, HUBComponentWrapper *> *componentWrappersByModelIdentifier;
-@property (nonatomic, strong, readonly) HUBComponentUIStateManager *componentUIStateManager;
-@property (nonatomic, strong, readonly) HUBComponentReusePool *childComponentReusePool;
 @property (nonatomic, strong, nullable) HUBComponentWrapper *highlightedComponentWrapper;
 @property (nonatomic, strong, nullable) id<HUBViewModel> viewModel;
 @property (nonatomic, assign) BOOL viewHasAppeared;
@@ -113,6 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
                 viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(id<HUBComponentRegistry>)componentRegistry
+             componentReusePool:(HUBComponentReusePool *)componentReusePool
          componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
@@ -124,6 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert(viewModelLoader != nil);
     NSParameterAssert(collectionViewFactory != nil);
     NSParameterAssert(componentRegistry != nil);
+    NSParameterAssert(componentReusePool != nil);
     NSParameterAssert(componentLayoutManager != nil);
     NSParameterAssert(actionHandler != nil);
     NSParameterAssert(scrollHandler != nil);
@@ -138,6 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
     _viewModelLoader = viewModelLoader;
     _collectionViewFactory = collectionViewFactory;
     _componentRegistry = componentRegistry;
+    _componentReusePool = componentReusePool;
     _componentLayoutManager = componentLayoutManager;
     _actionHandler = actionHandler;
     _scrollHandler = scrollHandler;
@@ -150,9 +151,6 @@ NS_ASSUME_NONNULL_BEGIN
     _componentWrappersByIdentifier = [NSMutableDictionary new];
     _componentWrappersByCellIdentifier = [NSMutableDictionary new];
     _componentWrappersByModelIdentifier = [NSMutableDictionary new];
-    _componentUIStateManager = [HUBComponentUIStateManager new];
-    _childComponentReusePool = [[HUBComponentReusePool alloc] initWithComponentRegistry:_componentRegistry
-                                                                         UIStateManager:_componentUIStateManager];
     
     viewModelLoader.delegate = self;
     viewModelLoader.actionPerformer = self;
@@ -579,9 +577,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 {
     CGSize const containerViewSize = [self childComponentContainerViewSizeForParentWrapper:componentWrapper];
     
-    HUBComponentWrapper * const childComponentWrapper = [self.childComponentReusePool componentWrapperForModel:model
-                                                                                                      delegate:self
-                                                                                                        parent:componentWrapper];
+    HUBComponentWrapper * const childComponentWrapper = [self.componentReusePool componentWrapperForModel:model
+                                                                                                 delegate:self
+                                                                                                   parent:componentWrapper];
     
     UIView * const childComponentView = HUBComponentLoadViewIfNeeded(childComponentWrapper);
     [self configureComponentWrapper:childComponentWrapper withModel:model containerViewSize:containerViewSize];
@@ -668,7 +666,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 - (void)sendComponentWrapperToReusePool:(HUBComponentWrapper *)componentWrapper
 {
     if (!componentWrapper.isRootComponent) {
-        [self.childComponentReusePool addComponentWrappper:componentWrapper];
+        [self.componentReusePool addComponentWrappper:componentWrapper];
     }
 
     if (componentWrapper.view) {
@@ -712,11 +710,14 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                                                                             forIndexPath:indexPath];
     
     if (cell.component == nil) {
-        id<HUBComponent> const component = [self.componentRegistry createComponentForModel:componentModel];
-        HUBComponentWrapper * const componentWrapper = [self wrapComponent:component withModel:componentModel];
+        HUBComponentWrapper * const componentWrapper = [self.componentReusePool componentWrapperForModel:componentModel
+                                                                                                delegate:self
+                                                                                                  parent:nil];
+        
         self.componentWrappersByCellIdentifier[cell.identifier] = componentWrapper;
         cell.component = componentWrapper;
         [componentWrapper viewDidMoveToSuperview:cell];
+        [self didAddComponentWrapper:componentWrapper];
     }
     
     HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:cell];
@@ -928,19 +929,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
 }
 
-- (HUBComponentWrapper *)wrapComponent:(id<HUBComponent>)component withModel:(id<HUBComponentModel>)model
-{
-    HUBComponentWrapper * const wrapper = [[HUBComponentWrapper alloc] initWithComponent:component
-                                                                                   model:model
-                                                                          UIStateManager:self.componentUIStateManager
-                                                                                delegate:self
-                                                                       gestureRecognizer:[HUBComponentGestureRecognizer new]
-                                                                                  parent:nil];
-    
-    [self didAddComponentWrapper:wrapper];
-    return wrapper;
-}
-
 - (void)didAddComponentWrapper:(HUBComponentWrapper *)wrapper
 {
     wrapper.delegate = self;
@@ -1008,8 +996,12 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     id<HUBComponentModel> const componentModel = self.viewModel.headerComponentModel;
     
     if (componentModel == nil) {
-        [self.headerComponentWrapper.view removeFromSuperview];
-        self.headerComponentWrapper = nil;
+        if (self.headerComponentWrapper != nil) {
+            HUBComponentWrapper * const headerComponentWrapper = self.headerComponentWrapper;
+            [self removeComponentWrapper:headerComponentWrapper];
+            self.headerComponentWrapper = nil;
+        }
+        
         return;
     }
     
@@ -1040,7 +1032,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
     
     for (HUBComponentWrapper * const unusedOverlayComponentWrapper in currentOverlayComponentWrappers) {
-        [self removeOverlayComponentWrapper:unusedOverlayComponentWrapper];
+        [self removeComponentWrapper:unusedOverlayComponentWrapper];
     }
 }
 
@@ -1068,12 +1060,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     [UIView commitAnimations];
 }
 
-- (void)removeOverlayComponentWrapper:(HUBComponentWrapper *)wrapper
-{
-    self.componentWrappersByIdentifier[wrapper.identifier] = nil;
-    [wrapper.view removeFromSuperview];
-}
-
 - (HUBComponentWrapper *)configureHeaderOrOverlayComponentWrapperWithModel:(id<HUBComponentModel>)componentModel
                                                   previousComponentWrapper:(nullable HUBComponentWrapper *)previousComponentWrapper
 {
@@ -1090,11 +1076,11 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     } else {
         if (previousComponentWrapper != nil) {
             HUBComponentWrapper * const nonNilPreviousComponentWrapper = previousComponentWrapper;
-            [self removeOverlayComponentWrapper:nonNilPreviousComponentWrapper];
+            [self removeComponentWrapper:nonNilPreviousComponentWrapper];
         }
         
-        id<HUBComponent> const component = [self.componentRegistry createComponentForModel:componentModel];
-        componentWrapper = [self wrapComponent:component withModel:componentModel];
+        componentWrapper = [self.componentReusePool componentWrapperForModel:componentModel delegate:self parent:nil];
+        [self didAddComponentWrapper:componentWrapper];
     }
     
     CGSize const containerViewSize = self.view.frame.size;
@@ -1116,6 +1102,13 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     [self addComponentWrapperToLookupTables:componentWrapper];
 
     return componentWrapper;
+}
+
+- (void)removeComponentWrapper:(HUBComponentWrapper *)wrapper
+{
+    self.componentWrappersByIdentifier[wrapper.identifier] = nil;
+    self.componentWrappersByModelIdentifier[wrapper.model.identifier] = nil;
+    [wrapper.view removeFromSuperview];
 }
 
 - (void)adjustCollectionViewContentInsetWithProposedTopValue:(CGFloat)topContentInset

--- a/sources/HUBViewControllerFactoryImplementation.m
+++ b/sources/HUBViewControllerFactoryImplementation.m
@@ -24,6 +24,7 @@
 #import "HUBViewModelLoaderFactoryImplementation.h"
 #import "HUBFeatureRegistryImplementation.h"
 #import "HUBComponentRegistryImplementation.h"
+#import "HUBComponentReusePool.h"
 #import "HUBImageLoaderFactory.h"
 #import "HUBFeatureRegistration.h"
 #import "HUBViewController+Initializer.h"
@@ -131,6 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     id<HUBImageLoader> const imageLoader = [self.imageLoaderFactory createImageLoader];
     HUBCollectionViewFactory * const collectionViewFactory = [HUBCollectionViewFactory new];
+    HUBComponentReusePool * const componentReusePool = [[HUBComponentReusePool alloc] initWithComponentRegistry:self.componentRegistry];
     
     id<HUBActionHandler> const actionHandler = featureRegistration.actionHandler ?: self.defaultActionHandler;
     id<HUBActionHandler> const actionHandlerWrapper = [[HUBActionHandlerWrapper alloc] initWithActionHandler:actionHandler
@@ -145,6 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
                                       viewModelLoader:viewModelLoader
                                 collectionViewFactory:collectionViewFactory
                                     componentRegistry:self.componentRegistry
+                                   componentReusePool:componentReusePool
                                componentLayoutManager:self.componentLayoutManager
                                         actionHandler:actionHandlerWrapper
                                         scrollHandler:scrollHandlerToUse

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -25,6 +25,7 @@
 #import "HUBViewModelLoaderImplementation.h"
 #import "HUBContentOperationMock.h"
 #import "HUBComponentRegistryImplementation.h"
+#import "HUBComponentReusePoolMock.h"
 #import "HUBIdentifier.h"
 #import "HUBJSONSChemaRegistryImplementation.h"
 #import "HUBJSONSchemaImplementation.h"
@@ -38,6 +39,7 @@
 #import "HUBComponentTarget.h"
 #import "HUBComponentFactoryMock.h"
 #import "HUBComponentMock.h"
+#import "HUBComponentWrapper.h"
 #import "HUBCollectionViewFactoryMock.h"
 #import "HUBCollectionViewMock.h"
 #import "HUBComponentLayoutManagerMock.h"
@@ -70,6 +72,7 @@
 @property (nonatomic, strong) HUBCollectionViewMock *collectionView;
 @property (nonatomic, strong) HUBCollectionViewFactoryMock *collectionViewFactory;
 @property (nonatomic, strong) HUBComponentRegistryImplementation *componentRegistry;
+@property (nonatomic, strong) HUBComponentReusePoolMock *componentReusePool;
 @property (nonatomic, strong) HUBViewControllerScrollHandlerMock *scrollHandler;
 @property (nonatomic, strong) HUBViewModelLoaderImplementation *viewModelLoader;
 @property (nonatomic, strong) HUBImageLoaderMock *imageLoader;
@@ -122,6 +125,8 @@
                                                                               JSONSchemaRegistry:JSONSchemaRegistry
                                                                                iconImageResolver:iconImageResolver];
     
+    self.componentReusePool = [[HUBComponentReusePoolMock alloc] initWithComponentRegistry:self.componentRegistry];
+    
     self.scrollHandler = [HUBViewControllerScrollHandlerMock new];
     
     self.component = [HUBComponentMock new];
@@ -168,6 +173,7 @@
                                                      viewModelLoader:self.viewModelLoader
                                                collectionViewFactory:self.collectionViewFactory
                                                    componentRegistry:self.componentRegistry
+                                                  componentReusePool:self.componentReusePool
                                               componentLayoutManager:componentLayoutManager
                                                        actionHandler:actionHandler
                                                        scrollHandler:self.scrollHandler
@@ -676,6 +682,37 @@
     XCTAssertEqual(self.component.numberOfAppearances, (NSUInteger)3);
 }
 
+- (void)testRemovingHeaderComponent
+{
+    __block BOOL shouldAddHeaderComponent = YES;
+    __weak HUBComponentWrapper *componentWrapper;
+    
+    @autoreleasepool {
+        self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+            if (shouldAddHeaderComponent) {
+                viewModelBuilder.headerComponentModelBuilder.title = @"Header";
+            }
+            
+            return YES;
+        };
+        
+        [self simulateViewControllerLayoutCycle];
+        
+        XCTAssertEqual(self.componentReusePool.componentsInUse.count, 1u);
+        componentWrapper = self.componentReusePool.componentsInUse[0];
+        HUBComponentWrapper * const strongComponentWrapper = componentWrapper;
+        XCTAssertEqualObjects(strongComponentWrapper.view, self.component.view);
+        
+        shouldAddHeaderComponent = NO;
+        [self.viewController reload];
+        [self.viewController viewDidLayoutSubviews];
+    }
+    
+    XCTAssertEqual(self.componentReusePool.componentsInUse.count, 0u);
+    XCTAssertNil(componentWrapper);
+    XCTAssertNil(self.component.view.superview);
+}
+
 - (void)testOverlayComponentReuse
 {
     HUBComponentMock * const componentA = [HUBComponentMock new];
@@ -781,34 +818,49 @@
 
 - (void)testUnreusedOverlayComponentsRemovedFromView
 {
-    __block BOOL isFirstLoad = YES;
+    __weak HUBComponentWrapper *originalComponentWrapper;
     
-    HUBComponentMock * const alternativeComponent = [HUBComponentMock new];
-    HUBComponentFactoryMock * const alternativeComponentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{@"alternative": alternativeComponent}];
-    [self.componentRegistry registerComponentFactory:alternativeComponentFactory forNamespace:@"alternative"];
-    
-    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
-        id<HUBComponentModelBuilder> const componentModelBuilder = [viewModelBuilder builderForOverlayComponentModelWithIdentifier:@"overlay"];
+    /// Here we use an autorelease pool to enable more fine grained control over object lifecycles
+    @autoreleasepool {
+        __block BOOL isFirstLoad = YES;
         
-        if (!isFirstLoad) {
-            componentModelBuilder.componentNamespace = @"alternative";
-            componentModelBuilder.componentName = @"alternative";
-        }
+        HUBComponentMock * const alternativeComponent = [HUBComponentMock new];
+        HUBComponentFactoryMock * const alternativeComponentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{@"alternative": alternativeComponent}];
+        [self.componentRegistry registerComponentFactory:alternativeComponentFactory forNamespace:@"alternative"];
         
-        isFirstLoad = NO;
+        self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+            id<HUBComponentModelBuilder> const componentModelBuilder = [viewModelBuilder builderForOverlayComponentModelWithIdentifier:@"overlay"];
+            
+            if (!isFirstLoad) {
+                componentModelBuilder.componentNamespace = @"alternative";
+                componentModelBuilder.componentName = @"alternative";
+            }
+            
+            isFirstLoad = NO;
+            
+            return YES;
+        };
         
-        return YES;
-    };
+        [self simulateViewControllerLayoutCycle];
+        XCTAssertNotNil(self.component.view.superview);
+        XCTAssertNil(alternativeComponent.view);
+        
+        XCTAssertEqual(self.componentReusePool.componentsInUse.count, 1u);
+        originalComponentWrapper = self.componentReusePool.componentsInUse[0];
+        HUBComponentWrapper * const strongOriginalComponentWrapper = originalComponentWrapper;
+        XCTAssertEqualObjects(strongOriginalComponentWrapper.view, self.component.view);
+        
+        [self.viewController reload];
+        [self.viewController viewDidLayoutSubviews];
+        
+        XCTAssertNotNil(alternativeComponent.view.superview);
+        XCTAssertNil(self.component.view.superview);
+    }
     
-    [self simulateViewControllerLayoutCycle];
-    XCTAssertNotNil(self.component.view.superview);
-    XCTAssertNil(alternativeComponent.view);
-    
-    [self.contentOperation.delegate contentOperationRequiresRescheduling:self.contentOperation];
-    [self.viewController viewDidLayoutSubviews];
-    
-    XCTAssertNotNil(alternativeComponent.view.superview);
-    XCTAssertNil(self.component.view.superview);
+    // The component wrapper for the original overlay component should now have been removed,
+    // and have been replaced by the alternative one
+    XCTAssertNil(originalComponentWrapper);
+    XCTAssertEqual(self.componentReusePool.componentsInUse.count, 1u);
 }
 
 - (void)testOverlayComponentsNotifiedOfViewWillAppear

--- a/tests/mocks/HUBComponentReusePoolMock.h
+++ b/tests/mocks/HUBComponentReusePoolMock.h
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBComponentReusePool.h"
 
 @protocol HUBComponentWrapper;

--- a/tests/mocks/HUBComponentReusePoolMock.h
+++ b/tests/mocks/HUBComponentReusePoolMock.h
@@ -1,0 +1,15 @@
+#import "HUBComponentReusePool.h"
+
+@protocol HUBComponentWrapper;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Mocked component reuse pool, for use in unit tests only
+@interface HUBComponentReusePoolMock : HUBComponentReusePool
+
+/// The components that are currently in use. The mock keeps a weak reference to these components.
+@property (nonatomic, strong, readonly) NSArray<HUBComponentWrapper *> *componentsInUse;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBComponentReusePoolMock.m
+++ b/tests/mocks/HUBComponentReusePoolMock.m
@@ -1,0 +1,49 @@
+#import "HUBComponentReusePoolMock.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBComponentReusePoolMock ()
+
+@property (nonatomic, strong, readonly) NSHashTable *mutableComponentsInUse;
+
+@end
+
+@implementation HUBComponentReusePoolMock
+
+#pragma mark - Initializer
+
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
+{
+    self = [super initWithComponentRegistry:componentRegistry];
+    
+    if (self) {
+        _mutableComponentsInUse = [NSHashTable weakObjectsHashTable];
+    }
+    
+    return self;
+}
+
+#pragma mark - HUBComponentReusePool
+
+- (HUBComponentWrapper *)componentWrapperForModel:(id<HUBComponentModel>)model
+                                         delegate:(id<HUBComponentWrapperDelegate>)delegate
+                                           parent:(nullable HUBComponentWrapper *)parent
+{
+    HUBComponentWrapper * const componentWrapper = [super componentWrapperForModel:model
+                                                                          delegate:delegate
+                                                                            parent:parent];
+    
+    [self.mutableComponentsInUse addObject:componentWrapper];
+    return componentWrapper;
+}
+
+#pragma mark - Property overrides
+
+- (NSArray<HUBComponentWrapper *> *)componentsInUse
+{
+    return self.mutableComponentsInUse.allObjects;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBComponentReusePoolMock.m
+++ b/tests/mocks/HUBComponentReusePoolMock.m
@@ -1,3 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 #import "HUBComponentReusePoolMock.h"
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
This change refactors the way that the framework manages component wrappers, to make it more streamlined:

Current situation:
- `HUBViewController` creates component wrappers for root components itself.
- `HUBComponentReusePool` is used to create & reuse child components.

New situation:
- `HUBComponentReusePool` is used to manage all component wrappers.

While doing this, I uncovered a memory leak where header & overlay component wrappers would get retained by the framework even after they were no longer needed (this would last until their view controller would be deallocated). This has now been fixed, and a unit test for it has been added.