### PR TITLE
Add feature info to HUBActionContext

### DIFF
--- a/include/HubFramework/HUBActionContext.h
+++ b/include/HubFramework/HUBActionContext.h
@@ -24,7 +24,7 @@
 
 #import "HUBActionTrigger.h"
 
-@protocol HUBViewModel, HUBComponentModel;
+@protocol HUBViewModel, HUBComponentModel, HUBFeatureInfo;
 @class HUBIdentifier;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -55,6 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  This property will always be `nil` if this context is for the default selection action
  */
 @property (nonatomic, strong, readonly, nullable) NSDictionary<NSString *, id> *customData;
+
+/// An object containing information about the feature that the action is being performed in
+@property (nonatomic, strong, readonly) id<HUBFeatureInfo> featureInfo;
 
 /// The URI of the view that the action is being performed in
 @property (nonatomic, copy, readonly) NSURL *viewURI;

--- a/sources/HUBActionContextImplementation.h
+++ b/sources/HUBActionContextImplementation.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param trigger The reason that the action will be triggered
  *  @param customActionIdentifier The identifier of any custom action that this context is for
  *  @param customData Any custom data that should be passed to the action
+ *  @param featureInfo Information about the feature that the action is for
  *  @param viewURI The URI of the view that the action is for
  *  @param viewModel The model of the view that the action is for
  *  @param componentModel The model of any component that the action is for
@@ -41,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTrigger:(HUBActionTrigger)trigger
          customActionIdentifier:(nullable HUBIdentifier *)customActionIdentifier
                      customData:(nullable NSDictionary<NSString *, id> *)customData
+                    featureInfo:(id<HUBFeatureInfo>)featureInfo
                         viewURI:(NSURL *)viewURI
                       viewModel:(id<HUBViewModel>)viewModel
                  componentModel:(nullable id<HUBComponentModel>)componentModel

--- a/sources/HUBActionContextImplementation.m
+++ b/sources/HUBActionContextImplementation.m
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @synthesize trigger = _trigger;
 @synthesize customActionIdentifier = _customActionIdentifier;
 @synthesize customData = _customData;
+@synthesize featureInfo = _featureInfo;
 @synthesize viewURI = _viewURI;
 @synthesize viewModel = _viewModel;
 @synthesize componentModel = _componentModel;
@@ -36,11 +37,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTrigger:(HUBActionTrigger)trigger
          customActionIdentifier:(nullable HUBIdentifier *)customActionIdentifier
                      customData:(nullable NSDictionary<NSString *, id> *)customData
