### PR TITLE
Don’t update state after calling the completion block.

### DIFF
--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -68,6 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
             [collectionView setNeedsLayout];
             [collectionView layoutIfNeeded];
         }
+        self.lastRenderedViewModel = viewModel;
         completionBlock();
     } else {
         void (^updateBlock)() = ^{
@@ -82,6 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      addHeaderMargin:addHeaderMargin];
                 
             } completion:^(BOOL finished) {
+                self.lastRenderedViewModel = viewModel;
                 completionBlock();
             }];
         };
@@ -92,8 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
             [UIView performWithoutAnimation:updateBlock];
         }
     }
-
-    self.lastRenderedViewModel = viewModel;
 }
 
 @end


### PR DESCRIPTION
The code was firing the completion to signal that it was done, and then updating internal state after. We should be updating our state before firing the completion.

We saw crashes where firing the completion could trigger an update, which would synchronously invoke another render - this meant that the start of the render method would be called again (reading an old `self.lastRenderedViewModel` and calculating a diff based on it) which would immediately be followed by the termination of the previous render method that would assign the correct object to `self.lastRenderedViewModel`. At this point, it was too late as the next invocation was already using an out-of-date object.

The would either manifest as a crash where:

- the collection view would be out of sync with the model at the end of `performBatchUpdates:completion:`
- the model would be deallocated while the collection view was accessing it.

Note that there are no tests as part of this PR. These are being worked on in parallel as I want to get this fix out ASAP to verify that it fixes all crashes we're experiencing.