### PR TITLE
View controller: Make rendering code operation oriented

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -40,6 +40,13 @@
 		8A2A72E61D4B6F1700141619 /* HUBComponentTargetBuilderImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A72E51D4B6F1700141619 /* HUBComponentTargetBuilderImplementation.m */; };
 		8A2A72EB1D4B726800141619 /* HUBComponentTargetJSONSchemaImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A72EA1D4B726800141619 /* HUBComponentTargetJSONSchemaImplementation.m */; };
 		8A2A72F31D4B75DA00141619 /* HUBActionRegistryImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A72F21D4B75DA00141619 /* HUBActionRegistryImplementation.m */; };
+		8A2BD2011E0A6B40008A5050 /* HUBOperationQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2BD1FF1E0A6B40008A5050 /* HUBOperationQueue.h */; };
+		8A2BD2021E0A6B40008A5050 /* HUBOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BD2001E0A6B40008A5050 /* HUBOperationQueue.m */; };
+		8A2BD2031E0A6B41008A5050 /* HUBOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BD2001E0A6B40008A5050 /* HUBOperationQueue.m */; };
+		8A2BD20B1E0A7555008A5050 /* HUBOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2BD2091E0A7555008A5050 /* HUBOperation.h */; };
+		8A2BD20C1E0A7555008A5050 /* HUBOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BD20A1E0A7555008A5050 /* HUBOperation.m */; };
+		8A2BD20D1E0A7555008A5050 /* HUBOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BD20A1E0A7555008A5050 /* HUBOperation.m */; };
+		8A2BD2101E0AA444008A5050 /* HUBOperationQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BD20F1E0AA444008A5050 /* HUBOperationQueueTests.m */; };
 		8A2EC3751D7971A500E4CAB3 /* HUBViewControllerScrollHandlerMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2EC3741D7971A500E4CAB3 /* HUBViewControllerScrollHandlerMock.m */; };
 		8A3D83941CA3FC3500662B73 /* HUBJSONSchemaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A3D83931CA3FC3500662B73 /* HUBJSONSchemaTests.m */; };
 		8A48F2FF1C7C94EC00B1467C /* HUBViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A48F2FE1C7C94EC00B1467C /* HUBViewControllerTests.m */; };
@@ -520,6 +527,11 @@
 		8A2A72EE1D4B749600141619 /* HUBAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBAction.h; sourceTree = "<group>"; };
 		8A2A72F11D4B75DA00141619 /* HUBActionRegistryImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBActionRegistryImplementation.h; sourceTree = "<group>"; };
 		8A2A72F21D4B75DA00141619 /* HUBActionRegistryImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBActionRegistryImplementation.m; sourceTree = "<group>"; };
+		8A2BD1FF1E0A6B40008A5050 /* HUBOperationQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBOperationQueue.h; sourceTree = "<group>"; };
+		8A2BD2001E0A6B40008A5050 /* HUBOperationQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBOperationQueue.m; sourceTree = "<group>"; };
+		8A2BD2091E0A7555008A5050 /* HUBOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBOperation.h; sourceTree = "<group>"; };
+		8A2BD20A1E0A7555008A5050 /* HUBOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBOperation.m; sourceTree = "<group>"; };
+		8A2BD20F1E0AA444008A5050 /* HUBOperationQueueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBOperationQueueTests.m; sourceTree = "<group>"; };
 		8A2EC3731D7971A500E4CAB3 /* HUBViewControllerScrollHandlerMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerScrollHandlerMock.h; sourceTree = "<group>"; };
 		8A2EC3741D7971A500E4CAB3 /* HUBViewControllerScrollHandlerMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewControllerScrollHandlerMock.m; sourceTree = "<group>"; };
 		8A3D83931CA3FC3500662B73 /* HUBJSONSchemaTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBJSONSchemaTests.m; sourceTree = "<group>"; };
@@ -937,6 +949,7 @@
 		8A2061101CCA1971008C34E3 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				8A2BD20E1E0AA2CF008A5050 /* Operations */,
 				8ADA48551D784C1400C27F21 /* HUBAutoEquatable.h */,
 				8ADA48561D784C1400C27F21 /* HUBAutoEquatable.m */,
 				DD244B181E086958005E5C68 /* HUBErrors.m */,
@@ -991,6 +1004,17 @@
 			name = Actions;
 			sourceTree = "<group>";
 		};
