### PR TITLE
Use more appropriate asserts

### DIFF
--- a/tests/HUBActionRegistryTests.m
+++ b/tests/HUBActionRegistryTests.m
@@ -58,7 +58,7 @@
     HUBActionFactoryMock * const factory = [[HUBActionFactoryMock alloc] initWithActions:@{actionIdentifier.namePart: action}];
     [self.actionRegistry registerActionFactory:factory forNamespace:actionIdentifier.namespacePart];
     
-    XCTAssertEqual([self.actionRegistry createCustomActionForIdentifier:actionIdentifier], action);
+    XCTAssertEqualObjects([self.actionRegistry createCustomActionForIdentifier:actionIdentifier], action);
 }
 
 - (void)testRegisteringAlreadyRegisteredFactoryThrows

--- a/tests/HUBComponentGestureRecognizerTests.m
+++ b/tests/HUBComponentGestureRecognizerTests.m
@@ -57,7 +57,7 @@
 
 - (void)testGestureRecognizerAddedToView
 {
-    XCTAssertEqual(self.gestureRecognizer.view, self.view);
+    XCTAssertEqualObjects(self.gestureRecognizer.view, self.view);
 }
 
 - (void)testTouchesBeganSetsBeganState

--- a/tests/HUBComponentImageDataBuilderTests.m
+++ b/tests/HUBComponentImageDataBuilderTests.m
@@ -74,10 +74,10 @@
     
     HUBComponentImageDataImplementation * const imageData = [self.builder buildWithIdentifier:identifier type:type];
     
-    XCTAssertEqual(imageData.identifier, identifier);
+    XCTAssertEqualObjects(imageData.identifier, identifier);
     XCTAssertEqual(imageData.type, type);
     XCTAssertEqualObjects(imageData.URL, self.builder.URL);
-    XCTAssertEqual(imageData.localImage, self.builder.localImage);
+    XCTAssertEqualObjects(imageData.localImage, self.builder.localImage);
     XCTAssertEqualObjects(imageData.placeholderIcon.identifier, @"placeholder");
     XCTAssertEqualObjects(imageData.customData, @{@"custom": @"data"});
 }

--- a/tests/HUBComponentModelBuilderTests.m
+++ b/tests/HUBComponentModelBuilderTests.m
@@ -144,9 +144,9 @@
     self.builder.backgroundImage = [UIImage new];
     
     XCTAssertEqualObjects(self.builder.mainImageDataBuilder.URL, self.builder.mainImageURL);
-    XCTAssertEqual(self.builder.mainImageDataBuilder.localImage, self.builder.mainImage);
+    XCTAssertEqualObjects(self.builder.mainImageDataBuilder.localImage, self.builder.mainImage);
     XCTAssertEqualObjects(self.builder.backgroundImageDataBuilder.URL, self.builder.backgroundImageURL);
-    XCTAssertEqual(self.builder.backgroundImageDataBuilder.localImage, self.builder.backgroundImage);
+    XCTAssertEqualObjects(self.builder.backgroundImageDataBuilder.localImage, self.builder.backgroundImage);
 }
 
 - (void)testCustomImageDataBuilder
@@ -208,7 +208,7 @@
     NSString * const childModelIdentifier = @"childModel";
     id<HUBComponentModelBuilder> const childBuilder = [self.builder builderForChildWithIdentifier:childModelIdentifier];
     
-    XCTAssertEqual([self.builder builderForChildWithIdentifier:childModelIdentifier], childBuilder);
+    XCTAssertEqualObjects([self.builder builderForChildWithIdentifier:childModelIdentifier], childBuilder);
 }
 
 - (void)testChildTypeSameAsParent
@@ -307,7 +307,7 @@
     id<HUBComponentModel> const child = [self.builder buildForIndex:0 parent:parent];
     id<HUBComponentModel> const actualParent = child.parent;
     
-    XCTAssertEqual(parent, actualParent);
+    XCTAssertEqualObjects(parent, actualParent);
 }
 
 - (void)testChildGrouping

