### PR TITLE
Don’t use XCTAssertEqual for NSIndexPath equivalence.

### DIFF
--- a/tests/HUBComponentModelTests.m
+++ b/tests/HUBComponentModelTests.m
@@ -170,16 +170,16 @@
     parent.children = @[childA, childB];
     childB.children = @[grandchild];
 
-    XCTAssertEqual(parent.indexPath, [NSIndexPath indexPathWithIndex:0]);
+    XCTAssertEqualObjects(parent.indexPath, [NSIndexPath indexPathWithIndex:0]);
 
     NSUInteger childAIndexPathArray[] = {0,0};
-    XCTAssertEqual(childA.indexPath, [NSIndexPath indexPathWithIndexes:childAIndexPathArray length:2]);
+    XCTAssertEqualObjects(childA.indexPath, [NSIndexPath indexPathWithIndexes:childAIndexPathArray length:2]);
 
     NSUInteger childBIndexPathArray[] = {0,1};
-    XCTAssertEqual(childB.indexPath, [NSIndexPath indexPathWithIndexes:childBIndexPathArray length:2]);
+    XCTAssertEqualObjects(childB.indexPath, [NSIndexPath indexPathWithIndexes:childBIndexPathArray length:2]);
 
     NSUInteger grandchildIndexPathArray[] = {0,1,0};
-    XCTAssertEqual(grandchild.indexPath, [NSIndexPath indexPathWithIndexes:grandchildIndexPathArray length:3]);
+    XCTAssertEqualObjects(grandchild.indexPath, [NSIndexPath indexPathWithIndexes:grandchildIndexPathArray length:3]);
 }
 
 - (void)testPropertiesThatDoNotAffectEquality


### PR DESCRIPTION
While we decide the best way to assert for object equivalence over at https://github.com/spotify/HubFramework/pull/259, we should fix the cases that are causing tests to fail on 32-bit systems (i.e. the `NSIndexPath` case).

For info, using instance equality (i.e. `==` ) on 2 "equivalent" instances will work on 64 bit architectures (with tagged pointers) but not on 32 bit architectures.