### PR TITLE
Removes code duplication for asserting equality with accuracy

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		1D98E5BC1DC09FB500607097 /* HUBComponentActionObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentActionObserver.h; sourceTree = "<group>"; };
 		2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentFactoryMock.m; sourceTree = "<group>"; };
 		2932EAD3C06CBB869669B382 /* HUBComponentFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactoryMock.h; sourceTree = "<group>"; };
+		4E29FCF31DED2D9600856D20 /* HUBTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBTestUtilities.h; sourceTree = "<group>"; };
 		528498861DC4E8E800291C0C /* HUBLiveServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBLiveServiceTests.m; sourceTree = "<group>"; };
 		528498891DC4FC1300291C0C /* HUBInputStreamMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBInputStreamMock.h; sourceTree = "<group>"; };
 		5284988A1DC4FC1300291C0C /* HUBInputStreamMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBInputStreamMock.m; sourceTree = "<group>"; };
@@ -657,6 +658,7 @@
 			children = (
 				8A5D7A6C1CBD0F0D00B987BA /* HUBComponentDefaults+Testing.h */,
 				8A5D7A6D1CBD0F0D00B987BA /* HUBComponentDefaults+Testing.m */,
+				4E29FCF31DED2D9600856D20 /* HUBTestUtilities.h */,
 			);
 			name = Utilities;
 			path = utilities;

--- a/tests/HUBCollectionViewLayoutTests.m
+++ b/tests/HUBCollectionViewLayoutTests.m
@@ -37,6 +37,7 @@
 #import "HUBIconImageResolverMock.h"
 #import "HUBCollectionViewMock.h"
 #import "HUBViewModelDiff.h"
+#import "HUBTestUtilities.h"
 
 @interface HUBCollectionViewLayoutTests : XCTestCase
 
@@ -266,11 +267,11 @@
 
     NSIndexPath * const componentIndexPath1 = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame1 = [layout layoutAttributesForItemAtIndexPath:componentIndexPath1].frame;
-    XCTAssertEqualWithAccuracy(componentViewFrame1.origin.x, 110, 0.001);
-
+    HUBAssertEqualFloatValues(componentViewFrame1.origin.x, 110);
+    
     NSIndexPath * const componentIndexPath2 = [NSIndexPath indexPathForItem:1 inSection:0];
     CGRect const componentViewFrame2 = [layout layoutAttributesForItemAtIndexPath:componentIndexPath2].frame;
-    XCTAssertEqualWithAccuracy(componentViewFrame2.origin.x, 160, 0.001);
+    HUBAssertEqualFloatValues(componentViewFrame2.origin.x, 160);
 }
 
 - (void)testProposedContentOffsetWithoutRecomputing
@@ -282,7 +283,7 @@
     HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
 
     CGPoint const proposedOffset = CGPointMake(0.0, 1200.0);
-    XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:proposedOffset].y, proposedOffset.y, 0.001);
+    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:proposedOffset].y, proposedOffset.y);
 }
 
 - (void)testProposedContentOffsetForInitiallyAddedComponents
@@ -367,7 +368,7 @@
 
     CGFloat expectedOffset = contentOffset.y - deletionHeight + insertionHeight;
     
-    XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:contentOffset].y, expectedOffset, 0.001);
+    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:contentOffset].y, expectedOffset);
 }
 
 - (void)testProposedContentOffsetBeyondBounds
@@ -394,8 +395,8 @@
     [layout computeForCollectionViewSize:self.collectionViewSize viewModel:secondViewModel diff:firstDiff addHeaderMargin:YES];
 
     CGFloat expectedOffset = layout.collectionViewContentSize.height + collectionView.contentInset.bottom - self.collectionViewSize.height;
-    XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset, 0.001);
-
+    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset);
+    
     for (NSUInteger i = 0; i < 10; i++) {
         [self removeBodyComponentAtIndex:i];
     }