--- a/tests/HUBComponentModelTests.m
+++ b/tests/HUBComponentModelTests.m
@@ -43,8 +43,8 @@
     HUBComponentModelImplementation * const model = [self createComponentModelWithIdentifier:@"id" index:0];
     model.children = childModels;
     
-    XCTAssertEqual([model childAtIndex:0], childModels[0]);
-    XCTAssertEqual([model childAtIndex:1], childModels[1]);
+    XCTAssertEqualObjects([model childAtIndex:0], childModels[0]);
+    XCTAssertEqualObjects([model childAtIndex:1], childModels[1]);
     XCTAssertNil([model childAtIndex:2]);
 }
 
@@ -154,9 +154,9 @@
     HUBComponentModelImplementation * const childC = [self createComponentModelWithIdentifier:@"childC" index:2];
     parent.children = @[childA, childB, childC];
     
-    XCTAssertEqual([parent childWithIdentifier:@"childA"], childA);
-    XCTAssertEqual([parent childWithIdentifier:@"childB"], childB);
-    XCTAssertEqual([parent childWithIdentifier:@"childC"], childC);
+    XCTAssertEqualObjects([parent childWithIdentifier:@"childA"], childA);
+    XCTAssertEqualObjects([parent childWithIdentifier:@"childB"], childB);
+    XCTAssertEqualObjects([parent childWithIdentifier:@"childC"], childC);
     XCTAssertNil([parent childWithIdentifier:@"noChild"]);
 }
 
@@ -170,16 +170,16 @@
     parent.children = @[childA, childB];
     childB.children = @[grandchild];
 
-    XCTAssertEqual(parent.indexPath, [NSIndexPath indexPathWithIndex:0]);
+    XCTAssertEqualObjects(parent.indexPath, [NSIndexPath indexPathWithIndex:0]);
 
     NSUInteger childAIndexPathArray[] = {0,0};
-    XCTAssertEqual(childA.indexPath, [NSIndexPath indexPathWithIndexes:childAIndexPathArray length:2]);
+    XCTAssertEqualObjects(childA.indexPath, [NSIndexPath indexPathWithIndexes:childAIndexPathArray length:2]);
 
     NSUInteger childBIndexPathArray[] = {0,1};
-    XCTAssertEqual(childB.indexPath, [NSIndexPath indexPathWithIndexes:childBIndexPathArray length:2]);
+    XCTAssertEqualObjects(childB.indexPath, [NSIndexPath indexPathWithIndexes:childBIndexPathArray length:2]);
 
     NSUInteger grandchildIndexPathArray[] = {0,1,0};
-    XCTAssertEqual(grandchild.indexPath, [NSIndexPath indexPathWithIndexes:grandchildIndexPathArray length:3]);
+    XCTAssertEqualObjects(grandchild.indexPath, [NSIndexPath indexPathWithIndexes:grandchildIndexPathArray length:3]);
 }
 
 - (void)testPropertiesThatDoNotAffectEquality

--- a/tests/HUBComponentRegistryTests.m
+++ b/tests/HUBComponentRegistryTests.m
@@ -81,7 +81,7 @@ static NSString * const DefaultNamespace = @"default";
     
     [self.registry registerComponentFactory:factory forNamespace:componentIdentifier.namespacePart];
 
-    XCTAssertEqual([self.registry createComponentForModel:componentModel], component);
+    XCTAssertEqualObjects([self.registry createComponentForModel:componentModel], component);
 }
 
 - (void)testRegisteringAlreadyRegisteredFactoryThrows
@@ -120,7 +120,7 @@ static NSString * const DefaultNamespace = @"default";
     id<HUBComponentModel> const componentModel = [self mockedComponentModelWithComponentIdentifier:unknownNamespaceIdentifier
                                                                                  componentCategory:componentCategory];
     
-    XCTAssertEqual([self.registry createComponentForModel:componentModel], fallbackComponent);
+    XCTAssertEqualObjects([self.registry createComponentForModel:componentModel], fallbackComponent);
 }
 
 - (void)testFallbackComponentCreatedWhenFactoryReturnsNil
