### PR TITLE
Check that blocks are not nil before calling them.

### DIFF
--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -3114,7 +3114,10 @@
 
 - (BOOL)viewControllerShouldStartScrolling:(HUBViewController *)viewController
 {
-    return self.viewControllerShouldStartScrollingBlock();
+    if (self.viewControllerShouldStartScrollingBlock) {
+        return self.viewControllerShouldStartScrollingBlock();
+    }
+    return NO;
 }
 
 - (void)viewController:(HUBViewController *)viewController
@@ -3157,7 +3160,10 @@
 - (BOOL)viewControllerShouldAutomaticallyManageTopContentInset:(HUBViewController *)viewController
 {
     XCTAssertEqual(viewController, self.viewController);
-    return self.viewControllerShouldAutomaticallyManageTopContentInset();
+    if (self.viewControllerShouldAutomaticallyManageTopContentInset) {
+        return self.viewControllerShouldAutomaticallyManageTopContentInset();
+    }
+    return NO;
 }
 
 #pragma mark - Utilities


### PR DESCRIPTION
I've seen cases of a race condition where:
- `HUBViewControllerTests` invokes some logic that triggers an update in the collection view
- the test finishes and `tearDown` is called
- `tearDown` sets all the blocks in `HUBViewControllerTests` to `nil`
- a callback fired from the collection view which calls completion blocks and ultimately tries to call some of the `HUBViewControllerTests` blocks which are now `nil`.

Tests that invoke render methods should wait until the completion block has fired before finishing, but for now, this will deal with the issue.