### PR TITLE
Make HUBAddJSONDataToBuilder() safer and rework error creation

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 		8AFF0F9A1C85C73300D5535B /* HUBCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */; };
 		8AFF10071C87105C00D5535B /* HUBComponentFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */; };
 		B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */; };
+		DD244A821E04520F005E5C68 /* HUBErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD244A811E04520D005E5C68 /* HUBErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DDBCF36C1C68DD2300693038 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36B1C68DD2300693038 /* UIKit.framework */; };
 		DDBCF36E1C68DE2C00693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
 		DDBCF36F1C68DE4900693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
@@ -741,6 +742,7 @@
 		B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionViewFactoryTests.m; sourceTree = "<group>"; };
 		DD13758E1C68C76000AD3499 /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
 		DD13758F1C68C76000AD3499 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
+		DD244A811E04520D005E5C68 /* HUBErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBErrors.h; sourceTree = "<group>"; };
 		DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBKeyPath.h; sourceTree = "<group>"; };
 		DD81AFEF1DF725040063DDE0 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBUtilities.h; sourceTree = "<group>"; };
@@ -944,10 +946,11 @@
 		8A2061111CCA1992008C34E3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				525E2F5C1DF4CEED008DCB85 /* HUBDefaults.h */,
+				DD244A811E04520D005E5C68 /* HUBErrors.h */,
 				8A5D7A5A1CB806E200B987BA /* HUBHeaderMacros.h */,
 				8AF21C9D1C6D044700960A06 /* HUBIdentifier.h */,
 				8A0E4B801CB69CD80019DE71 /* HUBSerializable.h */,
-				525E2F5C1DF4CEED008DCB85 /* HUBDefaults.h */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -1623,6 +1626,7 @@
 				8AE6C0791DF6E4020063B2B1 /* HUBFeatureRegistryImplementation.h in Headers */,
 				8AE6C0441DF6E3D40063B2B1 /* HUBComponentModel.h in Headers */,
 				8AE6C0771DF6E3F90063B2B1 /* HUBJSONParsingOperation.h in Headers */,
+				DD244A821E04520F005E5C68 /* HUBErrors.h in Headers */,
 				8AE6C0511DF6E3D40063B2B1 /* HUBScrollPosition.h in Headers */,
 				8AE6C0A21DF6E4020063B2B1 /* HUBViewModelDiff.h in Headers */,
 				8AE6C01D1DF6E3BE0063B2B1 /* HUBComponentTargetJSONSchema.h in Headers */,

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -409,6 +409,8 @@
 		8AFF10071C87105C00D5535B /* HUBComponentFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */; };
 		B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */; };
 		DD244A821E04520F005E5C68 /* HUBErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD244A811E04520D005E5C68 /* HUBErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD244B191E086958005E5C68 /* HUBErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD244B181E086958005E5C68 /* HUBErrors.m */; };
+		DD244B1A1E086958005E5C68 /* HUBErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD244B181E086958005E5C68 /* HUBErrors.m */; };
 		DDBCF36C1C68DD2300693038 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36B1C68DD2300693038 /* UIKit.framework */; };
 		DDBCF36E1C68DE2C00693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
 		DDBCF36F1C68DE4900693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
@@ -743,6 +745,7 @@
 		DD13758E1C68C76000AD3499 /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
 		DD13758F1C68C76000AD3499 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
 		DD244A811E04520D005E5C68 /* HUBErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBErrors.h; sourceTree = "<group>"; };
+		DD244B181E086958005E5C68 /* HUBErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBErrors.m; sourceTree = "<group>"; };
 		DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBKeyPath.h; sourceTree = "<group>"; };
 		DD81AFEF1DF725040063DDE0 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBUtilities.h; sourceTree = "<group>"; };
@@ -936,6 +939,7 @@
 			children = (
 				8ADA48551D784C1400C27F21 /* HUBAutoEquatable.h */,
 				8ADA48561D784C1400C27F21 /* HUBAutoEquatable.m */,
+				DD244B181E086958005E5C68 /* HUBErrors.m */,
 				8ACB2A791C6A2F7C000741D7 /* HUBIdentifier.m */,
 				DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */,
 				DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */,
@@ -1832,6 +1836,7 @@
 				8A786BB81C5A4CB400B2AB9E /* HUBMutableJSONPathImplementation.m in Sources */,
 				8AD0646C1C68E7B00086C081 /* HUBComponentCollectionViewCell.m in Sources */,
 				8A2A72F31D4B75DA00141619 /* HUBActionRegistryImplementation.m in Sources */,
