### PR TITLE
Automatically manage selection for child components

### DIFF
--- a/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
+++ b/demo/HubFrameworkDemo.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		8AD98C521DD5F25900F01A62 /* HeaderComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD98C511DD5F25900F01A62 /* HeaderComponent.swift */; };
 		8AD98C561DD5F5FE00F01A62 /* StickyHeaderContentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD98C551DD5F5FE00F01A62 /* StickyHeaderContentOperation.swift */; };
 		8AD98C591DD6062100F01A62 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD98C581DD6062100F01A62 /* NavigationController.swift */; };
+		8AE6BD2E1DF1BF780063B2B1 /* ColorContainerComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE6BD2D1DF1BF780063B2B1 /* ColorContainerComponent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -127,6 +128,7 @@
 		8AD98C511DD5F25900F01A62 /* HeaderComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderComponent.swift; sourceTree = "<group>"; };
 		8AD98C551DD5F5FE00F01A62 /* StickyHeaderContentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickyHeaderContentOperation.swift; sourceTree = "<group>"; };
 		8AD98C581DD6062100F01A62 /* NavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
+		8AE6BD2D1DF1BF780063B2B1 /* ColorContainerComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorContainerComponent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -250,6 +252,7 @@
 				8AD5EDC71D9A9C3C004B2CEA /* ActivityIndicatorComponent.swift */,
 				8AB850951DBF9DE300AFAFD0 /* CarouselComponent.swift */,
 				8AD98C511DD5F25900F01A62 /* HeaderComponent.swift */,
+				8AE6BD2D1DF1BF780063B2B1 /* ColorContainerComponent.swift */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -472,6 +475,7 @@
 				8AD72F571D9AC22600E4B427 /* ImageComponent.swift in Sources */,
 				8A2729A21D95486A00EF43FC /* URL+ViewURIs.swift in Sources */,
 				8AD98C521DD5F25900F01A62 /* HeaderComponent.swift in Sources */,
+				8AE6BD2E1DF1BF780063B2B1 /* ColorContainerComponent.swift in Sources */,
 				8AB850961DBF9DE300AFAFD0 /* CarouselComponent.swift in Sources */,
 				8AD98C591DD6062100F01A62 /* NavigationController.swift in Sources */,
 				8A374D001DBE659E0013E592 /* TodoListAddAction.swift in Sources */,

