### PR TITLE
View controller: Make view URI a public property

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -164,6 +164,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The identifier of the feature that this view controller belongs to
 @property (nonatomic, copy, readonly) NSString *featureIdentifier;
 
+/// The URI that this view controller was resolved from
+@property (nonatomic, copy, readonly) NSURL *viewURI;
+
 /**
  *  The current view model that the view controller is using
  *

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -62,7 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
     HUBCollectionViewDelegate
 >
 
-@property (nonatomic, copy, readonly) NSURL *viewURI;
 @property (nonatomic, strong, readonly) HUBViewModelLoaderImplementation *viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
 @property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;

--- a/tests/HUBViewControllerFactoryTests.m
+++ b/tests/HUBViewControllerFactoryTests.m
@@ -94,7 +94,9 @@
                                     viewControllerScrollHandler:nil];
     
     XCTAssertTrue([self.manager.viewControllerFactory canCreateViewControllerForViewURI:viewURI]);
-    XCTAssertNotNil([self.manager.viewControllerFactory createViewControllerForViewURI:viewURI]);
+    
+    HUBViewController * const viewController = [self.manager.viewControllerFactory createViewControllerForViewURI:viewURI];
+    XCTAssertEqualObjects(viewController.viewURI, viewURI);
 }
 
 - (void)testCreatingViewControllerForInvalidViewURIReturnsNil


### PR DESCRIPTION
No good reason to keep it private, and it makes some operations that handle view URIs a lot simpler, since they can just access it from the view controller directly, instead of having to pass another parameter around.