### PR TITLE
Expose the default scroll handler as a override point [fixed]

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -334,7 +334,6 @@
 		8AE6C09D1DF6E4020063B2B1 /* HUBViewURIPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E4B791CB562140019DE71 /* HUBViewURIPredicate.m */; };
 		8AE6C09E1DF6E4020063B2B1 /* HUBContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD009FC1CC64EF80012A9AF /* HUBContainerView.h */; };
 		8AE6C09F1DF6E4020063B2B1 /* HUBContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD009FD1CC64EF80012A9AF /* HUBContainerView.m */; };
-		8AE6C0A01DF6E4020063B2B1 /* HUBViewControllerDefaultScrollHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AEDA0981D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.h */; };
 		8AE6C0A11DF6E4020063B2B1 /* HUBViewControllerDefaultScrollHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDA0991D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.m */; };
 		8AE6C0A21DF6E4020063B2B1 /* HUBViewModelDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = F66658D71D9925CC0097929F /* HUBViewModelDiff.h */; };
 		8AE6C0A31DF6E4020063B2B1 /* HUBViewModelDiff.m in Sources */ = {isa = PBXBuildFile; fileRef = F66658D81D9925CC0097929F /* HUBViewModelDiff.m */; };
@@ -717,7 +716,6 @@
 		8AE6C0001DF6E3110063B2B1 /* HubFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HubFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AE6C0081DF6E3330063B2B1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = sources/Info.plist; sourceTree = "<group>"; };
 		8AED9F8F1D77090D00BEFD66 /* HUBViewControllerScrollHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerScrollHandler.h; sourceTree = "<group>"; };
-		8AEDA0981D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerDefaultScrollHandler.h; sourceTree = "<group>"; };
 		8AEDA0991D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewControllerDefaultScrollHandler.m; sourceTree = "<group>"; };
 		8AF21C9D1C6D044700960A06 /* HUBIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBIdentifier.h; sourceTree = "<group>"; };
 		8AF5B57D1C64B59E001FF228 /* HUBViewModelLoaderImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewModelLoaderImplementation.h; sourceTree = "<group>"; };
@@ -742,6 +740,7 @@
 		8AFF10061C87015A00D5535B /* HUBComponentLayoutTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBComponentLayoutTraits.h; sourceTree = "<group>"; };
 		9996E9691C6A42E000231D22 /* HUBComponentFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactory.h; sourceTree = "<group>"; };
 		B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionViewFactoryTests.m; sourceTree = "<group>"; };
+		B38EA90C1DFEF18400526587 /* HUBViewControllerDefaultScrollHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerDefaultScrollHandler.h; sourceTree = "<group>"; };
 		DD13758E1C68C76000AD3499 /* project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = project.xcconfig; sourceTree = "<group>"; };
 		DD13758F1C68C76000AD3499 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
 		DD244A811E04520D005E5C68 /* HUBErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBErrors.h; sourceTree = "<group>"; };
@@ -1458,6 +1457,7 @@
 				8AD064771C6906B00086C081 /* HUBViewControllerFactory.h */,
 				8A0E4B761CB561DE0019DE71 /* HUBViewURIPredicate.h */,
 				8AED9F8F1D77090D00BEFD66 /* HUBViewControllerScrollHandler.h */,
+				B38EA90C1DFEF18400526587 /* HUBViewControllerDefaultScrollHandler.h */,
 			);
 			name = View;
 			sourceTree = "<group>";
@@ -1490,7 +1490,6 @@
 				8A0E4B791CB562140019DE71 /* HUBViewURIPredicate.m */,
 				8AD009FC1CC64EF80012A9AF /* HUBContainerView.h */,
 				8AD009FD1CC64EF80012A9AF /* HUBContainerView.m */,
-				8AEDA0981D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.h */,
 				8AEDA0991D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.m */,
 				F66658D71D9925CC0097929F /* HUBViewModelDiff.h */,
 				F66658D81D9925CC0097929F /* HUBViewModelDiff.m */,
@@ -1594,7 +1593,6 @@
 				8AE6C05B1DF6E3E00063B2B1 /* HUBActionHandler.h in Headers */,
 				8AE6C03C1DF6E3D40063B2B1 /* HUBComponentWithSelectionState.h in Headers */,
 				8AE6C02F1DF6E3CE0063B2B1 /* HUBViewModelLoader.h in Headers */,