--- a/demo/sources/CarouselComponent.swift
+++ b/demo/sources/CarouselComponent.swift
@@ -143,10 +143,6 @@ class CarouselComponent: NSObject, HUBComponentWithChildren, HUBComponentWithRes
         childDelegate?.component(self, didStopDisplayingChildAt: UInt(indexPath.item), view: cell)
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        childDelegate?.component(self, childSelectedAt: UInt(indexPath.item), customData:nil)
-    }
-    
     // MARK: - Private utilities
     
     private static func makeCollectionViewLayout() -> UICollectionViewLayout {

--- a/demo/sources/ColorContainerComponent.swift
+++ b/demo/sources/ColorContainerComponent.swift
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import Foundation
+import HubFramework
+
+/**
+ *  A component that wraps a single child component and adds a colored background around it
+ *
+ *  This component is compatible with the following model data:
+ *
+ *  - customData["color"] (as String)
+ *  - children (only the first one is handled)
+ */
+class ColorContainerComponent: NSObject, HUBComponentWithChildren, HUBComponentViewObserver {
+    /// Structure containing custom data keys used by `ColorContainerComponent`
+    struct CustomDataKeys {
+        /// The key used to encode a color (a String value is expected)
+        static var color: String { return "color" }
+    }
+    
+    /// Enum containing all colors that `ColorContainerComponent` supports
+    enum Color: String {
+        case red
+        case blue
+        case green
+        case yellow
+    }
+    
+    var view: UIView?
+    weak var childDelegate: HUBComponentChildDelegate?
+    private var childComponent: HUBComponent? {
+        didSet {
+            guard childComponent !== oldValue else {
+                return
+            }
+            
+            oldValue?.view?.removeFromSuperview()
+            
+            guard let childView = childComponent?.view else {
+                return
+            }
+            
+            view?.addSubview(childView)
+        }
+    }
+    
+    // MARK: - HUBComponent
+    
+    var layoutTraits: Set<HUBComponentLayoutTrait> {
+        return [.fullWidth, .stackable]
+    }
+
+    func loadView() {
+        view = UIView()
+    }
+
+    func preferredViewSize(forDisplaying model: HUBComponentModel, containerViewSize: CGSize) -> CGSize {
+        guard let childModel = model.child(at: 0) else {
+            return .zero
+        }
+        
+        guard let childComponent = childDelegate?.component(self, childComponentFor: childModel) else {
+            return .zero
+        }
+        
+        var size = childComponent.preferredViewSize(forDisplaying: childModel, containerViewSize: containerViewSize)
+        size.width += ComponentMargin * 2
+        size.height += ComponentMargin * 2
+        return size
+    }
+
+    func prepareViewForReuse() {
+        // No-op
+    }
+
+    func configureView(with model: HUBComponentModel, containerViewSize: CGSize) {
+        view?.backgroundColor = color(fromModel: model)
+        
+        if let childModel = model.child(at: 0) {
+            childComponent = childDelegate?.component(self, childComponentFor: childModel)
+        } else {
+            childComponent = nil
+        }
+    }
+    
+    // MARK: - HUBComponentViewObserver
+    
+    func viewDidResize() {
+        guard let view = view else {
+            return
+        }
+        
+        childComponent?.view?.frame = CGRect(
+            x: ComponentMargin,
+            y: ComponentMargin,
+            width: view.frame.width - ComponentMargin * 2,
+            height: view.frame.height - ComponentMargin * 2
+        )
+    }
+    
+    func viewWillAppear() {
+        // No-op
+    }
+    
+    // MARK: - Private utilities
+    
+    private func color(fromModel model: HUBComponentModel) -> UIColor? {
+        guard let colorString = model.customData?[CustomDataKeys.color] as? String else {
+            return nil
+        }
+        
+        return Color(rawValue: colorString)?.color
+    }
+}
+
+private extension ColorContainerComponent.Color {
+    var color: UIColor {
+        switch self {
+        case .red:
+            return .red
+        case .blue:
+            return .blue
+        case .green:
+            return .green
+        case .yellow:
+            return .yellow
+        }
+    }
+}

--- a/demo/sources/DefaultComponentFactory.swift
+++ b/demo/sources/DefaultComponentFactory.swift
@@ -33,7 +33,8 @@ class DefaultComponentFactory: NSObject, HUBComponentFactory {
         DefaultComponentNames.searchBar: { SearchBarComponent() },
         DefaultComponentNames.activityIndicator: { ActivityIndicatorComponent() },
         DefaultComponentNames.carousel: { CarouselComponent() },
-        DefaultComponentNames.header: { HeaderComponent() }
+        DefaultComponentNames.header: { HeaderComponent() },
+        DefaultComponentNames.colorContainer: { ColorContainerComponent() }
     ]
     
     func createComponent(forName name: String) -> HUBComponent? {

--- a/demo/sources/DefaultComponentNames.swift
+++ b/demo/sources/DefaultComponentNames.swift
@@ -37,4 +37,6 @@ struct DefaultComponentNames {
     static var carousel: String { return "carousel" }
     /// A sticky header component - maps to `HeaderComponent`
     static var header: String { return "header" }
+    /// A container that wraps a component and adds a background color - maps to `ColorContainerComponent`
+    static var colorContainer: String { return "colorContainer" }
 }

--- a/demo/sources/StickyHeaderContentOperation.swift
+++ b/demo/sources/StickyHeaderContentOperation.swift
@@ -42,8 +42,12 @@ class StickyHeaderContentOperation: NSObject, HUBContentOperation {
         let reloadCountRowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "row-reloadCount")
         reloadCountRowBuilder.title = "Number of reloads: \(performCount)"
         
-        // Add a link to the "Pretty pictures" feature, for use in UI tests
-        let prettyPicturesRowBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "row-prettyPictures")
+        // Add a button to go to the "Pretty pictures" feature, for use in UI tests, wrapped in a color container
+        let colorContainerBuilder = viewModelBuilder.builderForBodyComponentModel(withIdentifier: "colorContainer")
+        colorContainerBuilder.componentName = DefaultComponentNames.colorContainer
+        colorContainerBuilder.customData = [ColorContainerComponent.CustomDataKeys.color: ColorContainerComponent.Color.green.rawValue]
+        
+        let prettyPicturesRowBuilder = colorContainerBuilder.builderForChild(withIdentifier: "row-prettyPictures")
         prettyPicturesRowBuilder.title = "Go to Pretty Pictures"
         prettyPicturesRowBuilder.targetBuilder.uri = .prettyPicturesViewURI
         

--- a/demo/tests/SelectionUITests.swift
+++ b/demo/tests/SelectionUITests.swift
@@ -66,12 +66,12 @@ class SelectionUITests: UITestCase {
         XCTAssertTrue(rootCell.exists)
         
         let carouselCellA = rootCell.cells.element(boundBy: 0)
-        let carouselCellB = rootCell.cells.element(boundBy: 1)
+        let carouselCellB = rootCell.cells.element(boundBy: 2)
         XCTAssertTrue(carouselCellA.exists)
         XCTAssertTrue(carouselCellB.exists)
         
         // Start pressing, then move to the next cell. No selection should happen = we're still in pretty pictures
-        carouselCellA.press(forDuration: 1, thenDragTo: carouselCellB)
+        carouselCellA.press(forDuration: 3, thenDragTo: carouselCellB)
         XCTAssertTrue(app.navigationBars["Pretty Pictures"].exists)
     }
 

--- a/demo/tests/SelectionUITests.swift
+++ b/demo/tests/SelectionUITests.swift
@@ -22,12 +22,11 @@
 import XCTest
 
 class SelectionUITests: UITestCase {
-    func testTappingTopLevelComponent() {
+    func testSelectingRootComponent() {
         let app = XCUIApplication()
 
         // Tap "Pretty pictures" and make sure we navigate to that page.
-        app.collectionViews.staticTexts["Pretty pictures"].tap()
-        XCTAssertTrue(app.navigationBars["Pretty Pictures"].exists)
+        navigateToPrettyPictures()
 
         // Tap the 2nd cell (index 1)
         let collectionView = rootCollectionView(for:app)
@@ -39,12 +38,11 @@ class SelectionUITests: UITestCase {
         XCTAssertFalse(app.navigationBars["Pretty Pictures"].exists)
     }
 
-    func testTappingNestedComponent() {
+    func testSelectingChildComponent() {
         let app = XCUIApplication()
 
         // Tap "Pretty pictures" and make sure we navigate to that page.
-        app.collectionViews.staticTexts["Pretty pictures"].tap()
-        XCTAssertTrue(app.navigationBars["Pretty Pictures"].exists)
+        navigateToPrettyPictures()
 
         // Tap the 2nd cell (index 1) in the 1st row (index 0)
         let collectionView = rootCollectionView(for:app)
@@ -55,6 +53,26 @@ class SelectionUITests: UITestCase {
 
         // Assert we've navigated away...
         XCTAssertFalse(app.navigationBars["Pretty Pictures"].exists)
+    }
+    
+    func testChildSelectionCancelledOnParentScrolling() {
+        let app = XCUIApplication()
+        navigateToPrettyPictures()
+        
+        let collectionView = rootCollectionView(for: app)
+        XCTAssertTrue(collectionView.exists)
+        
+        let rootCell = collectionView.children(matching: .cell).element(boundBy: 0)
+        XCTAssertTrue(rootCell.exists)
+        
+        let carouselCellA = rootCell.cells.element(boundBy: 0)
+        let carouselCellB = rootCell.cells.element(boundBy: 1)
+        XCTAssertTrue(carouselCellA.exists)
+        XCTAssertTrue(carouselCellB.exists)
+        
+        // Start pressing, then move to the next cell. No selection should happen = we're still in pretty pictures
+        carouselCellA.press(forDuration: 1, thenDragTo: carouselCellB)
+        XCTAssertTrue(app.navigationBars["Pretty Pictures"].exists)
     }
 
     /// This function walks the view hierarchy to find the hub framework's collection view.
@@ -67,5 +85,11 @@ class SelectionUITests: UITestCase {
         let viewControllerWrapperView = navigationTransitionView.children(matching: .other).element
         let hubContainerView = viewControllerWrapperView.children(matching: .other).element
         return hubContainerView.children(matching: .collectionView).element
+    }
+    
+    private func navigateToPrettyPictures() {
+        let app = XCUIApplication()
+        app.collectionViews.staticTexts["Pretty pictures"].tap()
+        XCTAssertTrue(app.navigationBars["Pretty Pictures"].exists)
     }
 }

--- a/include/HubFramework/HUBComponentWithChildren.h
+++ b/include/HubFramework/HUBComponentWithChildren.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  to be truly dynamic with which child components they support.
  *
  *  Components created this way are retained and managed by the Hub Framework, and reused whenever they are sent the
- *  `prepareViewForReuse` message.
+ *  `prepareViewForReuse` message. Selection for them is also automatically handled, just like it is for root components.
  *
  *  @return A component that was either newly created, or reused - if an inactive component of the same type was available.
  *          The component will have its view loaded and resized according to its parent and the component's `preferredViewSize`,
@@ -80,16 +80,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)component:(id<HUBComponentWithChildren>)component didStopDisplayingChildAtIndex:(NSUInteger)childIndex view:(UIView *)childView;
 
 /**
- *  Notify the Hub Framework that a component's child component has been selected
+ *  Notify the Hub Framework that a custom child component view was selected
  *
  *  @param component The parent component
  *  @param childIndex The index of the child component that was selected
- *  @param customData  Any custom data to use when the selection is handled. Will be available on the `HUBActionContext` passed to any actions handling the selection.
+ *  @param customData Any custom data to use when the selection is handled. Will be available on the `HUBActionContext`
+ *         passed to any actions handling the selection.
  *
- *  If your component has nested child components, you should call this method every time a child component was
- *  selected by the user, to enable the Hub Framework to handle the selection.
+ *  If you implement your child components as custom `UIViews` (that is, not using `HUBComponent` implementations resolved
+ *  using `childDelegate`), you can call this method to have the Hub Framework perform selection handling on behalf of your
+ *  child component.
+ *
+ *  If you are not using custom views, but rather nested `HUBComponent` implementations, you don't have to call this method,
+ *  as the Hub Framework will automatically manage selection for those components.
  */
-- (void)component:(id<HUBComponentWithChildren>)component childSelectedAtIndex:(NSUInteger)childIndex customData:(nullable NSDictionary<NSString *, id> *)customData;
+- (void)component:(id<HUBComponentWithChildren>)component
+        childWithCustomViewSelectedAtIndex:(NSUInteger)childIndex
+        customData:(nullable NSDictionary<NSString *, id> *)customData;
 
 @end
 

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -233,7 +233,9 @@ NS_ASSUME_NONNULL_BEGIN
     // No-op
 }
 
-- (void)component:(id<HUBComponentWithChildren>)component childSelectedAtIndex:(NSUInteger)childIndex customData:(nullable NSDictionary *)customData
+- (void)component:(id<HUBComponentWithChildren>)component
+        childWithCustomViewSelectedAtIndex:(NSUInteger)childIndex
+        customData:(nullable NSDictionary<NSString *, id> *)customData
 {
     // No-op
 }

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL shouldPerformDelayedHighlight;
 @property (nonatomic, assign) NSUInteger appearanceCount;
 @property (nonatomic, assign) HUBComponentSelectionState selectionState;
+@property (nonatomic, assign) CGRect interactionStartViewFrameInWindow;
 
 @end
 
@@ -378,9 +379,16 @@ NS_ASSUME_NONNULL_BEGIN
                 didDisappearAtIndex:childIndex];
 }
 
-- (void)component:(id<HUBComponentWithChildren>)component childSelectedAtIndex:(NSUInteger)childIndex customData:(nullable NSDictionary<NSString *, id> *)customData
+- (void)component:(id<HUBComponentWithChildren>)component
+        childWithCustomViewSelectedAtIndex:(NSUInteger)childIndex
+        customData:(nullable NSDictionary<NSString *, id> *)customData
 {
     if (self.component != component) {
+        return;
+    }
+    
+    // If this is accidentially called by the API user (for a managed component) - simply ignore it
+    if (self.childrenByIndex[@(childIndex)] != nil) {
         return;
     }
     
@@ -445,9 +453,19 @@ NS_ASSUME_NONNULL_BEGIN
     
     switch (gestureRecognizer.state) {
         case UIGestureRecognizerStatePossible:
-        case UIGestureRecognizerStateChanged:
             break;
+        case UIGestureRecognizerStateChanged: {
+            CGRect const currentViewFrameInWindow = [self calculateViewFrameInWindow];
+            
+            if (!CGRectEqualToRect(self.interactionStartViewFrameInWindow, currentViewFrameInWindow)) {
+                [self.gestureRecognizer cancel];
+            }
+            
+            break;
+        }
         case UIGestureRecognizerStateBegan: {
+            self.interactionStartViewFrameInWindow = [self calculateViewFrameInWindow];
+            
             self.shouldPerformDelayedHighlight = YES;
             [delegate componentWrapper:self willUpdateSelectionState:HUBComponentSelectionStateHighlighted];
             
@@ -546,6 +564,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (notifyDelegate) {
         [self.delegate componentWrapper:self didUpdateSelectionState:selectionState];
     }
+}
+
+- (CGRect)calculateViewFrameInWindow
+{
+    UIView * const view = HUBComponentLoadViewIfNeeded(self);
+    UIWindow * const window = [UIApplication sharedApplication].keyWindow;
+    return [window convertRect:view.frame fromView:view.superview];
 }
 
 @end

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -598,6 +598,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     childComponentView.frame = CGRectMake(0, 0, preferredViewSize.width, preferredViewSize.height);
     
     [self loadImagesForComponentWrapper:childComponentWrapper childIndex:nil];
+    [childComponentWrapper viewDidMoveToSuperview:HUBComponentLoadViewIfNeeded(componentWrapper)];
     
     return childComponentWrapper;
 }


### PR DESCRIPTION
This change makes the Hub Framework assume the responsibility of handling selection for child components, when those components were created through the framework (and not by using a custom `UIView`).

It’s become clear that it’s ambiguous (and very cumbersome) for each component to have to manually handle selection for its children. As long as we were mostly implementing containers (such as Carousels) as components with children, this was fine, as we could leverage nested `UICollectionViews` and `HUBComponentCollectionViewCell`. However, as we are creating more and more complex component hierarchies, with containers that add backgrounds and other fancy stuff - it started to become a problem.

So, with this change, parent components are no longer responsible for the selection of their children. The `component(_:childSelectedAt:customData:)` delegate method has been replaced with `component(_:childWithCustomViewSelectedAt:customData:)`, to clearly signal that this method is only meant to be called for custom `UIView` children.

The implementation is using the same `HUBComponentGestureRecognizer` as for root components to handle selection, and it now also keeps track of the frame of a component, so that nested scrolling (such as in a carousel) can be handled in the correct way.