### PR TITLE
Remove NSObject inheritance from all protocols.

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		344E43D11E1D6A230016C7CC /* HUBUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 344E43CF1E1D6A180016C7CC /* HUBUtilitiesTests.m */; };
+		344E43D21E1D6A230016C7CC /* HUBUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 344E43CF1E1D6A180016C7CC /* HUBUtilitiesTests.m */; };
 		521891E61DEE3C6E00FA3BF7 /* HUBBlockContentOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 521891E51DEE3C6E00FA3BF7 /* HUBBlockContentOperation.m */; };
 		521891EA1DEE3E4500FA3BF7 /* HUBContentOperationContextImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 521891E91DEE3E4500FA3BF7 /* HUBContentOperationContextImplementation.m */; };
 		521891ED1DEE410200FA3BF7 /* HUBBlockContentOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 521891EC1DEE410200FA3BF7 /* HUBBlockContentOperationTests.m */; };
@@ -461,6 +463,7 @@
 		1D98E5BC1DC09FB500607097 /* HUBComponentActionObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentActionObserver.h; sourceTree = "<group>"; };
 		2932E27842AE1C98FD5D1746 /* HUBComponentFactoryMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentFactoryMock.m; sourceTree = "<group>"; };
 		2932EAD3C06CBB869669B382 /* HUBComponentFactoryMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentFactoryMock.h; sourceTree = "<group>"; };
+		344E43CF1E1D6A180016C7CC /* HUBUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBUtilitiesTests.m; sourceTree = "<group>"; };
 		4E29FCF31DED2D9600856D20 /* HUBTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBTestUtilities.h; sourceTree = "<group>"; };
 		521891E21DEE3C3000FA3BF7 /* HUBBlockContentOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBBlockContentOperation.h; sourceTree = "<group>"; };
 		521891E51DEE3C6E00FA3BF7 /* HUBBlockContentOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBBlockContentOperation.m; sourceTree = "<group>"; };
@@ -1062,6 +1065,7 @@
 				8ADD42A91C21D08100D1A801 /* HUBManagerTests.m */,
 				8ACB2A7B1C6A2F99000741D7 /* HUBIdentifierTests.m */,
 				8A2BD20F1E0AA444008A5050 /* HUBOperationQueueTests.m */,
+				344E43CF1E1D6A180016C7CC /* HUBUtilitiesTests.m */,
 				8A6529E81D82B349007B1A15 /* JSON */,
 				8A6529E11D81B176007B1A15 /* View */,
 				8A6529E91D82B35F007B1A15 /* Feature */,
@@ -1959,6 +1963,7 @@
 				8ABD6CE61DF6ECFA005BCB33 /* HUBDefaultComponentLayoutManagerTests.m in Sources */,
 				8ABD6CCF1DF6ECF3005BCB33 /* HUBMutableJSONPathTests.m in Sources */,
 				8ABD6CCE1DF6ECF3005BCB33 /* HUBJSONPathTests.m in Sources */,
+				344E43D21E1D6A230016C7CC /* HUBUtilitiesTests.m in Sources */,
 				8ABD6CD71DF6ECF3005BCB33 /* HUBViewControllerTests.m in Sources */,
 				8ABD6CE11DF6ECFA005BCB33 /* HUBComponentRegistryTests.m in Sources */,
 				8ABD6CBB1DF6ECF3005BCB33 /* HUBComponentFactoryMock.m in Sources */,
@@ -2000,6 +2005,7 @@
 				8A2BD2101E0AA444008A5050 /* HUBOperationQueueTests.m in Sources */,
 				8AA29CF81C4FE59100E972B7 /* HUBComponentModelBuilderTests.m in Sources */,
 				8A6BA0561C89A00F0057485D /* HUBComponentLayoutManagerMock.m in Sources */,
+				344E43D11E1D6A230016C7CC /* HUBUtilitiesTests.m in Sources */,
 				B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */,
 				8A1513311DB7B5B100DE8C7A /* HUBTouchMock.m in Sources */,
 				8A9ED75F1D4A24C2006B27D8 /* HUBComponentModelTests.m in Sources */,

