### PR TITLE
Fix Hub Framework causing unsatisfiable constraints

### DIFF
--- a/sources/HUBComponentCollectionViewCell.m
+++ b/sources/HUBComponentCollectionViewCell.m
@@ -57,7 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     id<HUBComponent> const nonNilComponent = component;
-    [self.contentView addSubview:HUBComponentLoadViewIfNeeded(nonNilComponent)];
+
+    UIView * const componentView = HUBComponentLoadViewIfNeeded(nonNilComponent);
+    componentView.autoresizingMask |= UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+
+    [self.contentView addSubview:componentView];
 }
 
 #pragma mark - UICollectionViewCell


### PR DESCRIPTION
The way Hub Framework wrapped the view of components caused UIKit to run into unsatisfiable constraints. This affects all constraint based views that had internal margins. For example 8 points from the top and bottom. Since the view wasn’t given a size, and the autoresizing mask said it couldn’t be resized automatically, such constraints would require the view to “implode” (top edge 8 points _below_ the view and the bottom edge 8 points _above_ the view). I.e. an impossible layout.

It would also result in the following message being printed to (or rather filling up) the console. As well as hitting the `UIViewAlertForUnsatisfiableConstraints` symbolic breakpoint (everyone should be running that one 😉).
```
2016-12-22 15:36:41.493646 S4A[14387:9231016] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
	(Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x60000049d330 h=--& v=--& HUBRowView:0x7f8ea5d4d040.height == 0   (active)>",
    "<NSLayoutConstraint:0x60000049cca0 V:|-(>=8)-[trailing-accessory-contai...]   (active, names: trailing-accessory-contai...:0x7f8ea5d4d3e0, '|':HUBRowView:0x7f8ea5d4d040 )>",
    "<NSLayoutConstraint:0x60000049cd40 trailing-accessory-contai....bottom <= HUBRowView:0x7f8ea5d4d040.bottom - 8   (active, names: trailing-accessory-contai...:0x7f8ea5d4d3e0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000049cd40 trailing-accessory-contai....bottom <= SPTRowView:0x7f8ea5d4d040.bottom - 8   (active, names: trailing-accessory-contai...:0x7f8ea5d4d3e0 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKit/UIView.h> may also be helpful.
```

This change makes sure we configure the component view such that it will have a size. This is accomplished by setting the autoresizing mask to be flexibile in the height and width directions. All is now good 😄

---

@spotify/objc-dev 