### PR TITLE
Hiding a keyboard on drag implemented in the framework

### DIFF
--- a/demo/sources/SearchBarComponent.swift
+++ b/demo/sources/SearchBarComponent.swift
@@ -40,7 +40,7 @@ struct SearchBarComponentCustomDataKeys {
  *  This component uses the `customData` dictionary of `HUBComponentModel` for customization.
  *  See `SearchBarComponentCustomKeys` for what keys are used for what data.
  */
-class SearchBarComponent: NSObject, HUBComponentActionPerformer, UISearchBarDelegate, HUBComponentContentOffsetObserver {
+class SearchBarComponent: NSObject, HUBComponentActionPerformer, UISearchBarDelegate {
     var view: UIView?
     weak var actionPerformer: HUBActionPerformer?
 
@@ -124,12 +124,6 @@ class SearchBarComponent: NSObject, HUBComponentActionPerformer, UISearchBarDele
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchBar.resignFirstResponder()
-    }
-
-    // MARK: HUBComponentContentOffsetObserver
-
-    func updateView(forChangedContentOffset contentOffset: CGPoint) {
         searchBar.resignFirstResponder()
     }
 }

--- a/demo/sources/StickyHeaderContentOperation.swift
+++ b/demo/sources/StickyHeaderContentOperation.swift
@@ -33,6 +33,12 @@ class StickyHeaderContentOperation: NSObject, HUBContentOperation {
         headerBuilder.title = "A sticky header!"
         headerBuilder.backgroundImageURL = URL(string: "https://spotify.github.io/HubFramework/resources/getting-started-gothenburg.jpg")
         
+        let searchBarBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "searchBar")
+        searchBarBuilder.componentName = DefaultComponentNames.searchBar
+        searchBarBuilder.customData = [
+            SearchBarComponentCustomDataKeys.placeholder: "Dummy search bar",
+        ]
+
         for rowIndex in 0..<20 {
             let rowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "row-\(rowIndex)")
             rowBuilder.title = "Row number \(rowIndex + 1)"

--- a/demo/tests/HeaderComponentUITests.swift
+++ b/demo/tests/HeaderComponentUITests.swift
@@ -87,6 +87,21 @@ class HeaderComponentUITests: UITestCase {
         // Make sure that the header is now uncollapsed
         XCTAssertEqual(header.frame.height, 250)
     }
+
+    func testHiddingKeyboardOnDrag() {
+        navigateToStickyHeaderFeature()
+
+        let app = XCUIApplication()
+
+        let collectionview = app.collectionViews["collectionView"]
+        let searchField = collectionview.searchFields["Dummy search bar"]
+        searchField.tap()
+
+        collectionview.swipeUp()
+
+        // Make sure the keyboard is hidden
+        XCTAssert(app.keyboards.count == 0)
+    }
     
     // MARK: - Utilities
     

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -878,6 +878,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     collectionView.dataSource = self;
     collectionView.delegate = self;
 


### PR DESCRIPTION
Instead of registering a component as a `HUBComponentContentOffsetObserver` and calling `resignFirstResponder` in `updateView(forChangedContentOffset:)` we simply use `keyboardDismissMode` property which was introduced in iOS 7. 