### PR TITLE
Fix colored strings to restore original terminal color

### DIFF
--- a/live/sources/String+PrintWithColor.swift
+++ b/live/sources/String+PrintWithColor.swift
@@ -29,6 +29,7 @@ extension String {
      *  - Parameter color: The color to print the string using
      */
     func print(withColor color: AnsiColor) {
-        Swift.print(color.rawValue + self)
+        /// Append a reset color code to the string, to clear all colors and styles
+        Swift.print(color.rawValue + self + "\u{001B}[0;0m")
     }
 }


### PR DESCRIPTION
A potential fix for #163. It simply appends a white Ansi color code when printing colored strings. This successfully restores the original terminal color.

I'm not sure how you would create a unit test for something like this, but would love to hear any suggestions.