### PR TITLE
Add ability to specify keyboardDismissMode by the scroll handler

### DIFF
--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -55,7 +55,7 @@
 - (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(HUBViewController *)viewController;
 
 /**
- *  Return the manner in which the keyboard is dismissed when a drag begins in the view controller
+ *  Return the manner in which the keyboard is dismissed when the content in the view controller is dragged
  *
  *  @param viewController The view controller in question
  *
@@ -63,7 +63,7 @@
  *  assigned to the `keyboardDismissMode` property of the used scroll view, so see the documentation for that property
  *  on `UIScrollView` for more information.
  */
-- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForDraggingViewController:(HUBViewController *)viewController;
+- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForViewController:(HUBViewController *)viewController;
 
 /**
  *  Return the deceleration rate to use for scrolling in a view controller

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -55,6 +55,17 @@
 - (BOOL)shouldAutomaticallyAdjustContentInsetsInViewController:(HUBViewController *)viewController;
 
 /**
+ *  Return the manner in which the keyboard is dismissed when a drag begins in the view controller
+ *
+ *  @param viewController The view controller in question
+ *
+ *  The Hub Framework will call this method when a view controller is being set up. The returned value will be
+ *  assigned to the `keyboardDismissMode` property of the used scroll view, so see the documentation for that property
+ *  on `UIScrollView` for more information.
+ */
+- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForDraggingViewController:(HUBViewController *)viewController;
+
+/**
  *  Return the deceleration rate to use for scrolling in a view controller
  *
  *  @param viewController The view controller in question

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -880,7 +880,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     self.collectionView = collectionView;
     collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
-    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForDraggingViewController:self];
+    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
     collectionView.dataSource = self;
     collectionView.delegate = self;

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -880,6 +880,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     self.collectionView = collectionView;
     collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
+    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForDraggingViewController:self];
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
     collectionView.dataSource = self;
     collectionView.delegate = self;

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -36,6 +36,11 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
 }
 
+- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForDraggingViewController:(HUBViewController *)viewController
+{
+    return UIScrollViewKeyboardDismissModeNone;
+}
+
 - (CGFloat)scrollDecelerationRateForViewController:(HUBViewController *)viewController
 {
     return UIScrollViewDecelerationRateNormal;

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
 }
 
-- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForDraggingViewController:(HUBViewController *)viewController
+- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForViewController:(HUBViewController *)viewController
 {
     return UIScrollViewKeyboardDismissModeNone;
 }

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -2333,6 +2333,7 @@
 {
     self.scrollHandler.shouldShowScrollIndicators = YES;
     self.scrollHandler.shouldAutomaticallyAdjustContentInsets = YES;
+    self.scrollHandler.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     self.scrollHandler.scrollDecelerationRate = UIScrollViewDecelerationRateNormal;
     self.scrollHandler.contentInsetHandler = ^(HUBViewController *viewController, UIEdgeInsets proposedContentInset) {
         return UIEdgeInsetsMake(100, 30, 40, 200);
@@ -2342,6 +2343,7 @@
     
     XCTAssertEqual(self.collectionView.showsHorizontalScrollIndicator, YES);
     XCTAssertEqual(self.collectionView.showsVerticalScrollIndicator, YES);
+    XCTAssertEqual(self.collectionView.keyboardDismissMode, UIScrollViewKeyboardDismissModeOnDrag);
     HUBAssertEqualFloatValues(self.collectionView.decelerationRate, UIScrollViewDecelerationRateNormal);
     XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.collectionView.contentInset, UIEdgeInsetsMake(100, 30, 40, 200)));
 }

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.h
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether the handler should return that content insets should automatically be adjusted
 @property (nonatomic, assign) BOOL shouldAutomaticallyAdjustContentInsets;
 
+/// The manner in which the keyboard is dismissed when a drag begins
+@property (nonatomic, assign) UIScrollViewKeyboardDismissMode keyboardDismissMode;
+
 /// The scroll deceleration rate that the handler should return
 @property (nonatomic, assign) CGFloat scrollDecelerationRate;
 

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self.shouldAutomaticallyAdjustContentInsets;
 }
 
-- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForDraggingViewController:(HUBViewController *)viewController
+- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForViewController:(HUBViewController *)viewController
 {
     return self.keyboardDismissMode;
 }

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -43,6 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
     return self.shouldAutomaticallyAdjustContentInsets;
 }
 
+- (UIScrollViewKeyboardDismissMode)keyboardDismissModeForDraggingViewController:(HUBViewController *)viewController
+{
+    return self.keyboardDismissMode;
+}
+
 - (CGFloat)scrollDecelerationRateForViewController:(HUBViewController *)viewController
 {
     return self.scrollDecelerationRate;


### PR DESCRIPTION
`UIScrollView`'s `keyboardDismissMode` is available since iOS 7 and is the preferred way for configuring the automatic keyboard dismissal. This option can reduce a lot of custom content offset observing code so less bugs and code duplication.