--- a/demo/sources/ActivityIndicatorComponent.swift
+++ b/demo/sources/ActivityIndicatorComponent.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// A component that renders a system default activity indicator view
-class ActivityIndicatorComponent: NSObject, HUBComponentViewObserver {
+class ActivityIndicatorComponent: HUBComponentViewObserver {
     var view: UIView?
     
     private lazy var activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)

--- a/demo/sources/ColorContainerComponent.swift
+++ b/demo/sources/ColorContainerComponent.swift
@@ -30,7 +30,7 @@ import HubFramework
  *  - customData["color"] (as String)
  *  - children (only the first one is handled)
  */
-class ColorContainerComponent: NSObject, HUBComponentWithChildren, HUBComponentViewObserver {
+class ColorContainerComponent: HUBComponentWithChildren, HUBComponentViewObserver {
     /// Structure containing custom data keys used by `ColorContainerComponent`
     struct CustomDataKeys {
         /// The key used to encode a color (a String value is expected)

--- a/demo/sources/DefaultComponentFactory.swift
+++ b/demo/sources/DefaultComponentFactory.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Default component factory, used as the implicit factory when no namespace was given
-class DefaultComponentFactory: NSObject, HUBComponentFactory {
+class DefaultComponentFactory: HUBComponentFactory {
     static var namespace = "default"
     
     private lazy var creationMap: [String: () -> HUBComponent] = [

--- a/demo/sources/GitHubSearchActivityIndicatorContentOperation.swift
+++ b/demo/sources/GitHubSearchActivityIndicatorContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation that adds an activity indicator when loading results from the GitHub search API
-class GitHubSearchActivityIndicatorContentOperation: NSObject, HUBContentOperation {
+class GitHubSearchActivityIndicatorContentOperation: HUBContentOperation {
     weak var delegate: HUBContentOperationDelegate?
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {

--- a/demo/sources/GitHubSearchBarContentOperation.swift
+++ b/demo/sources/GitHubSearchBarContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation that adds a search bar for the GitHub search feature
-class GitHubSearchBarContentOperation: NSObject, HUBContentOperationActionObserver {
+class GitHubSearchBarContentOperation: HUBContentOperationActionObserver {
     weak var delegate: HUBContentOperationDelegate?
     private var searchString: String?
     private var searchActionIdentifier: HUBIdentifier { return HUBIdentifier(namespace: "github", name: "search") }

--- a/demo/sources/GitHubSearchContentOperationFactory.swift
+++ b/demo/sources/GitHubSearchContentOperationFactory.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation factory used for the GitHub search feature
-class GitHubSearchContentOperationFactory: NSObject, HUBContentOperationFactory {
+class GitHubSearchContentOperationFactory: HUBContentOperationFactory {
     func createContentOperations(forViewURI viewURI: URL) -> [HUBContentOperation] {
         return [
             GitHubSearchBarContentOperation(),

--- a/demo/sources/GitHubSearchResultsContentOperation.swift
+++ b/demo/sources/GitHubSearchResultsContentOperation.swift
@@ -33,7 +33,7 @@ import HubFramework
  *  to add the data to the view model builder. The reason we don't simply wait until the API response has been downloaded,
  *  is because we don't want to block the rendering of the view.
  */
-class GitHubSearchResultsContentOperation: NSObject, HUBContentOperation {
+class GitHubSearchResultsContentOperation: HUBContentOperation {
     weak var delegate: HUBContentOperationDelegate?
     private var dataTask: URLSessionDataTask?
     private var jsonData: Data?

--- a/demo/sources/HeaderComponent.swift
+++ b/demo/sources/HeaderComponent.swift
@@ -30,7 +30,7 @@ import HubFramework
  *  - title
  *  - backgroundImageData
  */
-class HeaderComponent: NSObject, HUBComponentContentOffsetObserver, HUBComponentWithImageHandling, HUBComponentViewObserver {
+class HeaderComponent: HUBComponentContentOffsetObserver, HUBComponentWithImageHandling, HUBComponentViewObserver {
     var view: UIView?
     private lazy var imageView = UIImageView()
     private lazy var titleLabel = UILabel()

--- a/demo/sources/ImageComponent.swift
+++ b/demo/sources/ImageComponent.swift
@@ -34,7 +34,7 @@ struct ImageComponentCustomDataKeys {
  *  This component uses the `customData` dictionary of `HUBComponentModel` for customization.
  *  See `ImageComponentCustomDataKeys` for what keys are used for what data.
  */
-class ImageComponent: NSObject, HUBComponentWithImageHandling, HUBComponentWithSelectionState {
+class ImageComponent: HUBComponentWithImageHandling, HUBComponentWithSelectionState {
     var view: UIView?
     
     private lazy var imageView = UIImageView()

--- a/demo/sources/LabelComponent.swift
+++ b/demo/sources/LabelComponent.swift
@@ -29,7 +29,7 @@ import HubFramework
  *
  *  - title
  */
-class LabelComponent: NSObject, HUBComponent {
+class LabelComponent: HUBComponent {
     var view: UIView?
 
     private lazy var label = UILabel()

--- a/demo/sources/PrettyPicturesActionHandler.swift
+++ b/demo/sources/PrettyPicturesActionHandler.swift
@@ -24,7 +24,7 @@ import HubFramework
 import SafariServices
 
 /// Action handler that opens a URL in a Safari VC
-class PrettyPicturesActionHandler: NSObject, HUBActionHandler {
+class PrettyPicturesActionHandler: HUBActionHandler {
     func handleAction(with context: HUBActionContext) -> Bool {
         guard let uri = context.componentModel?.target?.uri else {
             return false

--- a/demo/sources/PrettyPicturesContentOperation.swift
+++ b/demo/sources/PrettyPicturesContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation that adds a grid of pictures to the "Pretty pictures" feature
-class PrettyPicturesContentOperation: NSObject, HUBContentOperation {
+class PrettyPicturesContentOperation: HUBContentOperation {
     weak var delegate: HUBContentOperationDelegate?
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {

--- a/demo/sources/PrettyPicturesContentOperationFactory.swift
+++ b/demo/sources/PrettyPicturesContentOperationFactory.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation factory used in the "Pretty pictures" feature
-class PrettyPicturesContentOperationFactory: NSObject, HUBContentOperationFactory {
+class PrettyPicturesContentOperationFactory: HUBContentOperationFactory {
     func createContentOperations(forViewURI viewURI: URL) -> [HUBContentOperation] {
         return [PrettyPicturesContentOperation()]
     }

--- a/demo/sources/ReallyLongListContentOperation.swift
+++ b/demo/sources/ReallyLongListContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation that adds 10,000 rows as part of the "Really Long List" feature
-class ReallyLongListContentOperation: NSObject, HUBContentOperationWithPaginatedContent {
+class ReallyLongListContentOperation: HUBContentOperationWithPaginatedContent {
     weak var delegate: HUBContentOperationDelegate?
 
     func perform(forViewURI viewURI: URL, featureInfo: HUBFeatureInfo, connectivityState: HUBConnectivityState, viewModelBuilder: HUBViewModelBuilder, previousError: Error?) {

--- a/demo/sources/ReallyLongListContentOperationFactory.swift
+++ b/demo/sources/ReallyLongListContentOperationFactory.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation factory used for the "Really Long List" feature
-class ReallyLongListContentOperationFactory: NSObject, HUBContentOperationFactory {
+class ReallyLongListContentOperationFactory: HUBContentOperationFactory {
     func createContentOperations(forViewURI viewURI: URL) -> [HUBContentOperation] {
         return [ReallyLongListContentOperation()]
     }

--- a/demo/sources/RootContentOperation.swift
+++ b/demo/sources/RootContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation used to populate the "Root" feature
-class RootContentOperation: NSObject, HUBContentOperation {
+class RootContentOperation: HUBContentOperation {
     weak var delegate: HUBContentOperationDelegate?
     
     func perform(forViewURI viewURI: URL,

--- a/demo/sources/RootContentOperationFactory.swift
+++ b/demo/sources/RootContentOperationFactory.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation factory used for the "Root" feature
-class RootContentOperationFactory: NSObject, HUBContentOperationFactory {
+class RootContentOperationFactory: HUBContentOperationFactory {
     func createContentOperations(forViewURI viewURI: URL) -> [HUBContentOperation] {
         return [RootContentOperation()]
     }

--- a/demo/sources/RowComponent.swift
+++ b/demo/sources/RowComponent.swift
@@ -31,7 +31,7 @@ import HubFramework
  *  - subtitle
  *  - mainImageData
  */
-class RowComponent: NSObject, HUBComponentWithImageHandling, UIGestureRecognizerDelegate {
+class RowComponent: HUBComponentWithImageHandling {
     var layoutTraits: Set<HUBComponentLayoutTrait> { return [.fullWidth, .stackable] }
     var view: UIView?
     

--- a/demo/sources/SearchBarComponent.swift
+++ b/demo/sources/SearchBarComponent.swift
@@ -40,7 +40,7 @@ struct SearchBarComponentCustomDataKeys {
  *  This component uses the `customData` dictionary of `HUBComponentModel` for customization.
  *  See `SearchBarComponentCustomKeys` for what keys are used for what data.
  */
-class SearchBarComponent: NSObject, HUBComponentActionPerformer, UISearchBarDelegate, HUBComponentContentOffsetObserver {
+class SearchBarComponent: NSObject, HUBComponentActionPerformer, HUBComponentContentOffsetObserver, UISearchBarDelegate {
     var view: UIView?
     weak var actionPerformer: HUBActionPerformer?
 

--- a/demo/sources/StickyHeaderContentOperation.swift
+++ b/demo/sources/StickyHeaderContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation that adds a sticky header and a few rows beneath it
-class StickyHeaderContentOperation: NSObject, HUBContentOperation {
+class StickyHeaderContentOperation: HUBContentOperation {
     weak var delegate: HUBContentOperationDelegate?
     private var performCount = 0
 

--- a/demo/sources/TodoListActionFactory.swift
+++ b/demo/sources/TodoListActionFactory.swift
@@ -31,7 +31,7 @@ struct TodoListActionNames {
 }
 
 /// Action factory used by the "Todo list" feature
-class TodoListActionFactory: NSObject, HUBActionFactory {
+class TodoListActionFactory: HUBActionFactory {
     /// The namespace that this action factory is registered for with `HUBActionRegistry`
     static var namespace: String { return "namespace" }
     

--- a/demo/sources/TodoListAddAction.swift
+++ b/demo/sources/TodoListAddAction.swift
@@ -29,7 +29,7 @@ struct TodoListAddActionCustomDataKeys {
 }
 
 /// Action that presents an alert to add a todo list item
-class TodoListAddAction: NSObject, HUBAsyncAction {
+class TodoListAddAction: HUBAsyncAction {
     weak var delegate: HUBAsyncActionDelegate?
     
     func perform(with context: HUBActionContext) -> Bool {

--- a/demo/sources/TodoListContentOperation.swift
+++ b/demo/sources/TodoListContentOperation.swift
@@ -23,7 +23,7 @@ import Foundation
 import HubFramework
 
 /// Content operation used by the "Todo list" feature
-class TodoListContentOperation: NSObject, HUBContentOperationActionPerformer, HUBContentOperationActionObserver {
+class TodoListContentOperation: HUBContentOperationActionPerformer, HUBContentOperationActionObserver {
     weak var delegate: HUBContentOperationDelegate?
     weak var actionPerformer: HUBActionPerformer?
     private var addActionIdentifier: HUBIdentifier {

--- a/include/HubFramework/HUBAction.h
+++ b/include/HubFramework/HUBAction.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Actions are created by an implementation of `HUBActionFactory`, which are registered for a certain
  *  namespace with `HUBActionRegistry`.
  */
-@protocol HUBAction <NSObject>
+@protocol HUBAction
 
 /**
  *  Perform the action in a certain context

--- a/include/HubFramework/HUBActionContext.h
+++ b/include/HubFramework/HUBActionContext.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  information that an action can use to make decisions on how to execute, and is always
  *  relative to the component for which the action will be performed.
  */
-@protocol HUBActionContext <NSObject>
+@protocol HUBActionContext
 
 /// The type of event that triggered the action to be performed
 @property (nonatomic, assign, readonly) HUBActionTrigger trigger;

--- a/include/HubFramework/HUBActionFactory.h
+++ b/include/HubFramework/HUBActionFactory.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  for a certain namespace with `HUBActionRegistry`, and will be invoked when an action identifier
  *  with the matching namespace was encountered as part of the handling of an event.
  */
-@protocol HUBActionFactory <NSObject>
+@protocol HUBActionFactory
 
 /**
  *  Create an action for a certain name

--- a/include/HubFramework/HUBActionHandler.h
+++ b/include/HubFramework/HUBActionHandler.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  A default action handler to be used system-wide can also be supplied when setting up this
  *  application's `HUBManager`.
  */
-@protocol HUBActionHandler <NSObject>
+@protocol HUBActionHandler
 
 /**
  *  Handle an action with a given context

--- a/include/HubFramework/HUBActionPerformer.h
+++ b/include/HubFramework/HUBActionPerformer.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  an object conforming to this protocol to the `actionPerformer` property of either a
  *  component or content operation.
  */
-@protocol HUBActionPerformer <NSObject>
+@protocol HUBActionPerformer
 
 /**
  *  Perform an action with a given identifier, optionally passing custom data as well

--- a/include/HubFramework/HUBActionRegistry.h
+++ b/include/HubFramework/HUBActionRegistry.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  You don't conform to this protocol yourself, instead the application's `HUBManager` comes setup
  *  with a registry that you can use.
  */
-@protocol HUBActionRegistry <NSObject>
+@protocol HUBActionRegistry
 
 /**
  *  Register an action factory with the Hub Framework

--- a/include/HubFramework/HUBAsyncAction.h
+++ b/include/HubFramework/HUBAsyncAction.h
@@ -27,7 +27,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Delegate protocol used by `HUBAsyncAction` types to notify the Hub Framework when they finish
-@protocol HUBAsyncActionDelegate <NSObject>
+@protocol HUBAsyncActionDelegate
 
 /**
  *  Notify the Hub Framework that an asynchronous action finished

--- a/include/HubFramework/HUBComponent.h
+++ b/include/HubFramework/HUBComponent.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  `HUBComponentActionObserver`: For components that can observe actions (see `HUBAction`).
  */
-@protocol HUBComponent <NSObject>
+@protocol HUBComponent
 
 #pragma mark - Configuring the Component's layout
 

--- a/include/HubFramework/HUBComponentFactory.h
+++ b/include/HubFramework/HUBComponentFactory.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Each factory is registered with `HUBComponentRegistry` for a certain namespace, and will be used
  *  whenever a component model declares that namespace as part of its component identifier.
  */
-@protocol HUBComponentFactory <NSObject>
+@protocol HUBComponentFactory
 
 /**
  *  Create a new component matching a name

--- a/include/HubFramework/HUBComponentFallbackHandler.h
+++ b/include/HubFramework/HUBComponentFallbackHandler.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  provided by a fallback handler is used to set up all component model builders with default values, and
  *  the fallback handler also acts as a last line of defence for backwards compatibility.
  */
-@protocol HUBComponentFallbackHandler <NSObject>
+@protocol HUBComponentFallbackHandler
 
 /**
  *  The default component namespace, that all component model builders should have when created

--- a/include/HubFramework/HUBComponentImageDataJSONSchema.h
+++ b/include/HubFramework/HUBComponentImageDataJSONSchema.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  All paths in this schema are relative to a dictionary containing image data for a component.
  */
-@protocol HUBComponentImageDataJSONSchema <NSObject>
+@protocol HUBComponentImageDataJSONSchema
 
 /// The path that points to a HTTP image URL for the image that the data is for. Maps to `URL`.
 @property (nonatomic, strong) id<HUBJSONURLPath> URLPath;

--- a/include/HubFramework/HUBComponentLayoutManager.h
+++ b/include/HubFramework/HUBComponentLayoutManager.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, HUBComponentLayoutContentEdge) {
  *  A layout manager is always given a set of layout traits for the component(s) in question, to be able to make good
  *  decisions on what margins to use. For more information about layout traits; see `HUBComponentLayoutTrait`.
  */
-@protocol HUBComponentLayoutManager <NSObject>
+@protocol HUBComponentLayoutManager
 
 /**
  *  Return the margin to use between a component with a set of layout traits and a content edge

--- a/include/HubFramework/HUBComponentModelJSONSchema.h
+++ b/include/HubFramework/HUBComponentModelJSONSchema.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  All paths in this schema are relative to a JSON dictionary defining component model data.
  */
-@protocol HUBComponentModelJSONSchema <NSObject>
+@protocol HUBComponentModelJSONSchema
 
 /// The path to follow to extract a component model identifier. Maps to `identifier`.
 @property (nonatomic, strong) id<HUBJSONStringPath> identifierPath;

--- a/include/HubFramework/HUBComponentRegistry.h
+++ b/include/HubFramework/HUBComponentRegistry.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  You don't conform to this protocol yourself, instead the application's `HUBManager` comes
  *  setup with a registry that you can use.
  */
-@protocol HUBComponentRegistry <NSObject>
+@protocol HUBComponentRegistry
 
 /**
  *  Register a component factory with the Hub Framework

--- a/include/HubFramework/HUBComponentShowcaseManager.h
+++ b/include/HubFramework/HUBComponentShowcaseManager.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  You don't conform to this protocol yourself, instead the application's `HUBManager` comes setup with a
  *  showcase manager that you can use.
  */
-@protocol HUBComponentShowcaseManager <NSObject>
+@protocol HUBComponentShowcaseManager
 
 /**
  *  The component identifiers that have been declared as showcaseable

--- a/include/HubFramework/HUBComponentShowcaseShapshotGenerator.h
+++ b/include/HubFramework/HUBComponentShowcaseShapshotGenerator.h
@@ -31,7 +31,7 @@
  *  You don't conform to this protocol yourself, instead request an instance conforming
  *  to it from the application's `HUBComponentShowcaseManager`.
  */
-@protocol HUBComponentShowcaseSnapshotGenerator <NSObject>
+@protocol HUBComponentShowcaseSnapshotGenerator
 
 /**
  *  Generate a snapshot of the component that this object represents

--- a/include/HubFramework/HUBComponentTargetJSONSchema.h
+++ b/include/HubFramework/HUBComponentTargetJSONSchema.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  All paths in this schema are relative to a dictionary containing target data for a component.
  */
-@protocol HUBComponentTargetJSONSchema <NSObject>
+@protocol HUBComponentTargetJSONSchema
 
 /// The path to follow to extract a target URI string. Maps to `URI`.
 @property (nonatomic, strong) id<HUBJSONURLPath> URIPath;

--- a/include/HubFramework/HUBComponentWithChildren.h
+++ b/include/HubFramework/HUBComponentWithChildren.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  It's definitely recommended to use this protocol as much as possible when using child components, since
  *  you can leverage the framework's built-in capabilities for selection, image loading & other events.
  */
-@protocol HUBComponentChildDelegate <NSObject>
+@protocol HUBComponentChildDelegate
 
 /**
  *  Return a child component for a given model

--- a/include/HubFramework/HUBConnectivityStateResolver.h
+++ b/include/HubFramework/HUBConnectivityStateResolver.h
@@ -26,7 +26,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Protocol used to observe a connectivity state resolver for changes in connectivity state
-@protocol HUBConnectivityStateResolverObserver <NSObject>
+@protocol HUBConnectivityStateResolverObserver
 
 /**
  *  Notifiy an observer that the application's connectivity state changed
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  The resolver should also support observations; to enable the Hub Framework to react to changes
  *  in connectivity state. Whenever the resolver detected a change, it should call its observers.
  */
-@protocol HUBConnectivityStateResolver <NSObject>
+@protocol HUBConnectivityStateResolver
 
 /**
  *  Resolve the current connectivity state of the application

--- a/include/HubFramework/HUBContentOperation.h
+++ b/include/HubFramework/HUBContentOperation.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  property, which the Hub Framework will assign. You may then use the methods defined in this protocol to
  *  communicate content operation events back to the framework.
  */
-@protocol HUBContentOperationDelegate <NSObject>
+@protocol HUBContentOperationDelegate
 
 /**
  *  Notify the Hub Framework that a content operation finished
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  main content loading chain is started - it can conform to `HUBContentOperationWithInitialContent` to be able to
  *  do so.
  */
-@protocol HUBContentOperation <NSObject>
+@protocol HUBContentOperation
 
 /// The content operation's delegate. Don't assign this property yourself, it will be set by the Hub Framework.
 @property (nonatomic, weak, nullable) id<HUBContentOperationDelegate> delegate;

--- a/include/HubFramework/HUBContentOperationContext.h
+++ b/include/HubFramework/HUBContentOperationContext.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  about the properties that are part of this API, refer to `HUBContentOperation`, or to
  *  the "Content programming guide".
  */
-@protocol HUBContentOperationContext <NSObject>
+@protocol HUBContentOperationContext
 
 /// The URI of the view that the content operation is being used in
 @property (nonatomic, copy, readonly) NSURL *viewURI;

--- a/include/HubFramework/HUBContentOperationFactory.h
+++ b/include/HubFramework/HUBContentOperationFactory.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  For more information, see `HUBContentOperation`.
  */
-@protocol HUBContentOperationFactory <NSObject>
+@protocol HUBContentOperationFactory
 
 /**
  *  Create an array of content operations to use for a view with a certain URI

--- a/include/HubFramework/HUBContentReloadPolicy.h
+++ b/include/HubFramework/HUBContentReloadPolicy.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Each application using the Hub Framework also has a default content reload policy used for features that
  *  do not declare their own. This reload policy is passed when setting up `HUBManager`.
  */
-@protocol HUBContentReloadPolicy <NSObject>
+@protocol HUBContentReloadPolicy
 
 /**
  *  Return whether the content for a view should be reloaded

--- a/include/HubFramework/HUBFeatureInfo.h
+++ b/include/HubFramework/HUBFeatureInfo.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  You don't conform to this protocol yourself, instead the Hub Framework will create instances conforming
  *  to this protocol based on the information a feature provided when it was registered with the framework.
  */
-@protocol HUBFeatureInfo <NSObject>
+@protocol HUBFeatureInfo
 
 /// The identifier of the feature
 @property (nonatomic, copy, readonly) NSString *identifier;

--- a/include/HubFramework/HUBFeatureRegistry.h
+++ b/include/HubFramework/HUBFeatureRegistry.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  A feature is the top-level entity in the Hub Framework, that is used to ecapsulate related views into a logical group.
  *  Views that belong to the same feature share the same setup, such as a view URI predicate, content operation factories, etc.
  */
-@protocol HUBFeatureRegistry <NSObject>
+@protocol HUBFeatureRegistry
 
 /**
  *  Register a feature with the Hub Framework

--- a/include/HubFramework/HUBIcon.h
+++ b/include/HubFramework/HUBIcon.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  can be materialized into an image of any size. Images are resolved using the `HUBIconImageResolver`
  *  passed when setting up `HUBManager`.
  */
-@protocol HUBIcon <NSObject>
+@protocol HUBIcon
 
 /// The identifier of the icon. Can be used for custom image resolving.
 @property (nonatomic, copy, readonly) NSString *identifier;

--- a/include/HubFramework/HUBIconImageResolver.h
+++ b/include/HubFramework/HUBIconImageResolver.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  `HUBManager`. The Hub Framework uses this object whenever an image needs to be resolved from a
  *  `HUBIcon` instance.
  */
-@protocol HUBIconImageResolver <NSObject>
+@protocol HUBIconImageResolver
 
 /**
  *  Resolve an image for component icon

--- a/include/HubFramework/HUBImageLoader.h
+++ b/include/HubFramework/HUBImageLoader.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  that conforms to this protocol as the delegate of any image loader. You use the methods defined in this
  *  protocol to communicate an image loader's outcomes back to the framework.
  */
-@protocol HUBImageLoaderDelegate <NSObject>
+@protocol HUBImageLoaderDelegate
 
 /**
  *  Notify the Hub Framework that an image loader finished loading an image
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  See also `HUBImageLoaderFactory` which is used to create instances conforming to this protocol.
  */
-@protocol HUBImageLoader <NSObject>
+@protocol HUBImageLoader
 
 /// The image loader's delegate. Don't assign this property yourself, it will be set by the Hub Framework.
 @property (nonatomic, weak, nullable) id<HUBImageLoaderDelegate> delegate;

--- a/include/HubFramework/HUBImageLoaderFactory.h
+++ b/include/HubFramework/HUBImageLoaderFactory.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  See `HUBImageLoader` for more information.
  */
-@protocol HUBImageLoaderFactory <NSObject>
+@protocol HUBImageLoaderFactory
 
 /**
  *  Create an image loader

--- a/include/HubFramework/HUBJSONCompatibleBuilder.h
+++ b/include/HubFramework/HUBJSONCompatibleBuilder.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Builders that support JSON data will conform to this protocol. Most builders only support Dictionary-based JSON,
  *  except for `HUBViewModelBuilder` that supports Array-based JSON for defining an array of body component models.
  */
-@protocol HUBJSONCompatibleBuilder <NSObject>
+@protocol HUBJSONCompatibleBuilder
 
 /**
  *  Add the contents of the given JSON data to the builder.

--- a/include/HubFramework/HUBJSONPath.h
+++ b/include/HubFramework/HUBJSONPath.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  uses them to retrieve data internally. You might want to construct paths yourself, though, and for that you
  *  use the mutable version of this API; `HUBMutableJSONPath`.
  */
-@protocol HUBJSONPath <NSObject>
+@protocol HUBJSONPath
 
 /**
  *  Return an array of values by following this path in a JSON dictionary

--- a/include/HubFramework/HUBJSONSchema.h
+++ b/include/HubFramework/HUBJSONSchema.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  For a more in-depth description on how paths work, see the documentation for `HUBJSONPath` and `HUBMutableJSONPath`.
  */
-@protocol HUBJSONSchema <NSObject>
+@protocol HUBJSONSchema
 
 /// The schema used to retrieve data for `HUBViewModel` objects
 @property (nonatomic, strong, readonly) id<HUBViewModelJSONSchema> viewModelSchema;

--- a/include/HubFramework/HUBJSONSchemaRegistry.h
+++ b/include/HubFramework/HUBJSONSchemaRegistry.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  For more information on how Hub Framework JSON schemas work; see `HUBJSONSchema`.
  */
-@protocol HUBJSONSchemaRegistry <NSObject>
+@protocol HUBJSONSchemaRegistry
 
 /**
  *  Create a new JSON schema that can be customized for a custom JSON format

--- a/include/HubFramework/HUBLiveService.h
+++ b/include/HubFramework/HUBLiveService.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Implement this to recieve view controllers created by the service (using JSON passed from the
  *  `hublive` command line application).
  */
-@protocol HUBLiveServiceDelegate <NSObject>
+@protocol HUBLiveServiceDelegate
 
 /**
  *  Sent to the delegate whenever the live service created a new view controller
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Note though that this implementation is only compiled when the application hosting the framework is
  *  compiled for DEBUG.
  */
-@protocol HUBLiveService <NSObject>
+@protocol HUBLiveService
 
 /// The service's delegate. See `HUBLiveServiceDelegate` for more information.
 @property (nonatomic, weak, nullable) id<HUBLiveServiceDelegate> delegate;

--- a/include/HubFramework/HUBMutableJSONPath.h
+++ b/include/HubFramework/HUBMutableJSONPath.h
@@ -61,7 +61,7 @@ typedef id _Nullable(^HUBMutableJSONPathBlock)(NSObject *input);
  *  [[[path goTo:@"date"] goTo:@"weekday"] stringPath];
  *  @endcode
  */
-@protocol HUBMutableJSONPath <NSObject>
+@protocol HUBMutableJSONPath
 
 #pragma mark - Operations
 

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  Conform to this protocol in a custom object to get notified of events occuring in a Hub Framework view controller
  */
-@protocol HUBViewControllerDelegate <NSObject>
+@protocol HUBViewControllerDelegate
 
 /**
  *  Sent to a Hub Framework view controller's delegate when it is about to be updated with a new view model

--- a/include/HubFramework/HUBViewControllerFactory.h
+++ b/include/HubFramework/HUBViewControllerFactory.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Framework uses URL-based navigation (per default), a recommended place to create view controllers
  *  using this factory, would be when you are responding to opening URLs, for example in your App Delegate.
  */
-@protocol HUBViewControllerFactory <NSObject>
+@protocol HUBViewControllerFactory
 
 /**
  *  Return whether the factory is able to create a view controller for a given view URI

--- a/include/HubFramework/HUBViewControllerScrollHandler.h
+++ b/include/HubFramework/HUBViewControllerScrollHandler.h
@@ -31,7 +31,7 @@
  *  (through `HUBFeatureRegistry`). This enables a feature to customize how scrolling is handled
  *  for all view controllers that will be created on its behalf.
  */
-@protocol HUBViewControllerScrollHandler <NSObject>
+@protocol HUBViewControllerScrollHandler
 
 /**
  *  Return whether scroll indicators should be shown in a view controller

--- a/include/HubFramework/HUBViewModelJSONSchema.h
+++ b/include/HubFramework/HUBViewModelJSONSchema.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  All paths in this schema are relative to a JSON dictionary defining view model data.
  */
-@protocol HUBViewModelJSONSchema <NSObject>
+@protocol HUBViewModelJSONSchema
 
 /// The path to follow to extract a view model identifier. Maps to `identifier`.
 @property (nonatomic, strong) id<HUBJSONStringPath> identifierPath;

--- a/include/HubFramework/HUBViewModelLoader.h
+++ b/include/HubFramework/HUBViewModelLoader.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Conform to this protocol in a custom object to get notified when a view model was loaded, or if an
  *  error occured in the loading process.
  */
-@protocol HUBViewModelLoaderDelegate <NSObject>
+@protocol HUBViewModelLoaderDelegate
 
 /**
  *  Sent to a view model loader's delegate when a view model was loaded
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  this protocol internally. This API is currently not accessible from outside of the Hub Framework, but will
  *  be soon as part of the external data API.
  */
-@protocol HUBViewModelLoader <NSObject>
+@protocol HUBViewModelLoader
 
 /**
  *  The view model loader's delegate

--- a/include/HubFramework/HUBViewModelLoaderFactory.h
+++ b/include/HubFramework/HUBViewModelLoaderFactory.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  in case you want to use data from a Hub Framework-powered feature in a part of the app that does not
  *  use the framework.
  */
-@protocol HUBViewModelLoaderFactory <NSObject>
+@protocol HUBViewModelLoaderFactory
 
 /**
  *  Return whether the factory is able to create a view model loader for a given view URI

--- a/sources/HUBActionHandlerWrapper.m
+++ b/sources/HUBActionHandlerWrapper.m
@@ -30,6 +30,7 @@
 #import "HUBComponentModel.h"
 #import "HUBComponentTarget.h"
 #import "HUBViewModelLoaderImplementation.h"
+#import "HUBUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -95,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
     if ([self.actionHandler handleActionWithContext:context]) {
         actionPerformed = YES;
     } else {
-        if ([action conformsToProtocol:@protocol(HUBAsyncAction)]) {
+        if (HUBConformsToProtocol(action, @protocol(HUBAsyncAction))) {
             id<HUBAsyncAction> const asyncAction = (id<HUBAsyncAction>)action;
             HUBAsyncActionWrapper * const wrapper = [[HUBAsyncActionWrapper alloc] initWithAction:asyncAction context:context];
             wrapper.delegate = self;

--- a/sources/HUBAsyncActionWrapper.h
+++ b/sources/HUBAsyncActionWrapper.h
@@ -29,7 +29,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Delegate protocol for `HUBAsyncActionWrapper`
-@protocol HUBAsyncActionWrapperDelegate <NSObject>
+@protocol HUBAsyncActionWrapperDelegate
 
 /**
  *  Notify an async action wrapper's delegate that it finished

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -29,6 +29,7 @@
 #import "HUBIdentifier.h"
 #import "HUBComponentLayoutManager.h"
 #import "HUBViewModelDiff.h"
+#import "HUBUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -287,7 +288,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<HUBComponent> const newComponent = [self.componentRegistry createComponentForModel:model];
     self.componentCache[model.componentIdentifier] = newComponent;
     
-    if ([newComponent conformsToProtocol:@protocol(HUBComponentWithChildren)]) {
+    if (HUBConformsToProtocol(newComponent, @protocol(HUBComponentWithChildren))) {
         ((id<HUBComponentWithChildren>)newComponent).childDelegate = self;
     }
     

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -414,11 +414,23 @@ NS_ASSUME_NONNULL_BEGIN
                                      lastComponentX:(CGFloat)lastComponentX
                                            rowWidth:(CGFloat)rowWidth
 {
-    NSArray<NSSet<HUBComponentLayoutTrait> *> *componentsTraits = [components valueForKey:NSStringFromSelector(@selector(layoutTraits))];
+
+
+    NSArray<NSSet<HUBComponentLayoutTrait> *> *componentsTraits = [self.class layoutTraitsFromComponents:components];
     CGFloat adjustment = [self.componentLayoutManager horizontalOffsetForComponentsWithLayoutTraits:componentsTraits
                                                               firstComponentLeadingHorizontalOffset:firstComponentX
                                                               lastComponentTrailingHorizontalOffset:rowWidth - lastComponentX];
+
     [self updateLayoutAttributesForComponents:components horizontalAdjustment:adjustment lastComponentIndex:lastComponentIndex];
+}
+
++ (NSArray<NSSet<HUBComponentLayoutTrait> *> *)layoutTraitsFromComponents:(NSArray<id<HUBComponent>> *)components
+{
+    NSMutableArray *layoutTraints = [NSMutableArray new];
+    for (id<HUBComponent> component in components) {
+        [layoutTraints addObject:component.layoutTraits];
+    }
+    return [layoutTraints copy];
 }
 
 - (void)updateLayoutAttributesForComponents:(NSArray<id<HUBComponent>> *)components

--- a/sources/HUBComponentRegistryImplementation.m
+++ b/sources/HUBComponentRegistryImplementation.m
@@ -29,6 +29,7 @@
 #import "HUBComponentFallbackHandler.h"
 #import "HUBComponentModelBuilderShowcaseSnapshotGenerator.h"
 #import "HUBJSONSchemaRegistryImplementation.h"
+#import "HUBUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -105,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (NSString * const namespace in self.componentFactories) {
         id<HUBComponentFactory> const factory = self.componentFactories[namespace];
         
-        if (![factory conformsToProtocol:@protocol(HUBComponentFactoryShowcaseNameProvider)]) {
+        if (!HUBConformsToProtocol(factory, @protocol(HUBComponentFactoryShowcaseNameProvider))) {
             continue;
         }
         
@@ -124,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     id<HUBComponentFactory> const factory = self.componentFactories[componentIdentifier.namespacePart];
     
-    if (![factory conformsToProtocol:@protocol(HUBComponentFactoryShowcaseNameProvider)]) {
+    if (!HUBConformsToProtocol(factory, @protocol(HUBComponentFactoryShowcaseNameProvider))) {
         return nil;
     }
     

--- a/sources/HUBComponentResizeObservingView.h
+++ b/sources/HUBComponentResizeObservingView.h
@@ -26,7 +26,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Delegate protocol for `HUBComponentResizeObservingView`
-@protocol HUBComponentResizeObservingViewDelegate <NSObject>
+@protocol HUBComponentResizeObservingViewDelegate
 
 /**
  *  Notifies the delegate that a resize observing view was resized

--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -39,7 +39,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Delegate protocol for `HUBComponentWrapper`
-@protocol HUBComponentWrapperDelegate <NSObject>
+@protocol HUBComponentWrapperDelegate
 
 /**
  *  Notify the delegate that a component wrapper will update its selection state

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -81,11 +81,11 @@ NS_ASSUME_NONNULL_BEGIN
         _gestureRecognizer.delegate = self;
         [_gestureRecognizer addTarget:self action:@selector(handleGestureRecognizer:)];
         
-        if ([_component conformsToProtocol:@protocol(HUBComponentWithChildren)]) {
+        if (HUBConformsToProtocol(_component, @protocol(HUBComponentWithChildren))) {
             ((id<HUBComponentWithChildren>)_component).childDelegate = self;
         }
         
-        if ([_component conformsToProtocol:@protocol(HUBComponentActionPerformer)]) {
+        if (HUBConformsToProtocol(_component, @protocol(HUBComponentActionPerformer))) {
             ((id<HUBComponentActionPerformer>)_component).actionPerformer = self;
         }
     }
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)saveComponentUIState
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentWithRestorableUIState)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentWithRestorableUIState))) {
         return;
     }
     
@@ -146,17 +146,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)handlesImages
 {
-    return [self.component conformsToProtocol:@protocol(HUBComponentWithImageHandling)];
+    return HUBConformsToProtocol(self.component, @protocol(HUBComponentWithImageHandling));
 }
 
 - (BOOL)isContentOffsetObserver
 {
-    return [self.component conformsToProtocol:@protocol(HUBComponentContentOffsetObserver)];
+    return HUBConformsToProtocol(self.component, @protocol(HUBComponentContentOffsetObserver));
 }
 
 - (BOOL)isActionObserver
 {
-    return [self.component conformsToProtocol:@protocol(HUBComponentActionObserver)];
+    return HUBConformsToProtocol(self.component, @protocol(HUBComponentActionObserver));
 }
 
 - (BOOL)isRootComponent
@@ -187,7 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
     UIView * const view = HUBComponentLoadViewIfNeeded(self.component);
     
     if (!viewLoaded) {
-        if ([self.component conformsToProtocol:@protocol(HUBComponentViewObserver)]) {
+        if (HUBConformsToProtocol(self.component, @protocol(HUBComponentViewObserver))) {
             HUBComponentResizeObservingView * const resizeObservingView = [[HUBComponentResizeObservingView alloc] initWithFrame:view.bounds];
             resizeObservingView.delegate = self;
             [view addSubview:resizeObservingView];
@@ -242,7 +242,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CGSize)preferredSizeForImageFromData:(id<HUBComponentImageData>)imageData model:(id<HUBComponentModel>)model containerViewSize:(CGSize)containerViewSize
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentWithImageHandling)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentWithImageHandling))) {
         return CGSizeZero;
     }
     
@@ -253,7 +253,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateViewForLoadedImage:(UIImage *)image fromData:(id<HUBComponentImageData>)imageData model:(id<HUBComponentModel>)model animated:(BOOL)animated
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentWithImageHandling)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentWithImageHandling))) {
         return;
     }
     
@@ -269,7 +269,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     self.appearanceCount++;
     
-    if ([self.component conformsToProtocol:@protocol(HUBComponentViewObserver)]) {
+    if (HUBConformsToProtocol(self.component, @protocol(HUBComponentViewObserver))) {
         [(id<HUBComponentViewObserver>)self.component viewWillAppear];
     }
     
@@ -292,7 +292,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)viewDidResize
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentViewObserver)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentViewObserver))) {
         return;
     }
     
@@ -303,7 +303,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateViewForChangedContentOffset:(CGPoint)contentOffset
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentContentOffsetObserver)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentContentOffsetObserver))) {
         return;
     }
     
@@ -314,7 +314,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)actionPerformedWithContext:(id<HUBActionContext>)context
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentActionObserver)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentActionObserver))) {
         return;
     }
     
@@ -335,7 +335,7 @@ NS_ASSUME_NONNULL_BEGIN
                         animated:(BOOL)animated
                       completion:(void (^)(void))completion
 {
-    if ([self.component conformsToProtocol:@protocol(HUBComponentWithScrolling)]) {
+    if (HUBConformsToProtocol(self.component, @protocol(HUBComponentWithScrolling))) {
         [(id<HUBComponentWithScrolling>)self.component scrollToComponentAtIndex:childIndex
                                                                  scrollPosition:scrollPosition
                                                                        animated:animated
@@ -505,7 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)restoreComponentUIStateForModel:(id<HUBComponentModel>)model
 {
-    if (![self.component conformsToProtocol:@protocol(HUBComponentWithRestorableUIState)]) {
+    if (!HUBConformsToProtocol(self.component, @protocol(HUBComponentWithRestorableUIState))) {
         return;
     }
     
@@ -530,7 +530,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     self.selectionState = selectionState;
     
-    if ([self.component conformsToProtocol:@protocol(HUBComponentWithSelectionState)]) {
+    if (HUBConformsToProtocol(self.component, @protocol(HUBComponentWithSelectionState))) {
         [(id<HUBComponentWithSelectionState>)self.component updateViewForSelectionState:selectionState];
     } else if ([self.view isKindOfClass:[UITableViewCell class]]) {
         UITableViewCell * const tableViewCell = self.view;

--- a/sources/HUBContentOperationWrapper.h
+++ b/sources/HUBContentOperationWrapper.h
@@ -31,7 +31,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Delegate protocol for `HUBContentOperationWrapper`
-@protocol HUBContentOperationWrapperDelegate <NSObject>
+@protocol HUBContentOperationWrapperDelegate
 
 /**
  *  Notify the operation wrapper's delegate that the underlying operation finished

--- a/sources/HUBContentOperationWrapper.m
+++ b/sources/HUBContentOperationWrapper.m
@@ -21,6 +21,7 @@
 
 #import "HUBContentOperationWrapper.h"
 #import "HUBContentOperationWithPaginatedContent.h"
+#import "HUBUtilities.h"
 
 @interface HUBContentOperationWrapper () <HUBContentOperationDelegate>
 
@@ -58,7 +59,7 @@
     self.isExecuting = YES;
     
     if (pageIndex != nil) {
-        if ([self.contentOperation conformsToProtocol:@protocol(HUBContentOperationWithPaginatedContent)]) {
+        if (HUBConformsToProtocol(self.contentOperation, @protocol(HUBContentOperationWithPaginatedContent))) {
             id<HUBContentOperationWithPaginatedContent> const paginatedOperation = (id<HUBContentOperationWithPaginatedContent>)self.contentOperation;
             
             [paginatedOperation appendContentForPageIndex:pageIndex.unsignedIntegerValue

--- a/sources/HUBUtilities.h
+++ b/sources/HUBUtilities.h
@@ -20,6 +20,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <objc/runtime.h>
 
 #import "HUBComponent.h"
 #import "HUBErrors.h"
@@ -48,6 +49,23 @@ static inline BOOL HUBPropertyIsEqual(NSObject * _Nullable objectA, NSObject * _
     }
     
     return [valueA isEqual:valueB];
+}
+
+/**
+ *  Return whether an object conforms to a protocol
+ *
+ *  @param object The object
+ *  @param aProtocol The protocol
+ *
+ *  This function allows checking protocol conformance without inheriting from NSObject.
+ */
+static inline BOOL HUBConformsToProtocol(id _Nullable object, Protocol *aProtocol)
+{
+    if ([object respondsToSelector:@selector(conformsToProtocol:)]) {
+        return [object conformsToProtocol:aProtocol];
+    } else {
+        return class_conformsToProtocol([object class], aProtocol);
+    }
 }
 
 /**

--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)actionPerformedWithContext:(id<HUBActionContext>)context
 {
     for (id<HUBContentOperation> const operation in self.contentOperations) {
-        if (![operation conformsToProtocol:@protocol(HUBContentOperationActionObserver)]) {
+        if (!HUBConformsToProtocol(operation, @protocol(HUBContentOperationActionObserver))) {
             continue;
         }
         
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
     _actionPerformer = actionPerformer;
     
     for (id<HUBContentOperation> const operation in self.contentOperations) {
-        if (![operation conformsToProtocol:@protocol(HUBContentOperationActionPerformer)]) {
+        if (!HUBConformsToProtocol(operation, @protocol(HUBContentOperationActionPerformer))) {
             continue;
         }
         
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
     HUBViewModelBuilderImplementation * const builder = [self createBuilder];
     
     for (id<HUBContentOperation> const operation in self.contentOperations) {
-        if ([operation conformsToProtocol:@protocol(HUBContentOperationWithInitialContent)]) {
+        if (HUBConformsToProtocol(operation, @protocol(HUBContentOperationWithInitialContent))) {
             id<HUBContentOperationWithInitialContent> const initialContentOperation = (id<HUBContentOperationWithInitialContent>)operation;
             [initialContentOperation addInitialContentForViewURI:self.viewURI toViewModelBuilder:builder];
         }
@@ -391,7 +391,7 @@ NS_ASSUME_NONNULL_BEGIN
     newOperationWrapper.delegate = self;
     self.contentOperationWrappers[@(operationIndex)] = newOperationWrapper;
     
-    if ([operation conformsToProtocol:@protocol(HUBContentOperationWithPaginatedContent)]) {
+    if (HUBConformsToProtocol(operation, @protocol(HUBContentOperationWithPaginatedContent))) {
         self.anyContentOperationSupportsPagination = YES;
     }
     

--- a/tests/HUBUtilitiesTests.m
+++ b/tests/HUBUtilitiesTests.m
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "HUBUtilities.h"
+#import "HUBComponentMock.h"
+#import "HUBActionHandler.h"
+
+@interface HUBUtilitiesTests : XCTestCase
+
+@end
+
+@implementation HUBUtilitiesTests
+
+#pragma mark - Tests
+
+- (void)testHUBConformsToProtocol{
+    HUBComponentMock *componentMock = [[HUBComponentMock alloc] init];
+    // Check conformance
+    XCTAssertTrue(HUBConformsToProtocol(componentMock, @protocol(HUBComponentWithImageHandling)));
+    // Check non-conformance
+    XCTAssertFalse(HUBConformsToProtocol(componentMock, @protocol(HUBActionHandler)));
+    // Check override
+    componentMock.canHandleImages = NO;
+    XCTAssertFalse(HUBConformsToProtocol(componentMock, @protocol(HUBComponentWithImageHandling)));
+}
+
+@end


### PR DESCRIPTION
I was intrigued by the discussion on https://github.com/spotify/HubFramework/issues/70.

This PR solves the main issue with removing NSObject inheritance (by providing an NSObject-agnostic HUBConformsToProtocol function in HUBUtilities). The only protocol that keeps NSObject is HUBSerializable because it needs isEqual. 

Quick note: The reason HUBConformsToProtocol first tries to use the object's confromsToProtocol implementation (if it exists) is to make sure we don't break mock classes that override it. 

Missing:
- Linting. 