@@ -408,7 +409,7 @@
     [layout computeForCollectionViewSize:self.collectionViewSize viewModel:newViewModel diff:secondDiff addHeaderMargin:YES];
 
     expectedOffset = -collectionView.contentInset.top;
-    XCTAssertEqualWithAccuracy([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset, 0.001);
+    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset);
 }
 
 #pragma mark - Utilities

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -59,6 +59,7 @@
 #import "HUBViewControllerScrollHandlerMock.h"
 #import "HUBComponentCollectionViewCell.h"
 #import "HUBUtilities.h"
+#import "HUBTestUtilities.h"
 
 @interface HUBViewControllerTests : XCTestCase <HUBViewControllerDelegate>
 
@@ -1773,12 +1774,12 @@
 
     [self simulateViewControllerLayoutCycle];
     
-    XCTAssertEqualWithAccuracy(self.collectionView.contentInset.top, 0, 0.001);
+    HUBAssertEqualFloatValues(self.collectionView.contentInset.top, 0);
     
     // Now, let's enable and reload - content inset should now be reset
     self.viewControllerShouldAutomaticallyManageTopContentInset = ^{ return YES; };
     [self.viewController reload];
-    XCTAssertEqualWithAccuracy(self.collectionView.contentInset.top, 44, 0.001);
+    HUBAssertEqualFloatValues(self.collectionView.contentInset.top, 44);
 }
 
 - (void)testDisablingAutomaticTopInsetManagementWithHeaderComponent
@@ -1808,15 +1809,15 @@
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     UICollectionViewLayoutAttributes * const layoutAttributesA = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
     
-    XCTAssertEqualWithAccuracy(self.collectionView.contentInset.top, 0, 0.001);
-    XCTAssertEqualWithAccuracy(layoutAttributesA.frame.origin.y, 0, 0.001);
+    HUBAssertEqualFloatValues(self.collectionView.contentInset.top, 0);
+    HUBAssertEqualFloatValues(layoutAttributesA.frame.origin.y, 0);
     
     // Now, let's enable and reload - the first component should now have been pushed down by the header
     self.viewControllerShouldAutomaticallyManageTopContentInset = ^{ return YES; };
     [self.viewController reload];
     
     UICollectionViewLayoutAttributes * const layoutAttributesB = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
-    XCTAssertEqualWithAccuracy(layoutAttributesB.frame.origin.y, 400, 0.001);
+    HUBAssertEqualFloatValues(layoutAttributesB.frame.origin.y, 400);
 }
 
 - (void)testHeaderMarginAlwaysBasedOnComponentPreferredViewSize
@@ -1849,7 +1850,7 @@
     
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     UICollectionViewLayoutAttributes * const layoutAttributesA = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
-    XCTAssertEqualWithAccuracy(layoutAttributesA.frame.origin.y, 400, 0.0001);
+    HUBAssertEqualFloatValues(layoutAttributesA.frame.origin.y, 400);
     
     // If the header height is changed (for example, by the header itself, it shouldn't affect content inset)
     self.component.view.frame = CGRectMake(0, 0, 320, 100);
@@ -1859,7 +1860,7 @@
     XCTAssertEqual(self.contentOperation.performCount, 2u);
     
     UICollectionViewLayoutAttributes * const layoutAttributesB = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
-    XCTAssertEqualWithAccuracy(layoutAttributesB.frame.origin.y, 400, 0.0001);
+    HUBAssertEqualFloatValues(layoutAttributesB.frame.origin.y, 400);
 }
 
 - (void)testScrollingToRootComponentUsesScrollHandler
@@ -2135,7 +2136,7 @@
     
     XCTAssertEqual(self.collectionView.showsHorizontalScrollIndicator, YES);
     XCTAssertEqual(self.collectionView.showsVerticalScrollIndicator, YES);
-    XCTAssertEqualWithAccuracy(self.collectionView.decelerationRate, UIScrollViewDecelerationRateNormal, 0.001);
+    HUBAssertEqualFloatValues(self.collectionView.decelerationRate, UIScrollViewDecelerationRateNormal);
     XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.collectionView.contentInset, UIEdgeInsetsMake(100, 30, 40, 200)));
 }
 