+				DD244B191E086958005E5C68 /* HUBErrors.m in Sources */,
 				8A6529F91D82DC33007B1A15 /* HUBActionHandlerWrapper.m in Sources */,
 				8A786BB21C5A383800B2AB9E /* HUBViewModelJSONSchemaImplementation.m in Sources */,
 				8A5035221DD473040008B499 /* HUBCollectionView.m in Sources */,
@@ -2041,6 +2046,7 @@
 				8AE6C06A1DF6E3F90063B2B1 /* HUBComponentModelJSONSchemaImplementation.m in Sources */,
 				8AE6C0821DF6E4020063B2B1 /* HUBContentOperationWrapper.m in Sources */,
 				8AE6C0961DF6E4020063B2B1 /* HUBViewControllerFactoryImplementation.m in Sources */,
+				DD244B1A1E086958005E5C68 /* HUBErrors.m in Sources */,
 				8AE6C0BA1DF6E40D0063B2B1 /* HUBComponentCollectionViewCell.m in Sources */,
 				8AE6C0681DF6E3F90063B2B1 /* HUBViewModelJSONSchemaImplementation.m in Sources */,
 				8AE6C0AB1DF6E40D0063B2B1 /* HUBComponentModelImplementation.m in Sources */,

--- a/include/HubFramework/HUBComponentCategories.h
+++ b/include/HubFramework/HUBComponentCategories.h
@@ -31,7 +31,7 @@
  *  behavior, but still contain enough information for a `HUBComponentFallbackHandler` to create appropriate fallback
  *  components based on them.
  */
-typedef NSString * HUBComponentCategory NS_EXTENSIBLE_STRING_ENUM;
+typedef NSString * HUBComponentCategory HUBS_EXTENSIBLE_STRING_ENUM;
 
 /// Category for components that have a header-like appearance, usually used for header components
 static HUBComponentCategory const HUBComponentCategoryHeader = @"header";

--- a/include/HubFramework/HUBComponentLayoutTraits.h
+++ b/include/HubFramework/HUBComponentLayoutTraits.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Ideally, a layout trait should be generic enough to apply to a broad range of components, but still contain enough
  *  information for a `HUBComponentLayoutManager` to make correct decisions based on them.
  */
-typedef NSString * HUBComponentLayoutTrait NS_EXTENSIBLE_STRING_ENUM;
+typedef NSString * HUBComponentLayoutTrait HUBS_EXTENSIBLE_STRING_ENUM;
 
 /// Layout trait for components which width does not fill the screen and is considered compact
 static HUBComponentLayoutTrait const HUBComponentLayoutTraitCompactWidth = @"compactWidth";

--- a/include/HubFramework/HUBErrors.h
+++ b/include/HubFramework/HUBErrors.h
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - JSON Serialization Errors
+
+#pragma mark Error Domain
+/// Error domain for JSON serialization errors.
+static NSErrorDomain const HUBJSONSerializationErrorDomain = @"com.spotify.hubframework.json-serialization";
+
+#pragma mark Error Codes
+/**
+ *  Error code identifying the type of JSON serialization error that occurred.
+ *
+ *  - HUBJSONSerializationErrorCodeInvalidJSON: The data passed as JSON data was invalid.
+ */
+typedef NS_ENUM(NSInteger, HUBJSONSerializationErrorCode) {
+    HUBJSONSerializationErrorCodeInvalidJSON,
+};
+
+
+#pragma mark - Image Loading Errors
+
+#pragma mark Error Domain
+/// Error domain for image loading errors.
+static NSErrorDomain const HUBImageLoaderErrorDomain = @"com.spotify.hubframework.image-loader";
+
+#pragma mark Error Codes
+/**
+ *  Error code identifying the type of image loader error that occurred.
+ *
+ *  - HUBImageLoaderErrorCodeUnknown: The image data couldn’t be loaded for an unknown reason.
+ *  - HUBImageLoaderErrorCodeInvalidData: The data passed as image data was invalid.
+ */
+typedef NS_ENUM(NSInteger, HUBImageLoaderErrorCode) {
+    HUBImageLoaderErrorCodeUnknown,
+    HUBImageLoaderErrorCodeInvalidData,
+};
+
+NS_ASSUME_NONNULL_END

--- a/include/HubFramework/HUBErrors.h
+++ b/include/HubFramework/HUBErrors.h
@@ -23,11 +23,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma mark Xcode 7 Compatibility
+
+/// `NSErrorDomain` was introduced in Xcode 8 along with `NS_EXTENSIBLE_STRING_ENUM`. as such we need to fallback to
+/// the raw `NSString *` when we compile using Xcode 7.
+#ifdef NS_EXTENSIBLE_STRING_ENUM
+    #define HUBErrorDomain NSErrorDomain
+#else // NS_EXTENSIBLE_STRING_ENUM
+    #define HUBErrorDomain NSString *
+#endif // NS_EXTENSIBLE_STRING_ENUM
+
+
 #pragma mark - JSON Serialization Errors
 
 #pragma mark Error Domain
 /// Error domain for JSON serialization errors.