@@ -137,7 +137,7 @@ static NSString * const DefaultNamespace = @"default";
     id<HUBComponentModel> const componentModel = [self mockedComponentModelWithComponentIdentifier:unknownNameIdentifier
                                                                                  componentCategory:componentCategory];
     
-    XCTAssertEqual([self.registry createComponentForModel:componentModel], fallbackComponent);
+    XCTAssertEqualObjects([self.registry createComponentForModel:componentModel], fallbackComponent);
 }
 
 - (void)testFallbackComponentsForDifferentCategories
@@ -163,8 +163,8 @@ static NSString * const DefaultNamespace = @"default";
     id<HUBComponentModel> const componentModelB = [self mockedComponentModelWithComponentIdentifier:unknownNameIdentifier
                                                                                   componentCategory:componentCategoryB];
     
-    XCTAssertEqual([self.registry createComponentForModel:componentModelA], fallbackComponentA);
-    XCTAssertEqual([self.registry createComponentForModel:componentModelB], fallbackComponentB);
+    XCTAssertEqualObjects([self.registry createComponentForModel:componentModelA], fallbackComponentA);
+    XCTAssertEqualObjects([self.registry createComponentForModel:componentModelB], fallbackComponentB);
 }
 
 - (void)testShowcaseableComponentIdentifiers

--- a/tests/HUBDefaultImageLoaderTests.m
+++ b/tests/HUBDefaultImageLoaderTests.m
@@ -157,7 +157,7 @@
 
 - (void)imageLoader:(id<HUBImageLoader>)imageLoader didLoadImage:(UIImage *)image forURL:(NSURL *)imageURL
 {
-    XCTAssertEqual(self.imageLoader, imageLoader);
+    XCTAssertEqualObjects(self.imageLoader, imageLoader);
     
     self.loadedImage = image;
     self.loadedImageURL = imageURL;
@@ -167,7 +167,7 @@
 
 - (void)imageLoader:(id<HUBImageLoader>)imageLoader didFailLoadingImageForURL:(NSURL *)imageURL error:(NSError *)error
 {
-    XCTAssertEqual(self.imageLoader, imageLoader);
+    XCTAssertEqualObjects(self.imageLoader, imageLoader);
     
     self.loadingError = error;
 }

--- a/tests/HUBFeatureRegistryTests.m
+++ b/tests/HUBFeatureRegistryTests.m
@@ -97,7 +97,7 @@
     HUBFeatureRegistration * const registration = [self.registry featureRegistrationForViewURI:rootViewURI];
     XCTAssertEqualObjects(registration.featureIdentifier, featureIdentifier);
     XCTAssertEqualObjects(registration.featureTitle, @"Title");
-    XCTAssertEqual(registration.viewURIPredicate, viewURIPredicate);
+    XCTAssertEqualObjects(registration.viewURIPredicate, viewURIPredicate);
     XCTAssertEqualObjects(registration.contentOperationFactories, @[contentOperationFactory]);
     XCTAssertEqualObjects(registration.customJSONSchemaIdentifier, customJSONSchemaIdentifier);
 }

--- a/tests/HUBIconTests.m
+++ b/tests/HUBIconTests.m
@@ -81,7 +81,7 @@
                                                                              imageResolver:self.imageResolver
                                                                              isPlaceholder:NO];
     
-    XCTAssertEqual([icon imageWithSize:CGSizeZero color:[UIColor redColor]], image);
+    XCTAssertEqualObjects([icon imageWithSize:CGSizeZero color:[UIColor redColor]], image);
 }
 
 - (void)testResolvingPlaceholderImage
@@ -93,7 +93,7 @@
                                                                              imageResolver:self.imageResolver
                                                                              isPlaceholder:YES];
     
-    XCTAssertEqual([icon imageWithSize:CGSizeZero color:[UIColor redColor]], image);
+    XCTAssertEqualObjects([icon imageWithSize:CGSizeZero color:[UIColor redColor]], image);
 }
 
 @end

--- a/tests/HUBInitialViewModelRegistryTests.m
+++ b/tests/HUBInitialViewModelRegistryTests.m
@@ -57,7 +57,7 @@
     
     [self.registry registerInitialViewModel:viewModel forViewURI:viewURI];
     
