### PR TITLE
Memory management in tests

### DIFF
--- a/tests/HUBActionRegistryTests.m
+++ b/tests/HUBActionRegistryTests.m
@@ -42,6 +42,12 @@
     self.actionRegistry = [HUBActionRegistryImplementation registryWithDefaultSelectionAction];
 }
 
+- (void)tearDown
+{
+    self.actionRegistry = nil;
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testRegisteringFactoryAndCreatingAction

--- a/tests/HUBCollectionViewFactoryTests.m
+++ b/tests/HUBCollectionViewFactoryTests.m
@@ -30,16 +30,6 @@
 
 @implementation HUBCollectionViewFactoryTests
 
-- (void)setUp
-{
-    [super setUp];
-}
-
-- (void)tearDown
-{
-    [super tearDown];
-}
-
 - (void)testThatTheFactoryCreatesNonNilInstances
 {
     HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];

--- a/tests/HUBCollectionViewLayoutTests.m
+++ b/tests/HUBCollectionViewLayoutTests.m
@@ -119,6 +119,22 @@
                                                                         iconImageResolver:iconImageResolver];
 }
 
+- (void)tearDown
+{
+    self.compactComponent = nil;
+    self.compactComponentIdentifier = nil;
+    self.centeredComponent = nil;
+    self.centeredComponentIdentifier = nil;
+    self.fullWidthComponent = nil;
+    self.fullWidthComponentIdentifier = nil;
+    self.componentFactory = nil;
+    self.componentRegistry = nil;
+    self.componentLayoutManager = nil;
+    self.viewModelBuilder = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testTopLeftContentEdgeMargins

--- a/tests/HUBComponentGestureRecognizerTests.m
+++ b/tests/HUBComponentGestureRecognizerTests.m
@@ -45,6 +45,14 @@
     [self.view addGestureRecognizer:self.gestureRecognizer];
 }
 
+- (void)tearDown
+{
+    self.gestureRecognizer = nil;
+    self.view = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testGestureRecognizerAddedToView

--- a/tests/HUBComponentImageDataBuilderTests.m
+++ b/tests/HUBComponentImageDataBuilderTests.m
@@ -52,6 +52,14 @@
     self.builder.bundle = [NSBundle bundleForClass:self.class];
 }
 
+- (void)tearDown
+{
+    self.builder = nil;
+    self.schema = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testPropertyAssignment

--- a/tests/HUBComponentModelBuilderTests.m
+++ b/tests/HUBComponentModelBuilderTests.m
@@ -64,6 +64,15 @@
                                                                 backgroundImageDataBuilder:nil];
 }
 
+- (void)tearDown
+{
+    self.modelIdentifier = nil;
+    self.componentDefaults = nil;
+    self.builder = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testPropertyAssignment

--- a/tests/HUBComponentRegistryTests.m
+++ b/tests/HUBComponentRegistryTests.m
@@ -62,6 +62,14 @@ static NSString * const DefaultNamespace = @"default";
                                                                       iconImageResolver:nil];
 }
 
+- (void)tearDown
+{
+    self.componentFallbackHandler = nil;
+    self.registry = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testRegisteringComponentFactory

--- a/tests/HUBComponentTargetBuilderTests.m
+++ b/tests/HUBComponentTargetBuilderTests.m
@@ -53,6 +53,13 @@
                                                                      actionIdentifiers:nil];
 }
 
+- (void)tearDown
+{
+    self.builder = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testEmptyBuilderStillProducingModel

--- a/tests/HUBComponentWrapperTests.m
+++ b/tests/HUBComponentWrapperTests.m
@@ -61,6 +61,14 @@
     self.gestureRecognizer = [HUBComponentGestureRecognizer new];
 }
 
+- (void)tearDown
+{
+    self.UIStateManager = nil;
+    self.gestureRecognizer = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testComponentStateRestoring

--- a/tests/HUBDefaultImageLoaderTests.m
+++ b/tests/HUBDefaultImageLoaderTests.m
@@ -55,7 +55,12 @@
 
 - (void)tearDown
 {
-    [NSURLProtocol unregisterClass:[HUBURLProtocolMock class]];
+    self.session = nil;
+    self.imageLoader = nil;
+    self.loadedImage = nil;
+    self.loadedImageURL = nil;
+    self.loadingError = nil;
+
     [super tearDown];
 }
 

--- a/tests/HUBFeatureRegistryTests.m
+++ b/tests/HUBFeatureRegistryTests.m
@@ -42,6 +42,12 @@
     self.registry = [HUBFeatureRegistryImplementation new];
 }
 
+- (void)tearDown
+{
+    self.registry = nil;
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testConflictingIdentifiersTriggerAssert

--- a/tests/HUBIconTests.m
+++ b/tests/HUBIconTests.m
@@ -40,6 +40,12 @@
     self.imageResolver = [HUBIconImageResolverMock new];
 }
 
+- (void)tearDown
+{
+    self.imageResolver = nil;
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testEquality

--- a/tests/HUBInitialViewModelRegistryTests.m
+++ b/tests/HUBInitialViewModelRegistryTests.m
@@ -38,6 +38,12 @@
     self.registry = [HUBInitialViewModelRegistry new];
 }
 
+- (void)tearDown
+{
+    self.registry = nil;
+    [super tearDown];
+}
+
 - (void)testRegisteringRetrievingAndRemovingInitialViewModel
 {
     id<HUBViewModel> const viewModel = [[HUBViewModelImplementation alloc] initWithIdentifier:@"id"

--- a/tests/HUBJSONSchemaRegistryTests.m
+++ b/tests/HUBJSONSchemaRegistryTests.m
@@ -50,6 +50,13 @@
                                                                          iconImageResolver:iconImageResolver];
 }
 
