### PR TITLE
Fix testCollectionViewContentInsetEqualToHeaderHeight

### DIFF
--- a/demo/tests/HeaderComponentUITests.swift
+++ b/demo/tests/HeaderComponentUITests.swift
@@ -38,8 +38,9 @@ class HeaderComponentUITests: UITestCase {
         navigateToStickyHeaderFeature()
         
         let collectionView = XCUIApplication().collectionViews.element(boundBy: 0)
+        let header = XCUIApplication().otherElements["header"]
         let firstCell = collectionView.cells.element(boundBy: 0)
-        XCTAssertEqual(firstCell.frame.minY, 250)
+        XCTAssertEqual(firstCell.frame.minY, header.frame.height)
     }
     
     func testCollapsedHeaderNotUpdatingContentOffsetWhenViewIsUpdated() {


### PR DESCRIPTION
This was initially inside my tvOS PR but it will take some time for that one to be fixed and merged.

I cherrypicked it into this separate PR so we can act quicker. 

Fixes https://github.com/spotify/HubFramework/issues/264