-FOUNDATION_EXPORT NSErrorDomain const HUBJSONSerializationErrorDomain;
+FOUNDATION_EXPORT HUBErrorDomain const HUBJSONSerializationErrorDomain;
 
 #pragma mark Error Codes
 /**
@@ -46,7 +57,7 @@ typedef NS_ENUM(NSInteger, HUBJSONSerializationErrorCode) {
 
 #pragma mark Error Domain
 /// Error domain for image loading errors.
-FOUNDATION_EXPORT NSErrorDomain const HUBImageLoaderErrorDomain;
+FOUNDATION_EXPORT HUBErrorDomain const HUBImageLoaderErrorDomain;
 
 #pragma mark Error Codes
 /**

--- a/include/HubFramework/HUBErrors.h
+++ b/include/HubFramework/HUBErrors.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Error Domain
 /// Error domain for JSON serialization errors.
-static NSErrorDomain const HUBJSONSerializationErrorDomain = @"com.spotify.hubframework.json-serialization";
+FOUNDATION_EXPORT NSErrorDomain const HUBJSONSerializationErrorDomain;
 
 #pragma mark Error Codes
 /**
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, HUBJSONSerializationErrorCode) {
 
 #pragma mark Error Domain
 /// Error domain for image loading errors.
-static NSErrorDomain const HUBImageLoaderErrorDomain = @"com.spotify.hubframework.image-loader";
+FOUNDATION_EXPORT NSErrorDomain const HUBImageLoaderErrorDomain;
 
 #pragma mark Error Codes
 /**

--- a/include/HubFramework/HUBErrors.h
+++ b/include/HubFramework/HUBErrors.h
@@ -33,9 +33,11 @@ static NSErrorDomain const HUBJSONSerializationErrorDomain = @"com.spotify.hubfr
 /**
  *  Error code identifying the type of JSON serialization error that occurred.
  *
+ *  - HUBJSONSerializationErrorCodeEmptyData: The given data object was empty or `nil`.
  *  - HUBJSONSerializationErrorCodeInvalidJSON: The data passed as JSON data was invalid.
  */
 typedef NS_ENUM(NSInteger, HUBJSONSerializationErrorCode) {
+    HUBJSONSerializationErrorCodeEmptyData,
     HUBJSONSerializationErrorCodeInvalidJSON,
 };
 

--- a/include/HubFramework/HUBHeaderMacros.h
+++ b/include/HubFramework/HUBHeaderMacros.h
@@ -31,10 +31,13 @@
     /** Unavailable. Use the designated initializer instead */ \
     - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 
-/// This macro was introduced in Xcode 8, so adding this here for now (if not defined) to support Xcode 7 as well
-#ifndef NS_EXTENSIBLE_STRING_ENUM
-    #define NS_EXTENSIBLE_STRING_ENUM
-#endif
+/// This macro was introduced in Xcode 8, so adding this here for now (if not defined) to support Xcode 7 as well.
+#ifdef NS_EXTENSIBLE_STRING_ENUM
+    #define HUBS_EXTENSIBLE_STRING_ENUM NS_EXTENSIBLE_STRING_ENUM
+#else // NS_EXTENSIBLE_STRING_ENUM
+    #define HUBS_EXTENSIBLE_STRING_ENUM
+#endif // NS_EXTENSIBLE_STRING_ENUM
+
 
 /// Define an explicit `HUB_DEBUG` macro for conditionally compiling debug code
 #ifdef DEBUG

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -22,6 +22,7 @@
 #import "HUBManager.h"
 #import "HUBConnectivityStateResolver.h"
 #import "HUBDefaults.h"
+#import "HUBErrors.h"
 
 // JSON
 #import "HUBJSONSchema.h"

--- a/sources/HUBDefaultImageLoader.m
+++ b/sources/HUBDefaultImageLoader.m
@@ -21,6 +21,7 @@
 
 
 #import "HUBDefaultImageLoader.h"
+#import "HUBErrors.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -60,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
         id<HUBImageLoaderDelegate> const delegate = strongSelf.delegate;
         
         if (data == nil || error != nil) {
-            NSError * const nonNilError = error ?: [strongSelf createErrorWithIdentifier:@"unknown"];
+            NSError * const nonNilError = error ?: [NSError errorWithDomain:HUBImageLoaderErrorDomain code:HUBImageLoaderErrorCodeUnknown userInfo:nil];
             [delegate imageLoader:strongSelf didFailLoadingImageForURL:imageURL error:nonNilError];
             return;
         }