-    XCTAssertEqual([self.registry initialViewModelForViewURI:viewURI], viewModel);
+    XCTAssertEqualObjects([self.registry initialViewModelForViewURI:viewURI], viewModel);
     
     NSURL * const unknownViewURI = [NSURL URLWithString:@"spotify:some:other:uri"];
     XCTAssertNil([self.registry initialViewModelForViewURI:unknownViewURI]);

--- a/tests/HUBJSONSchemaRegistryTests.m
+++ b/tests/HUBJSONSchemaRegistryTests.m
@@ -106,8 +106,8 @@
     id<HUBViewModel> const originalViewModel = [originalSchema viewModelFromJSONDictionary:dictionary];
     id<HUBViewModel> const copiedViewModel = [copiedSchema viewModelFromJSONDictionary:dictionary];
     
-    XCTAssertEqual(originalViewModel.navigationItem.title, title);
-    XCTAssertEqual(originalViewModel.navigationItem.title, copiedViewModel.navigationItem.title);
+    XCTAssertEqualObjects(originalViewModel.navigationItem.title, title);
+    XCTAssertEqualObjects(originalViewModel.navigationItem.title, copiedViewModel.navigationItem.title);
 }
 
 - (void)testCopyingUknownSchemaReturningNil

--- a/tests/HUBLiveServiceTests.m
+++ b/tests/HUBLiveServiceTests.m
@@ -122,7 +122,7 @@
     
     [stream.delegate stream:stream handleEvent:NSStreamEventHasBytesAvailable];
     
-    XCTAssertEqual(self.viewController, viewController, @"View controller should have been reused");
+    XCTAssertEqualObjects(self.viewController, viewController, @"View controller should have been reused");
     
     id<HUBViewModel> const newViewModel = viewController.viewModel;
     XCTAssertEqualObjects(newViewModel.navigationItem.title, @"A new title!");
@@ -132,7 +132,7 @@
 
 - (void)liveService:(id<HUBLiveService>)liveService didCreateViewController:(HUBViewController *)viewController
 {
-    XCTAssertEqual(self.service, liveService);
+    XCTAssertEqualObjects(self.service, liveService);
     self.viewController = viewController;
 }
 

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -363,7 +363,7 @@
     
     [self simulateViewControllerLayoutCycle];
     
-    XCTAssertEqual(self.errorFromDelegateMethod, error);
+    XCTAssertEqualObjects(self.errorFromDelegateMethod, error);
 }
 
 - (void)testHeaderComponentImageLoading
@@ -423,7 +423,7 @@
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     [self.collectionView.dataSource collectionView:self.collectionView cellForItemAtIndexPath:indexPath];
     
-    XCTAssertEqual(self.component.mainImageData.localImage, localMainImage);
+    XCTAssertEqualObjects(self.component.mainImageData.localImage, localMainImage);
     XCTAssertNil(self.component.backgroundImageData);
     
     [self performAsynchronousTestWithDelay:0 block:^{
@@ -1090,7 +1090,7 @@
     XCTAssertNotNil(childComponentModelA);
     
     id<HUBComponent> const childComponentWrapper = [childDelegate component:component childComponentForModel:childComponentModelA];
-    XCTAssertEqual(childComponentWrapper.view, childComponent.view);
+    XCTAssertEqualObjects(childComponentWrapper.view, childComponent.view);
     XCTAssertTrue(CGSizeEqualToSize(childComponent.view.frame.size, childComponent.preferredViewSize),
                   @"Sizes not equal: %@ and %@",
                   NSStringFromCGSize(childComponent.view.frame.size),
@@ -1102,7 +1102,7 @@
     XCTAssertNotNil(childComponentModelB);
     
     id<HUBComponent> const reusedChildComponentWrapper = [childDelegate component:component childComponentForModel:childComponentModelB];
-    XCTAssertEqual(childComponentWrapper, reusedChildComponentWrapper);
+    XCTAssertEqualObjects(childComponentWrapper, reusedChildComponentWrapper);
 }
 
 - (void)testChildComponentsRemovedFromParentOnReuse
@@ -1153,7 +1153,7 @@
 
     [componentAChildDelegate component:componentA willDisplayChildAtIndex:0 view:childComponentView];
     NSIndexPath * const indexPathChildA = [NSIndexPath indexPathForItem:0 inSection:0];
-    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPathChildA], childComponentView);
+    XCTAssertEqualObjects([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPathChildA], childComponentView);
 
     [childComponentWrapperA prepareViewForReuse];
     XCTAssertNil([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPathChildA]);