+		8A2BD20E1E0AA2CF008A5050 /* Operations */ = {
+			isa = PBXGroup;
+			children = (
+				8A2BD2091E0A7555008A5050 /* HUBOperation.h */,
+				8A2BD20A1E0A7555008A5050 /* HUBOperation.m */,
+				8A2BD1FF1E0A6B40008A5050 /* HUBOperationQueue.h */,
+				8A2BD2001E0A6B40008A5050 /* HUBOperationQueue.m */,
+			);
+			name = Operations;
+			sourceTree = "<group>";
+		};
 		8A49BA8C1C77707A005F7453 /* Images & icons */ = {
 			isa = PBXGroup;
 			children = (
@@ -1037,6 +1061,7 @@
 			children = (
 				8ADD42A91C21D08100D1A801 /* HUBManagerTests.m */,
 				8ACB2A7B1C6A2F99000741D7 /* HUBIdentifierTests.m */,
+				8A2BD20F1E0AA444008A5050 /* HUBOperationQueueTests.m */,
 				8A6529E81D82B349007B1A15 /* JSON */,
 				8A6529E11D81B176007B1A15 /* View */,
 				8A6529E91D82B35F007B1A15 /* Feature */,
@@ -1550,6 +1575,7 @@
 				8AE6C0BF1DF6E40D0063B2B1 /* HUBComponentResizeObservingView.h in Headers */,
 				8AE6C0A61DF6E40D0063B2B1 /* HUBDefaultComponentLayoutManager.h in Headers */,
 				8AE6C0231DF6E3C40063B2B1 /* HUBFeatureInfo.h in Headers */,
+				8A2BD2011E0A6B40008A5050 /* HUBOperationQueue.h in Headers */,
 				8AE6C0871DF6E4020063B2B1 /* HUBViewController+Initializer.h in Headers */,
 				8AE6C0421DF6E3D40063B2B1 /* HUBComponentFactoryShowcaseNameProvider.h in Headers */,
 				8AE6C0D31DF6E4140063B2B1 /* HUBAsyncActionWrapper.h in Headers */,
@@ -1626,6 +1652,7 @@
 				8AE6C0751DF6E3F90063B2B1 /* HUBJSONPathImplementation.h in Headers */,
 				8AE6C03D1DF6E3D40063B2B1 /* HUBComponentContentOffsetObserver.h in Headers */,
 				8AE6C06D1DF6E3F90063B2B1 /* HUBComponentTargetJSONSchemaImplementation.h in Headers */,
+				8A2BD20B1E0A7555008A5050 /* HUBOperation.h in Headers */,
 				8AE6C0C11DF6E40D0063B2B1 /* HUBComponentReusePool.h in Headers */,
 				8AE6C0791DF6E4020063B2B1 /* HUBFeatureRegistryImplementation.h in Headers */,
 				8AE6C0441DF6E3D40063B2B1 /* HUBComponentModel.h in Headers */,
@@ -1841,6 +1868,7 @@
 				8A786BB21C5A383800B2AB9E /* HUBViewModelJSONSchemaImplementation.m in Sources */,
 				8A5035221DD473040008B499 /* HUBCollectionView.m in Sources */,
 				8AF5B57F1C64B59E001FF228 /* HUBViewModelLoaderImplementation.m in Sources */,
+				8A2BD2021E0A6B40008A5050 /* HUBOperationQueue.m in Sources */,
 				8A9ED75D1D4A049C006B27D8 /* HUBComponentReusePool.m in Sources */,
 				8AA97C141C60BD6D0078F19D /* HUBFeatureRegistration.m in Sources */,
 				8AF9FA071C5254F5003F3D6C /* HUBViewModelImplementation.m in Sources */,
@@ -1863,6 +1891,7 @@
 				8A5D7A621CBBAC2200B987BA /* HUBComponentDefaults.m in Sources */,
 				8A69DBAA1C7DF8C000F5EFC6 /* HUBCollectionViewFactory.m in Sources */,
 				8A49BAF81C777FB1005F7453 /* HUBComponentImageLoadingContext.m in Sources */,
+				8A2BD20C1E0A7555008A5050 /* HUBOperation.m in Sources */,
 				8AA29C8F1C4FAFC100E972B7 /* HUBComponentImageDataBuilderImplementation.m in Sources */,
 				8ACA8C871D1818920015310F /* HUBComponentModelBuilderShowcaseSnapshotGenerator.m in Sources */,
 				8A9C9CFF1DDC71930070258F /* HUBAsyncActionWrapper.m in Sources */,
@@ -1968,6 +1997,7 @@
 				8AD151841D9968390008E182 /* HUBURLSessionDataTaskMock.m in Sources */,
 				8A2EC3751D7971A500E4CAB3 /* HUBViewControllerScrollHandlerMock.m in Sources */,
 				8AD1517E1D9963120008E182 /* HUBDefaultImageLoaderTests.m in Sources */,
+				8A2BD2101E0AA444008A5050 /* HUBOperationQueueTests.m in Sources */,
 				8AA29CF81C4FE59100E972B7 /* HUBComponentModelBuilderTests.m in Sources */,
 				8A6BA0561C89A00F0057485D /* HUBComponentLayoutManagerMock.m in Sources */,
 				B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */,
@@ -2051,6 +2081,7 @@
 				8AE6C0681DF6E3F90063B2B1 /* HUBViewModelJSONSchemaImplementation.m in Sources */,
 				8AE6C0AB1DF6E40D0063B2B1 /* HUBComponentModelImplementation.m in Sources */,
 				8AE6C06C1DF6E3F90063B2B1 /* HUBComponentImageDataJSONSchemaImplementation.m in Sources */,
+				8A2BD2031E0A6B41008A5050 /* HUBOperationQueue.m in Sources */,
 				8AE6C0701DF6E3F90063B2B1 /* HUBJSONSchemaImplementation.m in Sources */,
 				8AE6C0B71DF6E40D0063B2B1 /* HUBComponentTargetBuilderImplementation.m in Sources */,
 				8AE6C0C61DF6E4100063B2B1 /* HUBDefaultImageLoaderFactory.m in Sources */,
@@ -2073,6 +2104,7 @@
 				8AE6C08E1DF6E4020063B2B1 /* HUBViewModelLoaderImplementation.m in Sources */,
 				8AE6C0981DF6E4020063B2B1 /* HUBCollectionViewFactory.m in Sources */,
 				8AE6C07C1DF6E4020063B2B1 /* HUBFeatureRegistration.m in Sources */,
+				8A2BD20D1E0A7555008A5050 /* HUBOperation.m in Sources */,
 				8AE6C0761DF6E3F90063B2B1 /* HUBJSONPathImplementation.m in Sources */,
 				8AE6C0A71DF6E40D0063B2B1 /* HUBDefaultComponentLayoutManager.m in Sources */,
 				8AE6C06E1DF6E3F90063B2B1 /* HUBComponentTargetJSONSchemaImplementation.m in Sources */,

--- a/sources/HUBOperation.h
+++ b/sources/HUBOperation.h
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/// Block type for completion handlers used with Hub Framework operations
+typedef void(^HUBOperationCompletionBlock)(void);
+
+/// Block type for synchronous Hub Framework operations
+typedef void(^HUBOperationSynchronousBlock)(void);
+
+/// Block type for asynchronous Hub Framework operations
+typedef void(^HUBOperationAsynchronousBlock)(HUBOperationCompletionBlock);
+
+/**
+ *  Class used to define atomic bodies of work as operations, that can either be synchronous or asynchronous
+ *
+ *  Why not use `NSOperations`? While `NSOperations` are great for scheduling work on background threads and
+ *  dealing with other forms of asynchronosity and managing dependencies between various tasks, they're very
+ *  cumbersome (& overkill) to use for simple operations that always should be executed in sequence on the
+ *  same thread. If this operation implementation ever becomes more complex, and in the need for some of the
+ *  features that `NSOperations` offers, we should totally replace it.
+ */
+@interface HUBOperation : NSObject
+
+/**
+ *  Create an operation that executes a block synchronously
+ *
+ *  @param block The block that makes up the operation
+ *
+ *  An operation constructed this way will call its completion handler directly after executing its block.
+ */
++ (HUBOperation *)synchronousOperationWithBlock:(HUBOperationSynchronousBlock)block;
+
+/**
+ *  Create an operation that executes a block asynchronously
+ *
+ *  @param block The block that makes up the operation
+ *
+ *  An operation constructed this way will call its completion handler once its block's completion handler
+ *  has been called.
+ */
++ (HUBOperation *)asynchronousOperationWithBlock:(HUBOperationAsynchronousBlock)block;
+
+/**
+ *  Perform the operation with a completion handler
+ *
+ *  @param completionHandler A completion handler that will be called once the operation was finished
+ */
+- (void)performWithCompletionHandler:(HUBOperationCompletionBlock)completionHandler;
+
+@end

--- a/sources/HUBOperation.m
+++ b/sources/HUBOperation.m
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBOperation.h"
+
+@interface HUBOperation ()
+
+@property (nonatomic, copy, readonly) HUBOperationAsynchronousBlock block;
+
+@end
+
+@implementation HUBOperation
+
+#pragma mark - Class constructors
+
++ (HUBOperation *)synchronousOperationWithBlock:(HUBOperationSynchronousBlock)block
+{
+    return [[HUBOperation alloc] initWithBlock:^(HUBOperationCompletionBlock completionHandler) {
+        block();
+        completionHandler();
+    }];
+}
+
++ (HUBOperation *)asynchronousOperationWithBlock:(HUBOperationAsynchronousBlock)block
+{
+    return [[HUBOperation alloc] initWithBlock:block];
+}
+
+#pragma mark - Initializer
+
+- (instancetype)initWithBlock:(HUBOperationAsynchronousBlock)block
+{
+    NSParameterAssert(block != nil);
+    
+    self = [super init];
+    
+    if (self) {
+        _block = [block copy];
+    }
+    
+    return self;
+}
+
+#pragma mark - API
+
+- (void)performWithCompletionHandler:(HUBOperationCompletionBlock)completionHandler
+{
+    self.block(completionHandler);
+}
+
+@end

--- a/sources/HUBOperationQueue.h
+++ b/sources/HUBOperationQueue.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class HUBOperation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  An operation queue that keeps executing scheduled operations whenever the previous one finished
+ *
+ *  See the documentation for `HUBOperation` for a discussion why `NSOperation(Queue)` is not used here.
+ */
+@interface HUBOperationQueue : NSObject
+
+/**
+ *  Add an operation to the queue
+ *
+ *  @param operation The operation to add
+ *
+ *  If the queue is empty, the operation will start directly. Otherwise, it'll start whenever the queue
+ *  became idle.
+ */
+- (void)addOperation:(HUBOperation *)operation;
+
+/**
+ *  Add an array of operations to the queue
+ *
+ *  @param operations The operations to add
+ *
+ *  All operations will be added to the queue before any of them are started. If the queue was empty when
+ *  added, the first operation in the array will then start. Otherwise, it'll start whenever the queue
+ *  became idle.
+ */
+- (void)addOperations:(NSArray<HUBOperation *> *)operations;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBOperationQueue.m
+++ b/sources/HUBOperationQueue.m
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "HUBOperationQueue.h"
+
+#import "HUBOperation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HUBOperationQueue ()
+
+@property (nonatomic, strong, readonly) NSMutableArray<HUBOperation *> *operations;
+
+@end
+
+@implementation HUBOperationQueue
+
+#pragma mark - Initializer
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self) {
+        _operations = [NSMutableArray new];
+    }
+    
+    return self;
+}
+
+#pragma mark - API
+
+- (void)addOperation:(HUBOperation *)operation
+{
+    [self addOperations:@[operation]];
+}
+
+- (void)addOperations:(NSArray<HUBOperation *> *)operations
+{
+    BOOL shouldPerformFirstOperation = (self.operations.count == 0);
+    [self.operations addObjectsFromArray:operations];
+    
+    if (shouldPerformFirstOperation) {
+        [self performFirstOperation];
+    }
+}
+
+#pragma mark - Private utilities
+
+- (void)performFirstOperation
+{
+    HUBOperation * const operation = self.operations.firstObject;
+    
+    if (operation == nil) {
+        return;
+    }
+    
+    __weak __typeof(self) weakSelf = self;
+    
+    [operation performWithCompletionHandler:^{
+        __typeof(self) strongSelf = weakSelf;
+        
+        if (strongSelf == nil) {
+            return;
+        }
+        
+        [strongSelf.operations removeObjectAtIndex:0];
+        [strongSelf performFirstOperation];
+    }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBOperationQueue.m
+++ b/sources/HUBOperationQueue.m
@@ -22,6 +22,7 @@
 #import "HUBOperationQueue.h"
 
 #import "HUBOperation.h"
+#import "HUBUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -76,14 +77,16 @@ NS_ASSUME_NONNULL_BEGIN
     __weak __typeof(self) weakSelf = self;
     
     [operation performWithCompletionHandler:^{
-        __typeof(self) strongSelf = weakSelf;
-        
-        if (strongSelf == nil) {
-            return;
-        }
-        
-        [strongSelf.operations removeObjectAtIndex:0];
-        [strongSelf performFirstOperation];
+        HUBPerformOnMainQueue(^{
+            __typeof(self) strongSelf = weakSelf;
+            
+            if (strongSelf == nil) {
+                return;
+            }
+            
+            [strongSelf.operations removeObjectAtIndex:0];
+            [strongSelf performFirstOperation];
+        });
     }];
 }
 

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -48,6 +48,8 @@
 #import "HUBActionHandlerWrapper.h"
 #import "HUBViewModelRenderer.h"
 #import "HUBFeatureInfo.h"
+#import "HUBOperation.h"
+#import "HUBOperationQueue.h"
 
 static NSTimeInterval const HUBImageDownloadTimeThreshold = 0.07;
 
@@ -84,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSUUID *, HUBComponentWrapper *> *componentWrappersByCellIdentifier;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, HUBComponentWrapper *> *componentWrappersByModelIdentifier;
 @property (nonatomic, strong, nullable) HUBComponentWrapper *highlightedComponentWrapper;
-@property (nonatomic, strong, nullable) id<HUBViewModel> pendingViewModel;
+@property (nonatomic, strong, readonly) HUBOperationQueue *renderingOperationQueue;
 @property (nonatomic, strong, nullable) id<HUBViewModel> viewModel;
 @property (nonatomic, assign) BOOL viewHasAppeared;
 @property (nonatomic, assign) BOOL viewHasBeenLaidOut;
@@ -92,7 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) CGFloat visibleKeyboardHeight;
 @property (nonatomic, assign) CGPoint lastContentOffset;
 @property (nonatomic, copy, nullable) void(^pendingScrollAnimationCallback)(void);
-@property (nonatomic, getter=isRendering) BOOL rendering;
 
 @end
 
@@ -147,6 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
     _componentWrappersByIdentifier = [NSMutableDictionary new];
     _componentWrappersByCellIdentifier = [NSMutableDictionary new];
     _componentWrappersByModelIdentifier = [NSMutableDictionary new];
+    _renderingOperationQueue = [HUBOperationQueue new];
     
     viewModelLoader.delegate = self;
     viewModelLoader.actionPerformer = self;
@@ -226,12 +228,14 @@ NS_ASSUME_NONNULL_BEGIN
     
     self.viewHasBeenLaidOut = YES;
 
-    if (self.viewModel != nil) {
-        if (self.viewModelHasChangedSinceLastLayoutUpdate || !CGRectEqualToRect(self.collectionView.frame, self.view.bounds)) {
-            self.collectionView.frame = self.view.bounds;
-            id<HUBViewModel> const viewModel = self.viewModel;
-            [self reloadCollectionViewWithViewModel:viewModel animated:NO];
-        }
+    if (self.viewModel == nil) {
+        return;
+    }
+    
+    if (self.viewModelHasChangedSinceLastLayoutUpdate || !CGRectEqualToRect(self.collectionView.frame, self.view.bounds)) {
+        self.collectionView.frame = self.view.bounds;
+        HUBOperation * const reloadOperation = [self createReloadCollectionViewOperation];
+        [self.renderingOperationQueue addOperation:reloadOperation];
     }
 }
 
@@ -450,31 +454,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader didLoadViewModel:(id<HUBViewModel>)viewModel
 {
-    if ([self.viewModel.buildDate isEqual:viewModel.buildDate]) {
-        return;
-    }
-
-    if (self.isRendering) {
-        self.pendingViewModel = viewModel;
-        return;
-    }
-
-    self.rendering = YES;
-
-    id<HUBViewControllerDelegate> const delegate = self.delegate;
-    [delegate viewController:self willUpdateWithViewModel:viewModel];
+    HUBOperation * const willUpdateDelegateOperation = [HUBOperation synchronousOperationWithBlock:^{
+        [self.delegate viewController:self willUpdateWithViewModel:viewModel];
+    }];
     
-    HUBCopyNavigationItemProperties(self.navigationItem, viewModel.navigationItem);
+    HUBOperation * const updateViewModelOperation = [HUBOperation synchronousOperationWithBlock:^{
+        HUBCopyNavigationItemProperties(self.navigationItem, viewModel.navigationItem);
+        self.viewModel = viewModel;
+        self.viewModelHasChangedSinceLastLayoutUpdate = YES;
+        [self.view setNeedsLayout];
+    }];
     
-    self.viewModel = viewModel;
-    self.viewModelHasChangedSinceLastLayoutUpdate = YES;
-    [self.view setNeedsLayout];
+    HUBOperation * const reloadCollectionViewOperation = [self createReloadCollectionViewOperation];
     
-    if (self.viewHasBeenLaidOut) {
-        [self reloadCollectionViewWithViewModel:viewModel animated:NO];
-    }
+    HUBOperation * const didUpdateDelegateOperation = [HUBOperation synchronousOperationWithBlock:^{
+        [self.delegate viewControllerDidUpdate:self];
+    }];
     
-    [delegate viewControllerDidUpdate:self];
+    [self.renderingOperationQueue addOperations:@[
+        willUpdateDelegateOperation,
+        updateViewModelOperation,
+        reloadCollectionViewOperation,
+        didUpdateDelegateOperation
+    ]];
 }
 
 - (void)viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader didFailLoadingWithError:(NSError *)error
@@ -893,45 +895,43 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     containerView.collectionView = self.collectionView;
 }
 
