### PR TITLE
Rename methods in HUBJSONCompatibleBuilder for coherency and Swiftiness

### DIFF
--- a/demo/sources/GitHubSearchResultsContentOperation.swift
+++ b/demo/sources/GitHubSearchResultsContentOperation.swift
@@ -63,7 +63,11 @@ class GitHubSearchResultsContentOperation: NSObject, HUBContentOperation {
         
         // If we've already downloaded JSON data, add it to the view and flush our state
         if let jsonData = jsonData {
-            viewModelBuilder.addJSONData(jsonData)
+            do {
+                try viewModelBuilder.addJSON(data: jsonData)
+            } catch let error {
+                finishAndResetState(with: error)
+            }
             
             // If the data didn't contain any components (we only have 1 = the search bar), add a
             // "No results found" label as an overlay component
@@ -109,9 +113,14 @@ class GitHubSearchResultsContentOperation: NSObject, HUBContentOperation {
         dataTask?.resume()
     }
     
-    private func finishAndResetState() {
+    private func finishAndResetState(with error: Error? = nil) {
         jsonData = nil
         dataTask = nil
-        delegate?.contentOperationDidFinish(self)
+
+        if let error = error {
+            delegate?.contentOperation(self, didFailWithError: error)
+        } else {
+            delegate?.contentOperationDidFinish(self)
+        }
     }
 }

--- a/include/HubFramework/HUBJSONCompatibleBuilder.h
+++ b/include/HubFramework/HUBJSONCompatibleBuilder.h
@@ -28,30 +28,32 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Protocol defining the public API for adding JSON data to a Hub Framework model builder
  *
- *  Builders that support JSON data will conform to this protocol. Most builders only support Dictionary-based
- *  JSON, except for `HUBViewModelBuilder` that supports Array-based JSON for defining an array of body
- *  component models.
+ *  Builders that support JSON data will conform to this protocol. Most builders only support Dictionary-based JSON,
+ *  except for `HUBViewModelBuilder` that supports Array-based JSON for defining an array of body component models.
  */
 @protocol HUBJSONCompatibleBuilder <NSObject>
 
 /**
- *  Add binary JSON data to the builder
+ *  Add the contents of the given JSON data to the builder.
  *
- *  @param JSONData The JSON data to add
- *
- *  The builder will use its feature's `HUBJSONSchema` to parse the data that was added, and return any error that
+ *  The builder will use its feature’s `HUBJSONSchema` to parse the data that was added, and return any error that
  *  occured while doing so, or nil if the operation was completed successfully.
+ *
+ *  @param data The JSON data to extract content from, after being serialized.
+ *  @param error If an internal error occurs, upon return contains an `NSError` object that describes the problem.
+ *
+ *  @return `YES` if the data was successfully serialized and added; otherwise `NO`.
  */
-- (nullable NSError *)addJSONData:(NSData *)JSONData;
+- (BOOL)addJSONData:(NSData *)data error:(NSError * _Nullable __autoreleasing *)error NS_SWIFT_NAME(addJSON(data:));
 
 /**
- *  Add a JSON dictionary to this builder
- *
- *  @param dictionary The JSON dictionary to extract content from
+ *  Add the contents of the given JSON dictionary to the builder.
  *
  *  The content that was extracted from the supplied dictionary will replace any previously defined content.
+ *
+ *  @param dictionary The JSON dictionary to extract content from.
  */
-- (void)addDataFromJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary;
+- (void)addJSONDictionary:(NSDictionary<NSString *, id> *)dictionary NS_SWIFT_NAME(addJSON(dictionary:));
 
 @end
 

--- a/sources/HUBComponentImageDataBuilderImplementation.m
+++ b/sources/HUBComponentImageDataBuilderImplementation.m
@@ -61,12 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBJSONCompatibleBuilder
 
-- (nullable NSError *)addJSONData:(NSData *)JSONData
+- (BOOL)addJSONData:(NSData *)data error:(NSError *__autoreleasing  _Nullable *)error
 {
-    return HUBAddJSONDataToBuilder(JSONData, self);
+    return HUBAddJSONDataToBuilder(data, self, error);
 }
 
-- (void)addDataFromJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary
+- (void)addJSONDictionary:(NSDictionary<NSString *, id> *)dictionary
 {
     id<HUBComponentImageDataJSONSchema> const imageDataSchema = self.JSONSchema.componentImageDataSchema;
     

--- a/sources/HUBComponentModelBuilderImplementation.m
+++ b/sources/HUBComponentModelBuilderImplementation.m
@@ -305,12 +305,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBJSONCompatibleBuilder
 
-- (nullable NSError *)addJSONData:(NSData *)JSONData
+- (BOOL)addJSONData:(NSData *)data error:(NSError *__autoreleasing  _Nullable *)error
 {
-    return HUBAddJSONDataToBuilder(JSONData, self);
+    return HUBAddJSONDataToBuilder(data, self, error);
 }
 
-- (void)addDataFromJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary
+- (void)addJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary
 {
     id<HUBComponentModelJSONSchema> componentModelSchema = self.JSONSchema.componentModelSchema;
     
@@ -366,7 +366,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSDictionary * const targetDictionary = [componentModelSchema.targetDictionaryPath dictionaryFromJSONDictionary:dictionary];
     
     if (targetDictionary != nil) {
-        [[self getOrCreateTargetBuilder] addDataFromJSONDictionary:targetDictionary];
+        [[self getOrCreateTargetBuilder] addJSONDictionary:targetDictionary];
     }
     
     NSDictionary * const metadata = [componentModelSchema.metadataPath dictionaryFromJSONDictionary:dictionary];
@@ -390,13 +390,13 @@ NS_ASSUME_NONNULL_BEGIN
     NSDictionary * const mainImageDataDictionary = [componentModelSchema.mainImageDataDictionaryPath dictionaryFromJSONDictionary:dictionary];
     
     if (mainImageDataDictionary != nil) {
-        [self.mainImageDataBuilderImplementation addDataFromJSONDictionary:mainImageDataDictionary];
+        [self.mainImageDataBuilderImplementation addJSONDictionary:mainImageDataDictionary];
     }
     
     NSDictionary * const backgroundImageDataDictionary = [componentModelSchema.backgroundImageDataDictionaryPath dictionaryFromJSONDictionary:dictionary];
     
     if (backgroundImageDataDictionary != nil) {
-        [self.backgroundImageDataBuilderImplementation addDataFromJSONDictionary:backgroundImageDataDictionary];
+        [self.backgroundImageDataBuilderImplementation addJSONDictionary:backgroundImageDataDictionary];
     }
     
     NSDictionary * const customImageDataDictionary = [componentModelSchema.customImageDataDictionaryPath dictionaryFromJSONDictionary:dictionary];
@@ -406,7 +406,7 @@ NS_ASSUME_NONNULL_BEGIN
         
         if ([imageDataDictionary isKindOfClass:[NSDictionary class]]) {
             HUBComponentImageDataBuilderImplementation * const builder = [self getOrCreateBuilderForCustomImageDataWithIdentifier:imageIdentifier];
-            [builder addDataFromJSONDictionary:imageDataDictionary];
+            [builder addJSONDictionary:imageDataDictionary];
         }
     }
     
@@ -421,7 +421,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (NSDictionary * const childDictionary in childDictionaries) {
         NSString * const childModelIdentifier = [componentModelSchema.identifierPath stringFromJSONDictionary:childDictionary];
         HUBComponentModelBuilderImplementation * const childModelBuilder = [self getOrCreateBuilderForChildWithIdentifier:childModelIdentifier];
-        [childModelBuilder addDataFromJSONDictionary:childDictionary];
+        [childModelBuilder addJSONDictionary:childDictionary];
     }
 }
 

--- a/sources/HUBComponentTargetBuilderImplementation.m
+++ b/sources/HUBComponentTargetBuilderImplementation.m
@@ -95,12 +95,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - HUBJSONCompatibleBuilder
 
-- (nullable NSError *)addJSONData:(NSData *)JSONData
+- (BOOL)addJSONData:(NSData *)data error:(NSError *__autoreleasing  _Nullable *)error
 {
-    return HUBAddJSONDataToBuilder(JSONData, self);
+    return HUBAddJSONDataToBuilder(data, self, error);
 }
 
-- (void)addDataFromJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary
+- (void)addJSONDictionary:(NSDictionary<NSString *, NSObject *> *)dictionary
 {
     id<HUBComponentTargetJSONSchema> const schema = self.JSONSchema.componentTargetSchema;
     
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSDictionary * const initialViewModelDictionary = [schema.initialViewModelDictionaryPath dictionaryFromJSONDictionary:dictionary];
     
     if (initialViewModelDictionary != nil) {
-        [[self getOrCreateInitialViewModelBuilder] addDataFromJSONDictionary:initialViewModelDictionary];
+        [[self getOrCreateInitialViewModelBuilder] addJSONDictionary:initialViewModelDictionary];
     }
     
     NSArray<NSString *> * const actionIdentifierStrings = [schema.actionIdentifiersPath valuesFromJSONDictionary:dictionary];

--- a/sources/HUBJSONSchemaImplementation.m
+++ b/sources/HUBJSONSchemaImplementation.m
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                                     componentDefaults:self.componentDefaults
                                                                                                     iconImageResolver:self.iconImageResolver];
     
-    [builder addDataFromJSONDictionary:dictionary];
+    [builder addJSONDictionary:dictionary];
     return [builder build];
 }
 

--- a/sources/HUBLiveContentOperation.m
+++ b/sources/HUBLiveContentOperation.m
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
          viewModelBuilder:(id<HUBViewModelBuilder>)viewModelBuilder
             previousError:(nullable NSError *)previousError
 {
-    [viewModelBuilder addJSONData:self.JSONData];
+    [viewModelBuilder addJSONData:self.JSONData error:nil];
     [self.delegate contentOperationDidFinish:self];
 }
 

--- a/sources/HUBUtilities.h
+++ b/sources/HUBUtilities.h
@@ -37,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Two nil values are considered equal.
  */
-static inline BOOL HUBPropertyIsEqual(NSObject * _Nullable objectA, NSObject * _Nullable objectB, NSString *propertyName) {
+static inline BOOL HUBPropertyIsEqual(NSObject * _Nullable objectA, NSObject * _Nullable objectB, NSString *propertyName)
+{
     NSObject * const valueA = [objectA valueForKey:propertyName];
     NSObject * const valueB = [objectB valueForKey:propertyName];
     
@@ -55,7 +56,8 @@ static inline BOOL HUBPropertyIsEqual(NSObject * _Nullable objectA, NSObject * _
  *
  *  This function asserts that a view has been loaded after -loadView was sent to the component.
  */
-static inline UIView *HUBComponentLoadViewIfNeeded(id<HUBComponent> component) {
+static inline UIView *HUBComponentLoadViewIfNeeded(id<HUBComponent> component)
+{
     if (component.view == nil) {
         [component loadView];
     }
@@ -101,7 +103,8 @@ static inline NSError * _Nullable HUBAddJSONDataToBuilder(NSData *data, id<HUBJS
  *  will be added to `dictionaryA`, overriding any values that have duplicate keys in both dictionaries.
  */
 static inline NSDictionary<NSString *, id> * _Nullable HUBMergeDictionaries(NSDictionary<NSString *, id> * _Nullable dictionaryA,
-                                                                            NSDictionary<NSString *, id> * _Nullable dictionaryB) {
+                                                                            NSDictionary<NSString *, id> * _Nullable dictionaryB)
+{
     if (dictionaryA == nil) {
         return dictionaryB;
     }
@@ -121,7 +124,8 @@ static inline NSDictionary<NSString *, id> * _Nullable HUBMergeDictionaries(NSDi
  *  This function is used to determine which properties should be compared or copied. Note that
  *  `HUBAutoEquatable` is not used here, since we don't control the implementation of the class.
  */
-static inline NSArray<NSString *> *HUBNavigationItemPropertyNames() {
+static inline NSArray<NSString *> *HUBNavigationItemPropertyNames()
+{
     return @[
         HUBKeyPath((UINavigationItem *)nil, title),
         HUBKeyPath((UINavigationItem *)nil, titleView),
@@ -143,7 +147,8 @@ static inline NSArray<NSString *> *HUBNavigationItemPropertyNames() {
  *  The two instances are considered equal if all properties which have names included in the array
  *  obtained by calling `HUBNavigationItemPropertyNames()` are equal.
  */
-static inline BOOL HUBNavigationItemEqualToNavigationItem(UINavigationItem *navigationItemA, UINavigationItem *navigationItemB) {
+static inline BOOL HUBNavigationItemEqualToNavigationItem(UINavigationItem *navigationItemA, UINavigationItem *navigationItemB)
+{
     for (NSString * const propertyName in HUBNavigationItemPropertyNames()) {
         if (!HUBPropertyIsEqual(navigationItemA, navigationItemB, propertyName)) {
             return NO;
@@ -164,7 +169,8 @@ static inline BOOL HUBNavigationItemEqualToNavigationItem(UINavigationItem *navi
  *  If `navigationItemB` is nil, all `navigationItemA` properties will be reset to `nil`. To determine
  *  which properties that should be handled, `HUBNavigationItemPropertyNames()` is called.
  */
-static inline UINavigationItem *HUBCopyNavigationItemProperties(UINavigationItem *navigationItemA, UINavigationItem * _Nullable navigationItemB) {
+static inline UINavigationItem *HUBCopyNavigationItemProperties(UINavigationItem *navigationItemA, UINavigationItem * _Nullable navigationItemB)
+{
     NSSet<NSString *> * const boolPropertyNames = [NSSet setWithObjects:HUBKeyPath(navigationItemA, hidesBackButton),
                                                                         HUBKeyPath(navigationItemA, leftItemsSupplementBackButton),
                                                                         nil];
@@ -192,7 +198,8 @@ static inline UINavigationItem *HUBCopyNavigationItemProperties(UINavigationItem
  *
  *  @return A string containing a serialized representation of the object (JSON), or nil if the operation failed
  */
-static inline NSString * _Nullable HUBSerializeToString(id<HUBSerializable> object) {
+static inline NSString * _Nullable HUBSerializeToString(id<HUBSerializable> object)
+{
     NSDictionary * const serialization = [object serialize];
     NSData * const jsonData = [NSJSONSerialization dataWithJSONObject:serialization options:NSJSONWritingPrettyPrinted error:nil];
     
@@ -211,7 +218,8 @@ static inline NSString * _Nullable HUBSerializeToString(id<HUBSerializable> obje
  *  The given block will be run synchronously in case this function is called on the main thread,
  *  or asynchronously if it's not.
  */
-static inline void HUBPerformOnMainQueue(dispatch_block_t block) {
+static inline void HUBPerformOnMainQueue(dispatch_block_t block)
+{
     if ([NSThread isMainThread]) {
         block();
         return;

--- a/tests/HUBComponentImageDataBuilderTests.m
+++ b/tests/HUBComponentImageDataBuilderTests.m
@@ -142,7 +142,7 @@
         }
     };
     
-    [self.builder addDataFromJSONDictionary:dictionary];
+    [self.builder addJSONDictionary:dictionary];
     
     XCTAssertEqualObjects(self.builder.URL, imageURL);
     XCTAssertEqualObjects(self.builder.placeholderIconIdentifier, @"place_holder");
@@ -164,7 +164,7 @@
     self.builder.localImage = localImage;
     self.builder.customData = @{@"custom": @"data"};
     
-    [self.builder addDataFromJSONDictionary:@{}];
+    [self.builder addJSONDictionary:@{}];
     
     XCTAssertEqualObjects(self.builder.placeholderIconIdentifier, @"placeholder");
     XCTAssertEqualObjects(self.builder.URL, imageURL);
@@ -175,10 +175,21 @@
 - (void)testAddingNonDictionaryJSONDataReturnsError
 {
     NSData * const stringData = [@"Not a dictionary" dataUsingEncoding:NSUTF8StringEncoding];
-    XCTAssertNotNil([self.builder addJSONData:stringData]);
-    
+    NSError *error = nil;
+
+    const BOOL success = [self.builder addJSONData:stringData error:&error];
+
+    XCTAssertFalse(success, @"Should not return success when failed to add JSON data");
+    XCTAssertNotNil(error, @"Should set the output error parameter");
+}
+
+- (void)testAddingNonDictionaryJSONDataDoesNotCrash
+{
     NSData * const arrayData = [NSJSONSerialization dataWithJSONObject:@[] options:(NSJSONWritingOptions)0 error:nil];
-    XCTAssertNotNil([self.builder addJSONData:arrayData]);
+
+    const BOOL success = [self.builder addJSONData:arrayData error:nil];
+
+    XCTAssertFalse(success, @"Should not return success when failed to add JSON data");
 }
 
 - (void)testCopying

--- a/tests/HUBComponentModelBuilderTests.m
+++ b/tests/HUBComponentModelBuilderTests.m
@@ -417,7 +417,7 @@
         ]
     };
     
-    [self.builder addDataFromJSONDictionary:dictionary];
+    [self.builder addJSONDictionary:dictionary];
     id<HUBComponentModel> const model = [self.builder buildForIndex:0 parent:nil];
     
     XCTAssertEqualObjects(model.componentIdentifier, componentIdentifier);
@@ -467,7 +467,7 @@
     self.builder.customData = @{@"custom": @"data"};
     
     NSData * const data = [NSJSONSerialization dataWithJSONObject:@{} options:(NSJSONWritingOptions)0 error:nil];
-    [self.builder addJSONData:data];
+    [self.builder addJSONData:data error:nil];
     
     XCTAssertEqualObjects(self.builder.componentNamespace, @"namespace");
     XCTAssertEqualObjects(self.builder.componentName, @"name");
@@ -491,7 +491,7 @@
         }
     };
     
-    [self.builder addDataFromJSONDictionary:JSONDictionary];
+    [self.builder addJSONDictionary:JSONDictionary];
     
     NSDictionary * const expectedMetadata = @{
         @"meta": @"data",
@@ -511,7 +511,7 @@
         }
     };
     
-    [self.builder addDataFromJSONDictionary:JSONDictionary];
+    [self.builder addJSONDictionary:JSONDictionary];
     
     NSDictionary * const expectedLoggingData = @{
         @"logging": @"data",
@@ -531,7 +531,7 @@
         }
     };
     
-    [self.builder addDataFromJSONDictionary:JSONDictionary];
+    [self.builder addJSONDictionary:JSONDictionary];
     
     NSDictionary * const expectedCustomData = @{
         @"custom": @"data",
@@ -544,10 +544,21 @@
 - (void)testAddingNonDictionaryJSONDataReturnsError
 {
     NSData * const stringData = [@"Not a dictionary" dataUsingEncoding:NSUTF8StringEncoding];
-    XCTAssertNotNil([self.builder addJSONData:stringData]);
-    
+    NSError *error = nil;
+
+    const BOOL success = [self.builder addJSONData:stringData error:&error];
+
+    XCTAssertFalse(success, @"Should not return success when failed to add JSON data");
+    XCTAssertNotNil(error, @"Should set the output error parameter");
+}
+
+- (void)testAddingNonDictionaryJSONDataDoesNotCrash
+{
     NSData * const arrayData = [NSJSONSerialization dataWithJSONObject:@[] options:(NSJSONWritingOptions)0 error:nil];
-    XCTAssertNotNil([self.builder addJSONData:arrayData]);
+
+    const BOOL success = [self.builder addJSONData:arrayData error:nil];
+
+    XCTAssertFalse(success, @"Should not return success when failed to add JSON data");
 }
 
 - (void)testCopying

--- a/tests/HUBComponentTargetBuilderTests.m
+++ b/tests/HUBComponentTargetBuilderTests.m
@@ -121,7 +121,7 @@
         ]
     };
     
-    [self.builder addDataFromJSONDictionary:dictionary];
+    [self.builder addJSONDictionary:dictionary];
     
     id<HUBComponentTarget> const target = [self.builder build];
     XCTAssertEqualObjects(target.actionIdentifiers, @[[[HUBIdentifier alloc] initWithNamespace:@"valid" name:@"action"]]);
@@ -143,7 +143,7 @@
         @"custom": @{@"json": @"customB"}
     };
     
-    [self.builder addDataFromJSONDictionary:dictionary];
+    [self.builder addJSONDictionary:dictionary];
     
     id<HUBComponentTarget> const target = [self.builder build];
     

--- a/tests/HUBJSONSchemaTests.m
+++ b/tests/HUBJSONSchemaTests.m
@@ -55,7 +55,7 @@
         ]
     };
     
-    [builder addDataFromJSONDictionary:dictionary];
+    [builder addJSONDictionary:dictionary];
     
     id<HUBViewModel> const viewModelFromSchema = [schema viewModelFromJSONDictionary:dictionary];
     id<HUBViewModel> const viewModelFromBuilder = [builder build];

--- a/tests/HUBViewModelBuilderTests.m
+++ b/tests/HUBViewModelBuilderTests.m
@@ -383,7 +383,7 @@
     };
     
     NSData * const data = [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingPrettyPrinted error:nil];
-    [self.builder addJSONData:data];
+    [self.builder addJSONData:data error:nil];
     
     id<HUBViewModel> const model = [self.builder build];
     
@@ -420,7 +420,7 @@
     ];
     
     NSData * const data = [NSJSONSerialization dataWithJSONObject:array options:NSJSONWritingPrettyPrinted error:nil];
-    [self.builder addJSONData:data];
+    [self.builder addJSONData:data error:nil];
     
     id<HUBViewModel> const model = [self.builder build];
     
@@ -430,8 +430,8 @@
 
 - (void)testAddingInvalidJSONData
 {
-    NSData * const data = [@"Clearly not JSON" dataUsingEncoding:NSUTF8StringEncoding];
-    XCTAssertNotNil([self.builder addJSONData:data]);
+    NSData * const data = [@"<html><head><title>Clearly not JSON</title></head></html>" dataUsingEncoding:NSUTF8StringEncoding];
+    XCTAssertFalse([self.builder addJSONData:data error:nil], @"Adding invalid JSON data should fail");
 }
 
 - (void)testAddingJSONDataNotRemovingExistingData
@@ -443,7 +443,7 @@
     [self.builder builderForBodyComponentModelWithIdentifier:@"component"].title = @"body title";
     
     NSData * const emptyJSONData = [NSJSONSerialization dataWithJSONObject:@{} options:NSJSONWritingPrettyPrinted error:nil];
-    [self.builder addJSONData:emptyJSONData];
+    [self.builder addJSONData:emptyJSONData error:nil];
     
     XCTAssertEqualObjects(self.builder.viewIdentifier, @"view");
     XCTAssertEqualObjects(self.builder.navigationBarTitle, @"title");
@@ -463,7 +463,7 @@
     };
     
     NSData * const JSONData = [NSJSONSerialization dataWithJSONObject:JSONDictionary options:NSJSONWritingPrettyPrinted error:nil];
-    [self.builder addJSONData:JSONData];
+    [self.builder addJSONData:JSONData error:nil];
     
     NSDictionary * const expectedCustomData = @{
         @"custom": @"data",


### PR DESCRIPTION
This PR resolves #232. More specifically it renames `-addJSONData:` to `-addJSONData:error:`, moving returned error to an out-parameter, instead returning a boolean success status. As well as renaming `-addDataFromJSONDictionary:` to `-addJSONDictionary:`

The methods where renamed to be more coherent and improve how they’re imported in Swift. This changes the addJSONData:error: method to now return its status and return the error via the passed in `NSError **`. Additionally the name of the methods is slightly tweaked when imported by Swift. As to make them read nicer. The methods will now import as follows in Swift:
```swift
public func addJSON(data: Data) throws
public func addJSON(dictionary: [String : Any])
```

As part of this change the `HUBAddJSONDataToBuilder()` function was refactored. Furthermore a function for setting the output error, `BOOL HUBSetOutError(NSError **, NSError *)`, was added.

Lastly a few bugs where fixed where the output `error` was checked. Instead of the method’s return value. This is unsafe since Cocoa sometimes uses the passed in pointer for internal stuff.

@spotify/objc-dev 