@@ -1161,11 +1161,11 @@
     id<HUBComponentChildDelegate> componentBChildDelegate = componentB.childDelegate;
     id<HUBComponentModel> const childComponentModelB = [componentB.model childAtIndex:0];
     id<HUBComponent> const childComponentWrapperB = [componentBChildDelegate component:componentB childComponentForModel:childComponentModelB];
-    XCTAssertEqual(childComponentWrapperA, childComponentWrapperB);
+    XCTAssertEqualObjects(childComponentWrapperA, childComponentWrapperB);
 
     [componentBChildDelegate component:componentB willDisplayChildAtIndex:0 view:childComponentView];
     NSIndexPath * const indexPathChildB = [NSIndexPath indexPathForItem:0 inSection:1];
-    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPathChildB], childComponentView);
+    XCTAssertEqualObjects([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPathChildB], childComponentView);
 
     [childComponentWrapperB prepareViewForReuse];
     XCTAssertNil([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:indexPathChildB]);
@@ -2332,7 +2332,7 @@
 
 - (void)testCollectionViewCreatedInLoadView
 {
-    XCTAssertEqual(self.viewController.view.subviews[0], self.collectionView);
+    XCTAssertEqualObjects(self.viewController.view.subviews[0], self.collectionView);
 }
 
 - (void)testCollectionViewSetupUsingScrollHandler
@@ -2548,10 +2548,10 @@
 
     NSDictionary<NSIndexPath *, UIView *> * const visibleHeaderViews = [self.viewController visibleComponentViewsForComponentType:HUBComponentTypeHeader];
     XCTAssertEqual(visibleHeaderViews.count, 1u);
-    XCTAssertEqual(visibleHeaderViews[[NSIndexPath indexPathWithIndex:0]], headerComponent.view);
+    XCTAssertEqualObjects(visibleHeaderViews[[NSIndexPath indexPathWithIndex:0]], headerComponent.view);
     
     NSIndexPath * const headerIndexPath = [NSIndexPath indexPathWithIndex:0];
-    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeHeader indexPath:headerIndexPath], headerComponent.view);
+    XCTAssertEqualObjects([self.viewController visibleViewForComponentOfType:HUBComponentTypeHeader indexPath:headerIndexPath], headerComponent.view);
 
     NSDictionary<NSIndexPath *, UIView *> * const visibleBodyViews = [self.viewController visibleComponentViewsForComponentType:HUBComponentTypeBody];
     XCTAssertEqual(visibleBodyViews.count, 3u);
@@ -2560,18 +2560,18 @@
     NSIndexPath * const bodyIndexPathB = [NSIndexPath indexPathWithIndex:1];
     NSIndexPath * const bodyIndexPathC = [NSIndexPath indexPathWithIndex:2];
     
-    XCTAssertEqual(visibleBodyViews[bodyIndexPathA], componentA.view);
-    XCTAssertEqual(visibleBodyViews[bodyIndexPathB], componentB.view);
-    XCTAssertEqual(visibleBodyViews[bodyIndexPathC], componentC.view);
+    XCTAssertEqualObjects(visibleBodyViews[bodyIndexPathA], componentA.view);
+    XCTAssertEqualObjects(visibleBodyViews[bodyIndexPathB], componentB.view);
+    XCTAssertEqualObjects(visibleBodyViews[bodyIndexPathC], componentC.view);
     
