### PR TITLE
ScrollHandler can manage the center point of overlay components.

### DIFF
--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -78,6 +78,17 @@
 - (UIEdgeInsets)contentInsetsForViewController:(HUBViewController *)viewController
                          proposedContentInsets:(UIEdgeInsets)proposedContentInsets;
 
+
+/**
+ *  Return the center point of an overlay coponent used in a view controller
+ *
+ *  @param viewController The view controller in question
+ *  @param proposedCenterPoint The center point that the Hub Framework is proposing
+ *
+ */
+- (CGPoint)centerPointForOverlayComponentInViewController:(HUBViewController *)viewController
+                                      proposedCenterPoint:(CGPoint)proposedCenterPoint;
+
 /**
  *  React to that a scrolling event started in a view controller
  *

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -1051,7 +1051,10 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     CGRect frame = self.view.bounds;
     frame.origin.y = self.collectionView.contentInset.top;
     frame.size.height -= self.visibleKeyboardHeight + CGRectGetMinY(frame);
-    return CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
+
+    CGPoint proposedCenterPoint = CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
+    return [self.scrollHandler centerPointForOverlayComponentInViewController:self
+                                                          proposedCenterPoint:proposedCenterPoint];
 }
 
 - (void)updateOverlayComponentCenterPointsWithKeyboardNotification:(NSNotification *)notification

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
     return proposedContentInsets;
 }
 
+- (CGPoint)centerPointForOverlayComponentInViewController:(HUBViewController *)viewController
+                                      proposedCenterPoint:(CGPoint)proposedCenterPoint
+{
+    return proposedCenterPoint;
+}
+
 - (void)scrollingWillStartInViewController:(HUBViewController *)viewController
                         currentContentRect:(CGRect)currentContentRect
 {

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -2809,7 +2809,7 @@
     NSNotification * const keyboardNotification = [NSNotification notificationWithName:UIKeyboardWillShowNotification
                                                                                 object:nil
                                                                               userInfo:notificationUserInfo];
-    
+
     // Show keyboard, which should push the overlay component
     NSNotificationCenter * const notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter postNotification:keyboardNotification];
@@ -2820,6 +2820,13 @@
     // Hide keyboard, which should pull the overlay component back down
     [notificationCenter postNotificationName:UIKeyboardWillHideNotification object:nil];
     
+    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualFloatValues(self.component.view.center.y, 200);
+
+    self.scrollHandler.overlayCenterPointHandler = ^(HUBViewController *viewController, CGPoint proposedCenterPoint) {
+        return CGPointMake(CGRectGetMidX(viewController.view.frame), CGRectGetMidY(viewController.view.frame));
+    };
+    [notificationCenter postNotification:keyboardNotification];
     HUBAssertEqualFloatValues(self.component.view.center.x, 160);
     HUBAssertEqualFloatValues(self.component.view.center.y, 200);
 }

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.h
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// A block that can be used instead of the @c contentInset property to determine the content inset.
 @property (nonatomic, copy) UIEdgeInsets (^ _Nullable contentInsetHandler)(HUBViewController *controller, UIEdgeInsets proposedOffset);
 
+/// A block that can be used instead to set the center point of the overlay components.
+@property (nonatomic, copy) CGPoint (^ _Nullable overlayCenterPointHandler)(HUBViewController *controller, CGPoint proposedCenterPoint);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBViewControllerScrollHandlerMock.m
+++ b/tests/mocks/HUBViewControllerScrollHandlerMock.m
@@ -58,6 +58,15 @@ NS_ASSUME_NONNULL_BEGIN
     return proposedContentInsets;
 }
 
+- (CGPoint)centerPointForOverlayComponentInViewController:(HUBViewController *)viewController
+                                      proposedCenterPoint:(CGPoint)proposedCenterPoint
+{
+    if (self.overlayCenterPointHandler) {
+        return self.overlayCenterPointHandler(viewController, proposedCenterPoint);
+    }
+    return proposedCenterPoint;
+}
+
 - (void)scrollingWillStartInViewController:(HUBViewController *)viewController
                         currentContentRect:(CGRect)currentContentRect
 {


### PR DESCRIPTION
This PR adds a possibility to customise the center point of overlay components in `HUBViewControllerScrollHandler`.