-- (void)reloadCollectionViewWithViewModel:(id<HUBViewModel>)viewModel animated:(BOOL)animated
+
+- (HUBOperation *)createReloadCollectionViewOperation
 {
-    if (![self.collectionView.collectionViewLayout isKindOfClass:[HUBCollectionViewLayout class]]) {
-        self.collectionView.collectionViewLayout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
-                                                                                       componentLayoutManager:self.componentLayoutManager];
-    }
-
-    [self saveStatesForVisibleComponents];
-
-    [self configureHeaderComponent];
-    [self configureOverlayComponents];
-    [self adjustCollectionViewContentInsetWithProposedTopValue:[self calculateTopContentInset]];
-    
-    BOOL const shouldAddHeaderMargin = [self shouldAutomaticallyManageTopContentInset];
-    
-    UICollectionView * const nonnullCollectionView = self.collectionView;
-    [self.viewModelRenderer renderViewModel:viewModel
-                           inCollectionView:nonnullCollectionView
-                          usingBatchUpdates:self.viewHasAppeared
-                                   animated:animated
-                            addHeaderMargin:shouldAddHeaderMargin
-                                 completion:^{
-        self.rendering = NO;
-
-        if (self.pendingViewModel != nil) {
-            id<HUBViewModel> pendingViewModel = self.pendingViewModel;
-            self.pendingViewModel = nil;
-            [self viewModelLoader:self.viewModelLoader didLoadViewModel:pendingViewModel];
+    return [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler){
+        if (!self.viewHasBeenLaidOut) {
+            completionHandler();
             return;
         }
-
-        id<HUBViewControllerDelegate> delegate = self.delegate;
-
-        [self headerAndOverlayComponentViewsWillAppear];
+        
+        if (![self.collectionView.collectionViewLayout isKindOfClass:[HUBCollectionViewLayout class]]) {
+            self.collectionView.collectionViewLayout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
+                                                                                           componentLayoutManager:self.componentLayoutManager];
+        }
+        
+        [self saveStatesForVisibleComponents];
+        [self configureHeaderComponent];
+        [self configureOverlayComponents];
         [self adjustCollectionViewContentInsetWithProposedTopValue:[self calculateTopContentInset]];
-        [delegate viewControllerDidFinishRendering:self];
+        
+        self.viewModelHasChangedSinceLastLayoutUpdate = NO;
+        
+        BOOL const shouldAddHeaderMargin = [self shouldAutomaticallyManageTopContentInset];
+        id<HUBViewModel> const viewModel = self.viewModel;
+        UICollectionView * const collectionView = self.collectionView;
+        
+        [self.viewModelRenderer renderViewModel:viewModel
+                               inCollectionView:collectionView
+                              usingBatchUpdates:self.viewHasAppeared
+                                       animated:NO
+                                addHeaderMargin:shouldAddHeaderMargin
+                                     completion:^{
+                                         [self headerAndOverlayComponentViewsWillAppear];
+                                         [self adjustCollectionViewContentInsetWithProposedTopValue:[self calculateTopContentInset]];
+                                         [self.delegate viewControllerDidFinishRendering:self];
+                                         completionHandler();
+                                     }];
     }];
-    
-    self.viewModelHasChangedSinceLastLayoutUpdate = NO;
 }
 
 - (void)saveStatesForVisibleComponents

