### PR TITLE
Remove code that is reseting the content offset when insets change

### DIFF
--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -1141,14 +1141,8 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     contentInsets = [self.scrollHandler contentInsetsForViewController:self
                                                  proposedContentInsets:contentInsets];
 
-    if (!UIEdgeInsetsEqualToEdgeInsets(self.collectionView.contentInset, contentInsets)) {
-        self.collectionView.contentInset = contentInsets;
-        CGPoint contentOffset = self.collectionView.contentOffset;
-        contentOffset.y = -contentInsets.top;
-        [self setContentOffset:contentOffset animated:NO];
-    }
-
-    self.collectionView.scrollIndicatorInsets = self.collectionView.contentInset;
+    self.collectionView.contentInset = contentInsets;
+    self.collectionView.scrollIndicatorInsets = contentInsets;
 }
 
 - (void)collectionViewCellWillAppear:(HUBComponentCollectionViewCell *)cell


### PR DESCRIPTION
That code was probably a workaround for some issue but it is not covered by any tests and there are no comments. Given the fact that it has side effects causing bugs (if the collection view is scrolled to a specific position when the content insets change, the content offset will be reset) it is better if this code is removed.