### PR TITLE
Exposes the HUBViewController's HUBActionPerformer

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -23,6 +23,7 @@
 #import "HUBComponentLayoutTraits.h"
 #import "HUBComponentType.h"
 #import "HUBScrollPosition.h"
+#import "HUBActionPerformer.h"
 
 @protocol HUBViewModel;
 @protocol HUBComponentModel;
@@ -156,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  This view controller renders `HUBComponent` instances using a collection view. What components that are rendered
  *  are determined by `HUBContentOperation`s that build a `HUBViewModel`.
  */
-@interface HUBViewController : UIViewController
+@interface HUBViewController : UIViewController <HUBActionPerformer>
 
 /// The view controller's delegate. See `HUBViewControllerDelegate` for more information.
 @property (nonatomic, weak, nullable) id<HUBViewControllerDelegate> delegate;

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -46,7 +46,6 @@
 #import "HUBComponentReusePool.h"
 #import "HUBActionContextImplementation.h"
 #import "HUBActionHandlerWrapper.h"
-#import "HUBActionPerformer.h"
 #import "HUBViewModelRenderer.h"
 #import "HUBFeatureInfo.h"
 
@@ -58,7 +57,6 @@ NS_ASSUME_NONNULL_BEGIN
     HUBViewModelLoaderDelegate,
     HUBImageLoaderDelegate,
     HUBComponentWrapperDelegate,
-    HUBActionPerformer,
     UICollectionViewDataSource,
     HUBCollectionViewDelegate
 >


### PR DESCRIPTION
Exposes the HUBViewController's HUBActionPerformer protocol publicly in order to allow programmatic triggering of actions.

@spotify/objc-dev 