-    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathA], componentA.view);
-    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathB], componentB.view);
-    XCTAssertEqual([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathC], componentC.view);
+    XCTAssertEqualObjects([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathA], componentA.view);
+    XCTAssertEqualObjects([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathB], componentB.view);
+    XCTAssertEqualObjects([self.viewController visibleViewForComponentOfType:HUBComponentTypeBody indexPath:bodyIndexPathC], componentC.view);
 
     NSDictionary<NSIndexPath *, UIView *> * const visibleOverlayViews = [self.viewController visibleComponentViewsForComponentType:HUBComponentTypeOverlay];
     XCTAssertEqual(visibleOverlayViews.count, 2u);
-    XCTAssertEqual(visibleOverlayViews[[NSIndexPath indexPathWithIndex:0]], component1.view);
-    XCTAssertEqual(visibleOverlayViews[[NSIndexPath indexPathWithIndex:1]], component2.view);
+    XCTAssertEqualObjects(visibleOverlayViews[[NSIndexPath indexPathWithIndex:0]], component1.view);
+    XCTAssertEqualObjects(visibleOverlayViews[[NSIndexPath indexPathWithIndex:1]], component2.view);
 }
 
 - (void)testNoVisibleComponents
@@ -2613,7 +2613,7 @@
     
     id<HUBComponentModel> const componentModel = self.viewModelFromDelegateMethod.bodyComponentModels[0];
     [self.viewController selectComponentWithModel:componentModel customData:nil];
-    XCTAssertEqual(self.contentOperation.actionContext, actionContext);
+    XCTAssertEqualObjects(self.contentOperation.actionContext, actionContext);
 }
 
 - (void)testPerformingActionFromComponent
@@ -2656,7 +2656,7 @@
     XCTAssertEqualObjects(actionContext.customData, customActionData);
     XCTAssertEqual(actionContext.trigger, HUBActionTriggerComponent);
     XCTAssertEqualObjects(self.actionHandler.contexts, @[actionContext]);
-    XCTAssertEqual(self.contentOperation.actionContext, actionContext);
+    XCTAssertEqualObjects(self.contentOperation.actionContext, actionContext);
 }
 
 - (void)testObservingActionsByComponent
@@ -2701,7 +2701,7 @@
     XCTAssertEqualObjects(actionContext.customData, customActionData);
     XCTAssertEqual(actionContext.trigger, HUBActionTriggerComponent);
     XCTAssertEqualObjects(self.actionHandler.contexts, @[actionContext]);
-    XCTAssertEqual(self.contentOperation.actionContext, actionContext);
+    XCTAssertEqualObjects(self.contentOperation.actionContext, actionContext);
 }
 
 - (void)testPerformingActionFromContentOperation
@@ -2725,7 +2725,7 @@
     XCTAssertEqualObjects(actionContext.customData, customActionData);
     XCTAssertEqual(actionContext.trigger, HUBActionTriggerContentOperation);
     XCTAssertEqualObjects(self.actionHandler.contexts, @[actionContext]);
-    XCTAssertEqual(self.contentOperation.actionContext, actionContext);
+    XCTAssertEqualObjects(self.contentOperation.actionContext, actionContext);
 }
 
 - (void)testPerformingAsyncAction
