### PR TITLE
Fix complaint about correct typography by Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -160,7 +160,7 @@ platform :ios do
   def shouldPerformStep(step)
     value = ENV[step].to_s.downcase
 
-    # We should perform if the value is the empty string, or if it’s set to `yes`, `true` or `1`
+    # We should perform if the value is the empty string, or if it's set to `yes`, `true` or `1`
     value.empty? or value == 'yes' or value == '1' or value == 'true'
   end
 


### PR DESCRIPTION
Fastlane, just like Danger so might a Ruby thing, prints a warning if typographic quotation marks, apostrophes and so on are use. Even when used only in a comment…

This changes so that Fastlane won’t be sad anymore. Instead we’ll let humans reading the comments be sad 😢 Yes I’m sad right now 😢 

@spotify/objc-dev 