+                    featureInfo:(id<HUBFeatureInfo>)featureInfo
                         viewURI:(NSURL *)viewURI
                       viewModel:(id<HUBViewModel>)viewModel
                  componentModel:(nullable id<HUBComponentModel>)componentModel
                  viewController:(UIViewController *)viewController
 {
+    NSParameterAssert(featureInfo != nil);
     NSParameterAssert(viewURI != nil);
     NSParameterAssert(viewModel != nil);
     NSParameterAssert(viewController != nil);
@@ -51,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
         _trigger = trigger;
         _customActionIdentifier = customActionIdentifier;
         _customData = customData;
+        _featureInfo = featureInfo;
         _viewURI = viewURI;
         _viewModel = viewModel;
         _componentModel = componentModel;

--- a/sources/HUBActionHandlerWrapper.m
+++ b/sources/HUBActionHandlerWrapper.m
@@ -129,6 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
         HUBActionContextImplementation * const chainedActionContext = [[HUBActionContextImplementation alloc] initWithTrigger:context.trigger
                                                                                                        customActionIdentifier:chainedActionIdentifier
                                                                                                                    customData:nextActionCustomData
+                                                                                                                  featureInfo:context.featureInfo
                                                                                                                       viewURI:context.viewURI
                                                                                                                     viewModel:context.viewModel
                                                                                                                componentModel:context.componentModel

--- a/sources/HUBViewController+Initializer.h
+++ b/sources/HUBViewController+Initializer.h
@@ -21,6 +21,7 @@
 
 #import "HUBViewController.h"
 
+@protocol HUBFeatureInfo;
 @protocol HUBComponentRegistry;
 @protocol HUBComponentLayoutManager;
 @protocol HUBActionHandler;
@@ -40,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Initialize an instance of this class with its required dependencies
  *
  *  @param viewURI The view URI that this view controller is for
- *  @param featureIdentifier The identifier of the feature that this view controller is for
+ *  @param featureInfo Information about the feature that the view controller is for
  *  @param viewModelLoader The object to use to load view models for the view controller
  *  @param viewModelRenderer The object used to render the view model
  *  @param collectionViewFactory The factory to use to create collection views
@@ -52,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param imageLoader The loader to use to load images for components
  */
 - (instancetype)initWithViewURI:(NSURL *)viewURI
-              featureIdentifier:(NSString *)featureIdentifier
+                    featureInfo:(id<HUBFeatureInfo>)featureInfo
                 viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
               viewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -48,6 +48,7 @@
 #import "HUBActionHandlerWrapper.h"
 #import "HUBActionPerformer.h"
 #import "HUBViewModelRenderer.h"
+#import "HUBFeatureInfo.h"
 
 static NSTimeInterval const HUBImageDownloadTimeThreshold = 0.07;
 
@@ -62,6 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
     HUBCollectionViewDelegate
 >
 
+@property (nonatomic, strong, readonly) id<HUBFeatureInfo> featureInfo;
 @property (nonatomic, strong, readonly) HUBViewModelLoaderImplementation *viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
 @property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
@@ -98,13 +100,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewController
 
-@synthesize delegate = _delegate;
-@synthesize featureIdentifier = _featureIdentifier;
-
 #pragma mark - Lifecycle
 
 - (instancetype)initWithViewURI:(NSURL *)viewURI
-              featureIdentifier:(NSString *)featureIdentifier
+                    featureInfo:(id<HUBFeatureInfo>)featureInfo
                 viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
               viewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
@@ -116,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
                     imageLoader:(id<HUBImageLoader>)imageLoader
 {
     NSParameterAssert(viewURI != nil);
-    NSParameterAssert(featureIdentifier != nil);
+    NSParameterAssert(featureInfo != nil);
     NSParameterAssert(viewModelLoader != nil);
     NSParameterAssert(viewModelRenderer != nil);
     NSParameterAssert(collectionViewFactory != nil);
@@ -132,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     _viewURI = [viewURI copy];
-    _featureIdentifier = [featureIdentifier copy];
+    _featureInfo = featureInfo;
     _viewModelLoader = viewModelLoader;
     _viewModelRenderer = viewModelRenderer;
     _collectionViewFactory = collectionViewFactory;
@@ -268,6 +267,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - HUBViewController
+
+- (NSString *)featureIdentifier
+{
+    return self.featureInfo.identifier;
+}
 
 - (BOOL)isViewScrolling
 {
@@ -1380,6 +1384,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     id<HUBActionContext> const context = [[HUBActionContextImplementation alloc] initWithTrigger:trigger
                                                                           customActionIdentifier:customIdentifier
                                                                                       customData:customData
+                                                                                     featureInfo:self.featureInfo
                                                                                          viewURI:self.viewURI
                                                                                        viewModel:viewModel
                                                                                   componentModel:componentModel

--- a/sources/HUBViewControllerFactoryImplementation.m
+++ b/sources/HUBViewControllerFactoryImplementation.m
@@ -27,6 +27,7 @@
 #import "HUBComponentReusePool.h"
 #import "HUBImageLoaderFactory.h"
 #import "HUBFeatureRegistration.h"
+#import "HUBFeatureInfoImplementation.h"
 #import "HUBViewController+Initializer.h"
 #import "HUBCollectionViewFactory.h"
 #import "HUBInitialViewModelRegistry.h"
@@ -140,6 +141,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (HUBViewController *)createViewControllerForViewURI:(NSURL *)viewURI
                                   featureRegistration:(HUBFeatureRegistration *)featureRegistration
 {
+    id<HUBFeatureInfo> const featureInfo = [[HUBFeatureInfoImplementation alloc] initWithIdentifier:featureRegistration.featureIdentifier
+                                                                                              title:featureRegistration.featureTitle];
+    
     HUBViewModelLoaderImplementation * const viewModelLoader = [self.viewModelLoaderFactory createViewModelLoaderForViewURI:viewURI
                                                                                                         featureRegistration:featureRegistration];
     
@@ -157,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<HUBViewControllerScrollHandler> const scrollHandlerToUse = featureRegistration.viewControllerScrollHandler ?: [HUBViewControllerDefaultScrollHandler new];
     
     return [[HUBViewController alloc] initWithViewURI:viewURI
-                                    featureIdentifier:featureRegistration.featureIdentifier
+                                          featureInfo:featureInfo
                                       viewModelLoader:viewModelLoader
                                     viewModelRenderer:viewModelRenderer
                                 collectionViewFactory:collectionViewFactory

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -224,7 +224,7 @@
                                                                                       viewModelLoader:self.viewModelLoader];
     
     self.viewController = [[HUBViewController alloc] initWithViewURI:self.viewURI
-                                                   featureIdentifier:self.featureInfo.identifier
+                                                         featureInfo:self.featureInfo
                                                      viewModelLoader:self.viewModelLoader
                                                    viewModelRenderer:viewModelRenderer
                                                collectionViewFactory:self.collectionViewFactory
@@ -239,6 +239,12 @@
 }
 
 #pragma mark - Tests
+
+- (void)testFeatureIdentifier
+{
+    XCTAssertNotNil(self.featureInfo.identifier);
+    XCTAssertEqualObjects(self.viewController.featureIdentifier, self.featureInfo.identifier);
+}
 
 - (void)testContentLoadedOnViewWillAppear
 {
@@ -348,7 +354,6 @@
     
     XCTAssertEqualObjects(self.viewModelFromDelegateMethod.navigationItem.title, viewModelNavBarTitleB);
 }
-
 
 - (void)testDelegateNotifiedOfViewModelUpdateError
 {
@@ -2773,6 +2778,8 @@
     XCTAssertNotNil(chainedActionContext);
     XCTAssertEqualObjects(chainedActionContext.customActionIdentifier, chainedActionIdentifier);
     XCTAssertEqualObjects(chainedActionContext.customData, chainedActionCustomData);
+    XCTAssertEqualObjects(chainedActionContext.featureInfo.identifier, self.featureInfo.identifier);
+    XCTAssertEqualObjects(chainedActionContext.featureInfo.title, self.featureInfo.title);
 }
 
 - (void)testAssigningNavigationItemProperties


### PR DESCRIPTION
This change makes `HUBActionContext` carry a `HUBFeatureInfo` object that contains information about the feature that the action is being performed in. This was previously only exposed to content operations.