### PR TITLE
Add proposed value for the scroll handler to be used by features

### DIFF
--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -114,16 +114,18 @@
 /**
  *  Return the content offset for displaying a component at a certain scroll position.
  *  
- *  @param componentIndex The index of the component to display.
- *  @param scrollPosition The position to display the component at.
+ *  @param componentIndex The index of the component to display
+ *  @param scrollPosition The position to display the component at
  *  @param contentInset The current content inset of the view controller's scroll view
  *  @param contentSize The current content size of the view controller's scroll view
- *  @param viewController The view controller in question.
+ *  @param viewController The view controller in question
+ *  @param proposedContentOffset The offset for the component to display proposed by the Hub Framework
  */
 - (CGPoint)contentOffsetForDisplayingComponentAtIndex:(NSUInteger)componentIndex
                                        scrollPosition:(HUBScrollPosition)scrollPosition
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
-                                       viewController:(HUBViewController *)viewController;
+                                       viewController:(HUBViewController *)viewController
+                                proposedContentOffset:(CGPoint)proposedContentOffset;
 
 @end

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -1423,11 +1423,29 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 {
     NSParameterAssert(componentIndex <= (NSUInteger)[self.collectionView numberOfItemsInSection:0]);
 
+    CGRect const componentFrame = [self frameForBodyComponentAtIndex:componentIndex];
+    CGFloat const viewHeight = CGRectGetHeight(self.view.frame);
+    CGFloat targetOffset = 0.0;
+
+    if (scrollPosition & HUBScrollPositionCenteredVertically) {
+        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0f);
+    } else if (scrollPosition & HUBScrollPositionBottom) {
+        targetOffset = CGRectGetMaxY(componentFrame) - viewHeight;
+    } else {
+        // Default to putting it at the top unless a proper position is provided
+        targetOffset = CGRectGetMinY(componentFrame);
+    }
+
+    targetOffset = MAX(-self.collectionView.contentInset.top,
+                       MIN(self.collectionView.contentSize.height - viewHeight, targetOffset));
+    CGPoint proposedContentOffset = CGPointMake(0.0, (CGFloat)floor((double)targetOffset));
+
     CGPoint const contentOffset = [self.scrollHandler contentOffsetForDisplayingComponentAtIndex:componentIndex
                                                                                   scrollPosition:scrollPosition
                                                                                     contentInset:self.collectionView.contentInset
                                                                                      contentSize:self.collectionView.contentSize
-                                                                                  viewController:self];
+                                                                                  viewController:self
+                                                                           proposedContentOffset:proposedContentOffset];
     
     // If the target offset is the same, the completion handler can be called instantly.
     if (CGPointEqualToPoint(contentOffset, self.collectionView.contentOffset)) {

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -72,22 +72,9 @@ NS_ASSUME_NONNULL_BEGIN
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
                                        viewController:(HUBViewController *)viewController
+                                proposedContentOffset:(CGPoint)proposedContentOffset
 {
-    CGRect const componentFrame = [viewController frameForBodyComponentAtIndex:componentIndex];
-    CGFloat const viewHeight = CGRectGetHeight(viewController.view.frame);
-    CGFloat targetOffset = 0.0;
-
-    if (scrollPosition & HUBScrollPositionCenteredVertically) {
-        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0f);
-    } else if (scrollPosition & HUBScrollPositionBottom) {
-        targetOffset = CGRectGetMaxY(componentFrame) - viewHeight;
-    } else {
-        // Default to putting it at the top unless a proper position is provided
-        targetOffset = CGRectGetMinY(componentFrame);
-    }
-
-    targetOffset = MAX(-contentInset.top, MIN(contentSize.height - viewHeight, targetOffset));
-    return CGPointMake(0.0, (CGFloat)floor((double)targetOffset));
+    return proposedContentOffset;
 }
 
 @end

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -92,6 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          contentInset:(UIEdgeInsets)contentInset
                                           contentSize:(CGSize)contentSize
                                        viewController:(HUBViewController *)viewController
+                                proposedContentOffset:(CGPoint)proposedContentOffset
 {
     return self.targetContentOffset;
 }


### PR DESCRIPTION
This PR moves the logic from the `HUBViewControllerDefaultScrollHandler` to the `HUBViewController` so that it could be reused by features that want to provide custom scroll handler to override some behaviour but don't want to replicate this logic.