--- a/tests/HUBOperationQueueTests.m
+++ b/tests/HUBOperationQueueTests.m
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "HUBOperationQueue.h"
+#import "HUBOperation.h"
+
+@interface HUBOperationQueueTests : XCTestCase
+
+@property (nonatomic, strong) HUBOperationQueue *queue;
+
+@end
+
+@implementation HUBOperationQueueTests
+
+#pragma mark - XCTestCase
+
+- (void)setUp
+{
+    [super setUp];
+    self.queue = [HUBOperationQueue new];
+}
+
+#pragma mark - Tests
+
+- (void)testAddingSingleOperation
+{
+    __block BOOL operationPerformed = NO;
+    
+    HUBOperation * const operation = [HUBOperation synchronousOperationWithBlock:^{
+        operationPerformed = YES;
+    }];
+    
+    [self.queue addOperation:operation];
+    XCTAssertTrue(operationPerformed);
+}
+
+- (void)testWaitingForAsyncOperation
+{
+    __block HUBOperationCompletionBlock asyncOperationCompletionHandler = nil;
+    __block BOOL syncOperationPerformed = NO;
+    
+    HUBOperation * const asyncOperation = [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler) {
+        asyncOperationCompletionHandler = completionHandler;
+    }];
+    
+    HUBOperation * const syncOperation = [HUBOperation synchronousOperationWithBlock:^{
+        syncOperationPerformed = YES;
+    }];
+    
+    [self.queue addOperations:@[asyncOperation, syncOperation]];
+    XCTAssertFalse(syncOperationPerformed);
+    
+    XCTAssertNotNil(asyncOperationCompletionHandler);
+    asyncOperationCompletionHandler();
+    XCTAssertTrue(syncOperationPerformed);
+}
+
+- (void)testAddingOperationToBusyQueue
+{
+    __block HUBOperationCompletionBlock asyncOperationCompletionHandler = nil;
+    __block BOOL syncOperationPerformed = NO;
+    
+    HUBOperation * const asyncOperation = [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler) {
+        asyncOperationCompletionHandler = completionHandler;
+    }];
+    
+    HUBOperation * const syncOperation = [HUBOperation synchronousOperationWithBlock:^{
+        syncOperationPerformed = YES;
+    }];
+    
+    [self.queue addOperation:asyncOperation];
+    [self.queue addOperation:syncOperation];
+    XCTAssertFalse(syncOperationPerformed);
+    
+    XCTAssertNotNil(asyncOperationCompletionHandler);
+    asyncOperationCompletionHandler();
+    XCTAssertTrue(syncOperationPerformed);
+}
+
+@end


### PR DESCRIPTION
This is the first in a series of tasks to make more code in the Hub Framework operation oriented.

We’ve run into a lot of issues during the last couple of months due to state management, where things have become out of sync or required even more state to be introduced. For example, when interfacing with `UICollectionView`, which is very asynchronous, we could end up with inconsistent states because we would update our models too early or too late.

Operations make this a lot simpler, since using a central queue that all events pass through, you can make more assumptions (and IMO, reason about it easier) about in what sequence various events and bodies of work will occur.

Now, instead of having to keep state like `pendingViewModel` and `isRendering`, `HUBViewController` now has an operation queue that it adds operations onto whenever it needs to re-render.

To make this happen, two new classes are introduced: `HUBOperation` and `HUBOperationQueue`. `NSOperations` where considered, but ruled out due to their complexity and optimisation towards background thread work (see the documentation for `HUBOperation` for a more in-depth discussion). So why are these not named `HUBRenderingOperation` (+queue)? Because we want to migrate more code to using this paradigm, but exclusively rendering code. For example, once we move to context-based content operations (see `HUBContentOperationContext`), we could implement a simple input/output for `HUBOperation` and use the same code for those.

But, for now, only the rendering code is updated.