### PR TITLE
JSON schema registry: Add API for unregistering a custom schema

### DIFF
--- a/include/HubFramework/HUBJSONSchemaRegistry.h
+++ b/include/HubFramework/HUBJSONSchemaRegistry.h
@@ -68,6 +68,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)registerCustomSchema:(id<HUBJSONSchema>)schema forIdentifier:(NSString *)identifier;
 
+/**
+ *  Unregister a custom JSON schema from the Hub Framework
+ *
+ *  @param identifier The identifier to unregister a schema for
+ *
+ *  Calling this will remove the custom JSON schema from the framework, opening up the identifier for use by other schemas.
+ */
+- (void)unregisterCustomSchemaWithIdentifier:(NSString *)identifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBJSONSchemaRegistryImplementation.m
+++ b/sources/HUBJSONSchemaRegistryImplementation.m
@@ -76,6 +76,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self.customSchemasByIdentifier setObject:schema forKey:identifier];
 }
 
+- (void)unregisterCustomSchemaWithIdentifier:(NSString *)identifier
+{
+    [self.customSchemasByIdentifier removeObjectForKey:identifier];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/HUBJSONSchemaRegistryTests.m
+++ b/tests/HUBJSONSchemaRegistryTests.m
@@ -52,12 +52,15 @@
 
 #pragma mark - Tests
 
-- (void)testRegisteringAndRetrievingCustomSchema
+- (void)testRegisteringRetrievingAndRemovingCustomSchema
 {
     id<HUBJSONSchema> const customSchema = [self.registry createNewSchema];
     NSString * const customSchemaIdentifier = @"custom";
     [self.registry registerCustomSchema:customSchema forIdentifier:customSchemaIdentifier];
     XCTAssertEqualObjects([self.registry customSchemaForIdentifier:customSchemaIdentifier], customSchema);
+    
+    [self.registry unregisterCustomSchemaWithIdentifier:customSchemaIdentifier];
+    XCTAssertNil([self.registry customSchemaForIdentifier:customSchemaIdentifier]);
 }
 
 - (void)testRetrievingUnknownSchemaReturnsNil


### PR DESCRIPTION
Was not yet implemented for some reason. All other registries offer an unregistration API, so makes sense for the JSON schema one to do so too.