+- (void)tearDown
+{
+    self.registry = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testRegisteringRetrievingAndRemovingCustomSchema

--- a/tests/HUBLiveServiceTests.m
+++ b/tests/HUBLiveServiceTests.m
@@ -59,7 +59,11 @@
 
 - (void)tearDown
 {
+    self.hubManager = nil;
     self.service = nil;
+    self.viewController = nil;
+
+    [super tearDown];
 }
 
 #pragma mark - Tests

--- a/tests/HUBViewControllerFactoryTests.m
+++ b/tests/HUBViewControllerFactoryTests.m
@@ -75,6 +75,15 @@
                                       appendedContentOperationFactory:nil];
 }
 
+- (void)tearDown
+{
+    self.defaultActionHandler = nil;
+    self.defaultContentReloadPolicy = nil;
+    self.manager = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testCreatingViewControllerForValidViewURI

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -177,6 +177,44 @@
     self.viewControllerShouldAutomaticallyManageTopContentInset = ^{ return YES; };
 }
 
+- (void)tearDown
+{
+    self.contentOperation = nil;
+    self.contentReloadPolicy = nil;
+    self.componentIdentifier = nil;
+    self.component = nil;
+    self.componentFactory = nil;
+    self.collectionView = nil;
+    self.collectionViewFactory = nil;
+    self.componentRegistry = nil;
+    self.componentReusePool = nil;
+    self.scrollHandler = nil;
+    self.viewModelLoader = nil;
+    self.viewModelRenderer = nil;
+    self.imageLoader = nil;
+    self.initialViewModelRegistry = nil;
+    self.actionHandler = nil;
+    self.selectionAction = nil;
+    self.actionRegistry = nil;
+    self.viewURI = nil;
+    self.featureInfo = nil;
+    self.viewController = nil;
+    self.viewModelFromDelegateMethod = nil;
+    self.errorFromDelegateMethod = nil;
+    self.componentModelsFromAppearanceDelegateMethod = nil;
+    self.componentLayoutTraitsFromAppearanceDelegateMethod = nil;
+    self.componentModelsFromDisapperanceDelegateMethod = nil;
+    self.componentLayoutTraitsFromDisapperanceDelegateMethod = nil;
+    self.componentModelsFromSelectionDelegateMethod = nil;
+    self.componentViewsFromApperanceDelegateMethod = nil;
+    self.componentViewsFromReuseDelegateMethod = nil;
+    self.viewControllerDidFinishRenderingBlock = nil;
+    self.viewControllerShouldStartScrollingBlock = nil;
+    self.viewControllerShouldAutomaticallyManageTopContentInset = nil;
+
+    [super tearDown];
+}
+
 - (void)createViewControllerWithViewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
 {
     id<HUBComponentLayoutManager> const componentLayoutManager = [HUBComponentLayoutManagerMock new];

--- a/tests/HUBViewModelBuilderTests.m
+++ b/tests/HUBViewModelBuilderTests.m
@@ -56,6 +56,15 @@
                                                                iconImageResolver:self.iconImageResolver];
 }
 
+- (void)tearDown
+{
+    self.componentDefaults = nil;
+    self.iconImageResolver = nil;
+    self.builder = nil;
+
+    [super tearDown];
+}
+
 #pragma mark - Tests
 
 - (void)testPropertyAssignment

--- a/tests/HUBViewModelLoaderFactoryTests.m
+++ b/tests/HUBViewModelLoaderFactoryTests.m
@@ -73,6 +73,17 @@
                                                                                 defaultContentReloadPolicy:nil];
 }
 
+- (void)tearDown
+{
+    self.featureRegistry = nil;
+    self.defaultComponentNamespace = nil;
+    self.prependedContentOperationFactory = nil;
+    self.appendedContentOperationFactory = nil;
+    self.viewModelLoaderFactory = nil;
+
+    [super tearDown];
+}
+
 - (void)testCreatingViewModelLoaderForValidViewURI
 {
     NSURL * const viewURI = [NSURL URLWithString:@"spotify:hub:framework"];

--- a/tests/HUBViewModelLoaderTests.m
+++ b/tests/HUBViewModelLoaderTests.m
@@ -67,7 +67,10 @@
 - (void)tearDown
 {
     self.loader = nil;
+    self.featureInfo = nil;
+    self.contentReloadPolicy = nil;
     self.connectivityStateResolver.state = HUBConnectivityStateOnline;
+    self.connectivityStateResolver = nil;
     self.viewModelFromSuccessDelegateMethod = nil;
     self.errorFromFailureDelegateMethod = nil;
     


### PR DESCRIPTION
We need to make sure we `nil` all of our strong properties in the `tearDown` phase of unit tests.

*Errrr... Why?*
`XCTest` will create a new instance of your `XCTestCase` subclass for each test method in that class, and it will *not* release that test case for the lifetime of the tests being run. Maybe that's a bug in `XCTest`, or maybe it's by design. I'm not sure, but it's the way it's always been.

This means that any properties created during a test will never be released for us - `tearDown` is the only real opportunity we have to step in and release references to these instances.

*But why do we care during testing?*
- We want to test our `dealloc` methods too, right?
- Profiling unit tests is much more difficult when every property created in every test is still alive.
- If we ever introduce code that sends `NSNotification`s (for example), we'll potentially have problems where old instances could be producing / consuming events that we don't expect.