### PR TITLE
Add ability to perform actions from scroll handler

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 		DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBUtilities.h; sourceTree = "<group>"; };
 		DDBCF36B1C68DD2300693038 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		E9B84D441DF6ED48009E57D5 /* HUBViewControllerScrollHandlerActionPerformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerScrollHandlerActionPerformer.h; sourceTree = "<group>"; };
 		F64C5C2B1DB82CA30077E619 /* HUBViewModelRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelRenderer.h; sourceTree = "<group>"; };
 		F64C5C2C1DB82CA30077E619 /* HUBViewModelRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewModelRenderer.m; sourceTree = "<group>"; };
 		F65C149A1DC93AEB0030958D /* HUBComponentWithScrolling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentWithScrolling.h; sourceTree = "<group>"; };
@@ -1125,6 +1126,7 @@
 				8AD064771C6906B00086C081 /* HUBViewControllerFactory.h */,
 				8A0E4B761CB561DE0019DE71 /* HUBViewURIPredicate.h */,
 				8AED9F8F1D77090D00BEFD66 /* HUBViewControllerScrollHandler.h */,
+				E9B84D441DF6ED48009E57D5 /* HUBViewControllerScrollHandlerActionPerformer.h */,
 			);
 			name = View;
 			sourceTree = "<group>";

--- a/include/HubFramework/HUBViewControllerScrollHandlerActionPerformer.h
+++ b/include/HubFramework/HUBViewControllerScrollHandlerActionPerformer.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBViewControllerScrollHandler.h"
+
+@protocol HUBActionPerformer;
+
+/**
+ *  Extended scroll handler protocol that adds the ability to perform actions
+ *
+ *  Use this protocol whenever you want your scroll handler to be able to perform
+ *  actions. Actions can be used to perform small, atomic tasks and provide a lightweight way
+ *  to extend the Hub Framework with additional functionality.
+ *
+ *  For more information about actions, see `HUBAction`, as well as the "Action programming
+ *  guide" available at https://spotify.github.io/HubFramework/action-programming-guide.html.
+ *
+ *  For more information about scroll handler, see `HUBViewControllerScrollHandler`.
+ */
+@protocol HUBViewControllerScrollHandlerActionPerformer <HUBViewControllerScrollHandler>
+
+/**
+ *  An object that can be used to perform actions on behalf of this scroll handler
+ *
+ *  Don't assign any custom objects to this property. Instead, just \@sythensize it, so that
+ *  the Hub Framework can assign an internal object to this property, to enable you to perform
+ *  actions from the scroll handler.
+ */
+@property (nonatomic, weak, nullable) id<HUBActionPerformer> actionPerformer;
+
+@end
+

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -59,6 +59,7 @@
 #import "HUBViewControllerFactory.h"
 #import "HUBViewController.h"
 #import "HUBViewControllerScrollHandler.h"
+#import "HUBViewControllerScrollHandlerActionPerformer.h"
 #import "HUBViewURIPredicate.h"
 
 // Components

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -42,7 +42,7 @@
 #import "HUBCollectionViewLayout.h"
 #import "HUBContainerView.h"
 #import "HUBContentReloadPolicy.h"
-#import "HUBViewControllerScrollHandler.h"
+#import "HUBViewControllerScrollHandlerActionPerformer.h"
 #import "HUBComponentReusePool.h"
 #import "HUBActionContextImplementation.h"
 #import "HUBActionHandlerWrapper.h"
@@ -155,6 +155,9 @@ NS_ASSUME_NONNULL_BEGIN
     viewModelLoader.delegate = self;
     viewModelLoader.actionPerformer = self;
     imageLoader.delegate = self;
+    if ([scrollHandler conformsToProtocol:@protocol(HUBViewControllerScrollHandlerActionPerformer)]) {
+        ((id<HUBViewControllerScrollHandlerActionPerformer>)scrollHandler).actionPerformer = self;
+    }
     
     self.automaticallyAdjustsScrollViewInsets = [_scrollHandler shouldAutomaticallyAdjustContentInsetsInViewController:self];
     


### PR DESCRIPTION
This covers a use case when actions need to be performed in relation to scrolling in Hub view controller (for example centering new item).