@@ -3105,25 +3105,25 @@
 
 - (void)viewController:(HUBViewController *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     self.viewModelFromDelegateMethod = viewModel;
 }
 
 - (void)viewControllerDidUpdate:(HUBViewController *)viewController
 {
-    XCTAssertEqual(viewController, self.viewController);
-    XCTAssertEqual(self.viewModelFromDelegateMethod, viewController.viewModel);
+    XCTAssertEqualObjects(viewController, self.viewController);
+    XCTAssertEqualObjects(self.viewModelFromDelegateMethod, viewController.viewModel);
 }
 
 - (void)viewController:(HUBViewController *)viewController didFailToUpdateWithError:(NSError *)error
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     self.errorFromDelegateMethod = error;
 }
 
 - (void)viewControllerDidFinishRendering:(HUBViewController *)viewController
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     self.didReceiveViewControllerDidFinishRendering = YES;
 
     if (self.viewControllerDidFinishRenderingBlock) {
@@ -3144,7 +3144,7 @@
           layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
       willAppearInView:(nonnull UIView *)componentView
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     XCTAssertFalse([componentView isKindOfClass:[HUBComponentCollectionViewCell class]]);
 
     [self.componentViewsFromApperanceDelegateMethod addObject:componentView];
@@ -3157,7 +3157,7 @@
           layoutTraits:(NSSet<HUBComponentLayoutTrait> *)layoutTraits
   didDisappearFromView:(UIView *)componentView
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     
     [self.componentModelsFromDisapperanceDelegateMethod addObject:componentModel];
     [self.componentLayoutTraitsFromDisapperanceDelegateMethod addObject:layoutTraits];
@@ -3165,20 +3165,20 @@
 
 - (void)viewController:(HUBViewController *)viewController willReuseComponentWithView:(UIView *)componentView
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
 
     [self.componentViewsFromReuseDelegateMethod addObject:componentView];
 }
 
 - (void)viewController:(HUBViewController *)viewController componentSelectedWithModel:(id<HUBComponentModel>)componentModel
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     [self.componentModelsFromSelectionDelegateMethod addObject:componentModel];
 }
 
 - (BOOL)viewControllerShouldAutomaticallyManageTopContentInset:(HUBViewController *)viewController
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     if (self.viewControllerShouldAutomaticallyManageTopContentInset) {
         return self.viewControllerShouldAutomaticallyManageTopContentInset();
     }
@@ -3188,7 +3188,7 @@
 - (CGPoint)centerPointForOverlayComponentInViewController:(HUBViewController *)viewController
                                       proposedCenterPoint:(CGPoint)proposedCenterPoint
 {
-    XCTAssertEqual(viewController, self.viewController);
+    XCTAssertEqualObjects(viewController, self.viewController);
     if (self.centerPointForOverlayComponents == nil) {
         return proposedCenterPoint;
     } else {

--- a/tests/HUBViewModelBuilderTests.m
+++ b/tests/HUBViewModelBuilderTests.m
@@ -108,7 +108,7 @@
     
     id<HUBViewModel> const model = [self.builder build];
     XCTAssertNotEqual(model.navigationItem, self.builder.navigationItem);
-    XCTAssertEqual(model.navigationItem.titleView, titleView);
+    XCTAssertEqualObjects(model.navigationItem.titleView, titleView);
 }
 
 - (void)testHeaderComponentBuilder
@@ -192,7 +192,7 @@
     XCTAssertNotNil(componentBuilder);
     XCTAssertEqualObjects(componentBuilder.componentNamespace, self.componentDefaults.componentNamespace);
     XCTAssertTrue([self.builder builderExistsForBodyComponentModelWithIdentifier:componentModelIdentifier]);
-    XCTAssertEqual(componentBuilder,  [self.builder builderForBodyComponentModelWithIdentifier:componentModelIdentifier]);
+    XCTAssertEqualObjects(componentBuilder,  [self.builder builderForBodyComponentModelWithIdentifier:componentModelIdentifier]);
 }
 
 - (void)testRemovalOfBodyComponentBuilders
@@ -520,8 +520,8 @@
     XCTAssertNotEqual(self.builder.navigationItem, builderCopy.navigationItem);
     XCTAssertEqualObjects(builderCopy.navigationItem.title, @"title");
     XCTAssertEqualObjects(builderCopy.navigationBarTitle, @"title");
-    XCTAssertEqual(builderCopy.navigationItem.titleView, titleView);
-    XCTAssertEqual(builderCopy.navigationItem.leftBarButtonItem, leftBarButtonItem);
+    XCTAssertEqualObjects(builderCopy.navigationItem.titleView, titleView);
+    XCTAssertEqualObjects(builderCopy.navigationItem.leftBarButtonItem, leftBarButtonItem);
     XCTAssertEqualObjects(builderCopy.navigationItem.rightBarButtonItems, rightBarButtonItems);
     
     XCTAssertEqualObjects(builderCopy.viewIdentifier, @"id");

