### PR TITLE
Fix Danger choking on nil junit report path

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -34,7 +34,8 @@ xcode_summary.report 'build/demo/summary.json' if File.file?('build/demo/summary
 
 def report_junit_results(path)
   junit_report_path = Dir.glob(path + "/*TestSummaries.junit").first
-  if File.readable_real?(junit_report_path)
+
+  if !junit_report_path.nil? and File.readable_real?(junit_report_path)
     junit.parse junit_report_path
     junit.report
   else


### PR DESCRIPTION
There seems to be a bug in our Dangerfile ruby that leads to Danger failing and existing with a non-zero status. It appears it’s because `junit_report_path` is `nil` if the tests weren’t even ran. Which is the case if the license header check failed.

```
[21:18:35]: $ bundle exec danger
[21:18:37]: ▸ bundler: failed to load command: danger (/Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/bin/danger)
[21:18:37]: ▸ Danger::DSLError: 
[21:18:37]: ▸ [!] Invalid `Dangerfile` file: no implicit conversion of nil into String
[21:18:37]: ▸ #  from Dangerfile:37
[21:18:37]: ▸ #  -------------------------------------------
[21:18:37]: ▸ #    junit_report_path = Dir.glob(path + "/*TestSummaries.junit").first
[21:18:37]: ▸ >    if File.readable_real?(junit_report_path)
[21:18:37]: ▸ #      junit.parse junit_report_path
[21:18:37]: ▸ #  -------------------------------------------
[21:18:37]: ▸ Dangerfile:37:in `readable_real?'
[21:18:37]: ▸ Dangerfile:37:in `report_junit_results'
[21:18:37]: ▸ Dangerfile:46:in `block in parse'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/danger_core/dangerfile.rb:199:in `eval'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/danger_core/dangerfile.rb:199:in `block in parse'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/danger_core/dangerfile.rb:195:in `instance_eval'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/danger_core/dangerfile.rb:195:in `parse'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/danger_core/dangerfile.rb:272:in `run'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/danger_core/executor.rb:27:in `run'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/lib/danger/commands/runner.rb:66:in `run'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/gems/danger-4.0.1/bin/danger:5:in `<top (required)>'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/bin/danger:23:in `load'
[21:18:37]: ▸ /Users/travis/build/spotify/HubFramework/vendor/bundle/ruby/2.2.0/bin/danger:23:in `<top (required)>'
```

@spotify/objc-dev 