@@ -2150,32 +2151,32 @@
     id<UIScrollViewDelegate> const scrollViewDelegate = self.collectionView.delegate;
     [scrollViewDelegate scrollViewWillBeginDragging:self.collectionView];
     
-    XCTAssertEqualWithAccuracy(CGRectGetMinX(self.scrollHandler.startContentRect), 0, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetMinY(self.scrollHandler.startContentRect), 200, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetWidth(self.scrollHandler.startContentRect), 320, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetHeight(self.scrollHandler.startContentRect), 480, 0.001);
+    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
+    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.startContentRect), 200);
+    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.startContentRect), 320);
+    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.startContentRect), 480);
     
     self.collectionView.contentOffset = CGPointMake(0, 800);
     [scrollViewDelegate scrollViewWillBeginDragging:self.collectionView];
     
-    XCTAssertEqualWithAccuracy(CGRectGetMinX(self.scrollHandler.startContentRect), 0, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetMinY(self.scrollHandler.startContentRect), 800, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetWidth(self.scrollHandler.startContentRect), 320, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetHeight(self.scrollHandler.startContentRect), 480, 0.001);
+    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
+    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.startContentRect), 800);
+    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.startContentRect), 320);
+    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.startContentRect), 480);
 
     self.collectionView.contentOffset = CGPointMake(0, 1200);
     [scrollViewDelegate scrollViewDidEndDragging:self.collectionView willDecelerate:NO];
-    XCTAssertEqualWithAccuracy(CGRectGetMinX(self.scrollHandler.startContentRect), 0, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetMinY(self.scrollHandler.endContentRect), 1200, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetWidth(self.scrollHandler.endContentRect), 320, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetHeight(self.scrollHandler.endContentRect), 400, 0.001);
+    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
+    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.endContentRect), 1200);
+    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.endContentRect), 320);
+    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.endContentRect), 400);
 
     self.collectionView.contentOffset = CGPointMake(0, 1240);
     [scrollViewDelegate scrollViewDidEndDecelerating:self.collectionView];
-    XCTAssertEqualWithAccuracy(CGRectGetMinX(self.scrollHandler.endContentRect), 0, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetMinY(self.scrollHandler.endContentRect), 1240, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetWidth(self.scrollHandler.endContentRect), 320, 0.001);
-    XCTAssertEqualWithAccuracy(CGRectGetHeight(self.scrollHandler.endContentRect), 360, 0.001);
+    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.endContentRect), 0);
+    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.endContentRect), 1240);
+    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.endContentRect), 320);
+    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.endContentRect), 360);
 }
 
 - (void)testScrollHandlerModifyingTargetContentOffset
@@ -2189,8 +2190,8 @@
                                                withVelocity:CGPointZero
                                         targetContentOffset:&targetContentOffset];
     
-    XCTAssertEqualWithAccuracy(targetContentOffset.x, 300, 0.001);
-    XCTAssertEqualWithAccuracy(targetContentOffset.y, 500, 0.001);
+    HUBAssertEqualFloatValues(targetContentOffset.x, 300);
+    HUBAssertEqualFloatValues(targetContentOffset.y, 500);
 }
 
 - (void)testIsViewScrolling
@@ -2592,8 +2593,8 @@
     // Sets view controller's view frame to {0, 0, 320, 400}
     [self simulateViewControllerLayoutCycle];
     
-    XCTAssertEqualWithAccuracy(self.component.view.center.x, 160, 0.001);
-    XCTAssertEqualWithAccuracy(self.component.view.center.y, 200, 0.001);
+    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualFloatValues(self.component.view.center.y, 200);
     
     CGRect const keyboardEndFrame = CGRectMake(0, 200, 320, 200);
     NSDictionary * const notificationUserInfo = @{
@@ -2607,14 +2608,14 @@
     NSNotificationCenter * const notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter postNotification:keyboardNotification];
     