--- a/tests/HUBViewModelLoaderFactoryTests.m
+++ b/tests/HUBViewModelLoaderFactoryTests.m
@@ -173,8 +173,8 @@
     XCTAssertEqual(contentOperation.performCount, (NSUInteger)1);
     
     // Verify operation chain order by checking error forwarding
-    XCTAssertEqual(contentOperation.previousContentOperationError, prependedOperationError);
-    XCTAssertEqual(appendedOperation.previousContentOperationError, contentOperationError);
+    XCTAssertEqualObjects(contentOperation.previousContentOperationError, prependedOperationError);
+    XCTAssertEqualObjects(appendedOperation.previousContentOperationError, contentOperationError);
 }
 
 @end

--- a/tests/HUBViewModelLoaderTests.m
+++ b/tests/HUBViewModelLoaderTests.m
@@ -168,7 +168,7 @@
     [contentOperation.delegate contentOperation:contentOperation didFailWithError:error];
     
     XCTAssertNil(self.viewModelFromSuccessDelegateMethod);
-    XCTAssertEqual(error, self.errorFromFailureDelegateMethod);
+    XCTAssertEqualObjects(error, self.errorFromFailureDelegateMethod);
 }
 
 - (void)testContentOperationErrorRecovery
@@ -315,7 +315,7 @@
     
     [self.loader loadViewModel];
     
-    XCTAssertEqual(self.errorFromFailureDelegateMethod, nil);
+    XCTAssertNil(self.errorFromFailureDelegateMethod);
     XCTAssertEqual(self.didLoadViewModelErrorCount, (NSUInteger)0);
     XCTAssertEqual(self.didLoadViewModelCount, (NSUInteger)1);
 }
@@ -339,7 +339,7 @@
     
     [self.loader loadViewModel];
     
-    XCTAssertEqual(self.errorFromFailureDelegateMethod, error);
+    XCTAssertEqualObjects(self.errorFromFailureDelegateMethod, error);
     XCTAssertEqual(self.didLoadViewModelErrorCount, (NSUInteger)1);
     XCTAssertEqual(self.didLoadViewModelCount, (NSUInteger)0);
 }
@@ -514,7 +514,7 @@
     id<HUBContentOperationDelegate> const contentOperationDelegate = contentOperation.delegate;
     [contentOperationDelegate contentOperation:contentOperation didFailWithError:error];
     
-    XCTAssertEqual(self.errorFromFailureDelegateMethod, error);
+    XCTAssertEqualObjects(self.errorFromFailureDelegateMethod, error);
     self.errorFromFailureDelegateMethod = nil;
     contentOperation.contentLoadingBlock = nil;
     
@@ -625,7 +625,7 @@
     [self.loader loadViewModel];
     
     XCTAssertNotNil(contentOperation.featureInfo);
-    XCTAssertEqual(contentOperation.featureInfo, self.featureInfo);
+    XCTAssertEqualObjects(contentOperation.featureInfo, self.featureInfo);
 }
 
 - (void)testFeatureTitleAssignedAsViewTitleIfNil

--- a/tests/HUBViewModelRendererTests.m
+++ b/tests/HUBViewModelRendererTests.m
@@ -108,8 +108,8 @@
     [self waitForExpectationsWithTimeout:2 handler:nil];
 
     XCTAssertEqual([self.collectionViewLayout numberOfInvocations], 2u);
-    XCTAssertEqualObjects([self.collectionViewLayout capturedViewModelAtIndex:0], firstViewModel);
-    XCTAssertEqualObjects([self.collectionViewLayout capturedViewModelAtIndex:1], secondViewModel);
+    XCTAssertEqual([self.collectionViewLayout capturedViewModelAtIndex:0], firstViewModel);
+    XCTAssertEqual([self.collectionViewLayout capturedViewModelAtIndex:1], secondViewModel);
 
     XCTAssertEqual([self.collectionViewLayout numberOfInvocations], 2u);
     // The first invocation shouldn't generate a diff.


### PR DESCRIPTION
Always use `XCTAssertEqualObjects` when comparing objects for equality. `XCTAssertEqual` was causing some issues with `NSIndexPath` equality on 32 bit architectures (possibly because 64-bit architectures pool instances that are equal?)