-				8AE6C0A01DF6E4020063B2B1 /* HUBViewControllerDefaultScrollHandler.h in Headers */,
 				8AE6C0C71DF6E4100063B2B1 /* HUBDefaultImageLoader.h in Headers */,
 				8AE6C0891DF6E4020063B2B1 /* HUBViewModelImplementation.h in Headers */,
 				8AE6C0B01DF6E40D0063B2B1 /* HUBComponentImageDataImplementation.h in Headers */,

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -406,7 +406,7 @@
 		8AFF0F321C846DA700D5535B /* HUBComponentWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F311C846DA700D5535B /* HUBComponentWrapper.m */; };
 		8AFF0F9A1C85C73300D5535B /* HUBCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */; };
 		8AFF10071C87105C00D5535B /* HUBComponentFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */; };
-		B30B7F4F1E005AB30049D013 /* HUBViewControllerDefaultScrollHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B38EA90C1DFEF18400526587 /* HUBViewControllerDefaultScrollHandler.h */; };
+		B30B7F4F1E005AB30049D013 /* HUBViewControllerDefaultScrollHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B38EA90C1DFEF18400526587 /* HUBViewControllerDefaultScrollHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */; };
 		DD244A821E04520F005E5C68 /* HUBErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD244A811E04520D005E5C68 /* HUBErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD244B191E086958005E5C68 /* HUBErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD244B181E086958005E5C68 /* HUBErrors.m */; };

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 		8AFF0F321C846DA700D5535B /* HUBComponentWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F311C846DA700D5535B /* HUBComponentWrapper.m */; };
 		8AFF0F9A1C85C73300D5535B /* HUBCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */; };
 		8AFF10071C87105C00D5535B /* HUBComponentFactoryMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */; };
+		B30B7F4F1E005AB30049D013 /* HUBViewControllerDefaultScrollHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B38EA90C1DFEF18400526587 /* HUBViewControllerDefaultScrollHandler.h */; };
 		B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B35E40F81DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m */; };
 		DD244A821E04520F005E5C68 /* HUBErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD244A811E04520D005E5C68 /* HUBErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD244B191E086958005E5C68 /* HUBErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD244B181E086958005E5C68 /* HUBErrors.m */; };
@@ -1605,6 +1606,7 @@
 				8AE6C0481DF6E3D40063B2B1 /* HUBComponentTarget.h in Headers */,
 				8AE6C05F1DF6E3E60063B2B1 /* HUBHeaderMacros.h in Headers */,
 				8AE6C02B1DF6E3C80063B2B1 /* HUBBlockContentOperationFactory.h in Headers */,
+				B30B7F4F1E005AB30049D013 /* HUBViewControllerDefaultScrollHandler.h in Headers */,
 				8AE6C01A1DF6E3BE0063B2B1 /* HUBViewModelJSONSchema.h in Headers */,
 				8AE6C04D1DF6E3D40063B2B1 /* HUBComponentCategories.h in Headers */,
 				8AE6C02A1DF6E3C80063B2B1 /* HUBContentOperationContext.h in Headers */,

--- a/include/HubFramework/HUBViewControllerDefaultScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerDefaultScrollHandler.h
@@ -23,7 +23,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Default view controller scroll handler, used for features that don't define their own
+/**
+ *  Default view controller scroll handler, used for features that don't define their own or as a override point
+ *  when specifying different behaviour just for few of the methods specified in `HUBViewControllerScrollHandler`
+ */
 @interface HUBViewControllerDefaultScrollHandler : NSObject <HUBViewControllerScrollHandler>
 
 @end

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -60,6 +60,7 @@
 #import "HUBViewControllerFactory.h"
 #import "HUBViewController.h"
 #import "HUBViewControllerScrollHandler.h"
+#import "HUBViewControllerDefaultScrollHandler.h"
 #import "HUBViewURIPredicate.h"
 
 // Components


### PR DESCRIPTION
This PR is a fixed version of #230. The problem with the initial PR was that it didn’t mark the header as _public_ for the framework. As such it didn’t build. Given an error about “duplicate module map”.

Since it’s a new PR I opted to rebase away the original merge with `master` commits.

Original description from @nataliq in #230:
> Moves the `HUBViewControllerDefaultScrollHandler` to the include folder so that it could be subclassed by features that want to provide different implementation just for few methods. Apart from that only the description of the class is slightly modified.

@spotify/objc-dev 