### PR TITLE
View controller: Don’t force image loading to be async

### DIFF
--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -1296,10 +1296,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     if (contextsForURL == nil) {
         contextsForURL = [NSMutableArray arrayWithObject:context];
         self.componentImageLoadingContexts[imageURL] = contextsForURL;
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self.imageLoader loadImageForURL:imageURL targetSize:preferredSize];
-        });
+        [self.imageLoader loadImageForURL:imageURL targetSize:preferredSize];
     } else {
         [contextsForURL addObject:context];
     }


### PR DESCRIPTION
Previously, all image loading (even from cache) was forced to be async. The reason behind this was that we were using collection view cells to track what images belong to what component. But since a while back we’re now using component wrappers for that instead, which means that we can now allow some image loading to be synchronous (that’s up to `HUBImageLoader`).

This heavily reduces image flickering in view that are rapidly reloaded.