### PR TITLE
Swift refinement: Tweak simplest API for creating a view controller

### DIFF
--- a/include/HubFramework/HUBViewControllerFactory.h
+++ b/include/HubFramework/HUBViewControllerFactory.h
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  title into lowercase characters.
  */
 - (HUBViewController *)createViewControllerWithContentOperations:(NSArray<id<HUBContentOperation>> *)contentOperations
-                                                    featureTitle:(NSString *)featureTitle;
+                                                    featureTitle:(NSString *)featureTitle NS_SWIFT_NAME(createViewController(withContentOperations:featureTitle:));
 
 /**
  *  Create a view controller without a feature registration, with explicit identifiers


### PR DESCRIPTION
Before:

```swift
viewControllerFactory.createViewController(with:featureTitle:)
```

After:

```swift
viewControllerFactory.createViewController(withContentOperations:featureTitle:)
```

Using only `for:`, it’s not clear that the parameter refers to an array of content operations.