-    XCTAssertEqualWithAccuracy(self.component.view.center.x, 160, 0.001);
-    XCTAssertEqualWithAccuracy(self.component.view.center.y, 100, 0.001);
+    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualFloatValues(self.component.view.center.y, 100);
     
     // Hide keyboard, which should pull the overlay component back down
     [notificationCenter postNotificationName:UIKeyboardWillHideNotification object:nil];
     
-    XCTAssertEqualWithAccuracy(self.component.view.center.x, 160, 0.001);
-    XCTAssertEqualWithAccuracy(self.component.view.center.y, 200, 0.001);
+    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualFloatValues(self.component.view.center.y, 200);
 }
 
 - (void)testScrollingToComponentAfterViewModelFinishesRendering
@@ -2688,7 +2689,7 @@
     
     // Here we force update the collection view's content size as it doesn't do it automatically when not attached to a proper window
     self.collectionView.contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize;
-    XCTAssertEqualWithAccuracy(self.collectionView.contentSize.height, 500, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentSize.height, 500);
     
     CGPoint targetContentOffset = CGPointMake(0, 500);
     self.scrollHandler.targetContentOffset = targetContentOffset;
@@ -2703,7 +2704,7 @@
     XCTAssertEqualObjects(self.viewController.viewModel.bodyComponentModels[5].identifier, @"extended-component-page-1");
     
     self.collectionView.contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize;
-    XCTAssertEqualWithAccuracy(self.collectionView.contentSize.height, 600, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentSize.height, 600);
     
     targetContentOffset = CGPointMake(0, 600);
     self.scrollHandler.targetContentOffset = targetContentOffset;
@@ -2740,16 +2741,16 @@
     
     // First verify that we can scroll the view per default
     self.collectionView.contentOffset = CGPointMake(0, 500);
-    XCTAssertEqualWithAccuracy(self.collectionView.contentOffset.y, 500, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 500);
     
     self.viewControllerShouldStartScrollingBlock = ^{ return NO; };
     self.collectionView.contentOffset = CGPointMake(0, 600);
-    XCTAssertEqualWithAccuracy(self.collectionView.contentOffset.y, 500, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 500);
     
     // Verify that scrolling works again as soon as we switch back
     self.viewControllerShouldStartScrollingBlock = ^{ return YES; };
     self.collectionView.contentOffset = CGPointMake(0, 700);
-    XCTAssertEqualWithAccuracy(self.collectionView.contentOffset.y, 700, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 700);
 }
 
 - (void)testViewControllerWithoutDelegateIsAlwaysScrollable
@@ -2778,11 +2779,11 @@
     
     // Here we force update the collection view's content size as it doesn't do it automatically when not attached to a proper window
     self.collectionView.contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize;
-    XCTAssertEqualWithAccuracy(self.collectionView.contentSize.height, 1000, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentSize.height, 1000);
     XCTAssertGreaterThan(self.collectionView.contentSize.height, CGRectGetHeight(self.collectionView.frame));
     
     self.collectionView.contentOffset = CGPointMake(0, 500);
-    XCTAssertEqualWithAccuracy(self.collectionView.contentOffset.y, 500, 0.0001);
+    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 500);
 }
 
 - (void)testThatDelegateIsNotifiedWhenOverlayAppears

--- a/tests/utilities/HUBTestUtilities.h
+++ b/tests/utilities/HUBTestUtilities.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
+//Macro that wraps assertion of equal values with accuracy
+#define HUBAssertEqualFloatValues(realValue, expectedValue) XCTAssertEqualWithAccuracy(realValue, expectedValue, 0.001)


### PR DESCRIPTION
Adds macro HUBAssertEqualFloatValues to replace XCTAssertEqualWithAccuracy as in #188.
Also adds HUBTestUtilities header for other reusable utilities functions for tests. 