@@ -69,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
         UIImage *image = [UIImage imageWithData:nonNilData scale:[UIScreen mainScreen].scale];
         
         if (image == nil) {
-            NSError * const dataError = [self createErrorWithIdentifier:@"invalidData"];
+            NSError * const dataError = [NSError errorWithDomain:HUBImageLoaderErrorDomain code:HUBImageLoaderErrorCodeInvalidData userInfo:nil];
             [delegate imageLoader:strongSelf didFailLoadingImageForURL:imageURL error:dataError];
             return;
         }
@@ -86,12 +87,6 @@ NS_ASSUME_NONNULL_BEGIN
     }];
 
     [task resume];
-}
-
-- (NSError *)createErrorWithIdentifier:(NSString *)identifier
-{
-    NSString * const domain = [NSString stringWithFormat:@"com.spotify.hubFramework.imageLoader.%@", identifier];
-    return [NSError errorWithDomain:domain code:-1 userInfo:nil];
 }
 
 @end

--- a/sources/HUBErrors.m
+++ b/sources/HUBErrors.m
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBErrors.h"
+
+NSErrorDomain const HUBJSONSerializationErrorDomain = @"com.spotify.hubframework.json-serialization";
+NSErrorDomain const HUBImageLoaderErrorDomain = @"com.spotify.hubframework.image-loader";

--- a/sources/HUBErrors.m
+++ b/sources/HUBErrors.m
@@ -21,5 +21,5 @@
 
 #import "HUBErrors.h"
 
-NSErrorDomain const HUBJSONSerializationErrorDomain = @"com.spotify.hubframework.json-serialization";
-NSErrorDomain const HUBImageLoaderErrorDomain = @"com.spotify.hubframework.image-loader";
+HUBErrorDomain const HUBJSONSerializationErrorDomain = @"com.spotify.hubframework.json-serialization";
+HUBErrorDomain const HUBImageLoaderErrorDomain = @"com.spotify.hubframework.image-loader";

--- a/sources/HUBUtilities.h
+++ b/sources/HUBUtilities.h
@@ -22,9 +22,10 @@
 #import <UIKit/UIKit.h>
 
 #import "HUBComponent.h"
+#import "HUBErrors.h"
 #import "HUBJSONCompatibleBuilder.h"
-#import "HUBSerializable.h"
 #import "HUBKeyPath.h"
+#import "HUBSerializable.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -108,7 +109,7 @@ static inline BOOL HUBAddJSONDataToBuilder(NSData *data,
     }
 
     if (![JSONObject isKindOfClass:[NSDictionary class]]) {
-        return HUBSetOutError(outError, [NSError errorWithDomain:@"spotify.com.hubFramework.invalidJSON" code:0 userInfo:nil]);
+        return HUBSetOutError(outError, [NSError errorWithDomain:HUBJSONSerializationErrorDomain code:HUBJSONSerializationErrorCodeInvalidJSON userInfo:nil]);
     }
     
     [builder addJSONDictionary:(NSDictionary *)JSONObject];

--- a/sources/HUBUtilities.h
+++ b/sources/HUBUtilities.h
@@ -101,6 +101,10 @@ static inline BOOL HUBAddJSONDataToBuilder(NSData *data,
                                            id<HUBJSONCompatibleBuilder> builder,
                                            NSError * _Nullable __autoreleasing *outError)
 {
+    if (data.length == 0) {
+        return HUBSetOutError(outError, [NSError errorWithDomain:HUBJSONSerializationErrorDomain code:HUBJSONSerializationErrorCodeEmptyData userInfo:nil]);
+    }
+
     NSError *JSONError;
     id JSONObject = [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:&JSONError];
 


### PR DESCRIPTION
This PR makes the helper `HUBAddJSONDataToBuilder()` function safer and reworks how we create errors.

### Make `HUBAddJSONDataToBuilder()` safer
This makes adding JSON data to a `HUBJSONCompatibleBuilder` safer. Since we’ll make sure `nil` isn’t passed to an Apple API that doesn’t support it.

Basically the Objective-C compiler is so easy to trick about nullability we’ve observed places where `nil` was passed to `addJSONData:error:`. This change makes sure we catch that before sending nil to an Apple owned API parameter that is marked as nonnull. Better safe than sorry eh 😅

### Rework how we create errors
This changes all errors to use a domain and code.

The standard Cocoa way of creating errors is to create an error domain that groups errors belonging together. The domain should not be used to identify _specific_ errors, as was done before this PR. Instead the combination of error domain and code should be used to identify a specific error. Which should then obviously be handled accordingly 😉 

I’ve translated the existing potential errors from the unique error domains they were using to domain + codes tuples.

---

Review would be appreciated @spotify/objc-dev 🛩 