### PR TITLE
Add test for content operation and render overlap

### DIFF
--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -3101,6 +3101,58 @@
     viewModelRenderer.completionBlocks[1]();
 }
 
+- (void)testThatModelIsNotSetImmediatelyOnOverlappingRenderAndLayoutRequests
+{
+    HUBViewModelRendererMock *viewModelRenderer = [HUBViewModelRendererMock new];
+    [self createViewControllerWithViewModelRenderer:viewModelRenderer];
+
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder headerComponentModelBuilder].title = @"title1";
+        return YES;
+    };
+
+    [self simulateViewControllerLayoutCycle];
+
+    // The model should be set at this point as there's no existing render in progress
+    XCTAssertEqualObjects(self.viewController.viewModel.headerComponentModel.title, @"title1");
+
+    self.contentOperation.contentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder headerComponentModelBuilder].title = @"title2";
+        return YES;
+    };
+
+    // While the 1st render is in progress, a 2nd render request comes in
+    [self.viewController reload];
+
+    // The 2nd model should NOT be set at this point as the 1st render hasn't finished
+    XCTAssertEqualObjects(self.viewController.viewModel.headerComponentModel.title, @"title1");
+    // Only 1 render request has been made at this point (the 2nd is pending)
+    XCTAssertEqual(viewModelRenderer.completionBlocks.count, 1u);
+    // Complete the 1st render request
+    viewModelRenderer.completionBlocks[0]();
+
+    // The 2nd model should now be set as the 1st render has finished and the 2nd is in progress
+    XCTAssertEqualObjects(self.viewController.viewModel.headerComponentModel.title, @"title2");
+    // 2 render requests have now been made
+    XCTAssertEqual(viewModelRenderer.completionBlocks.count, 2u);
+
+    // While the 2nd render is in progress, a layout requests comes in.
+    CGRect rect = self.viewController.view.bounds;
+    CGRect offsetRect = CGRectOffset(rect, 1, 1);
+    self.viewController.view.bounds = offsetRect;
+    [self.viewController.view layoutIfNeeded];
+
+    // Only 2 render requests have been made at this point (the 3rd is pending)
+    XCTAssertEqual(viewModelRenderer.completionBlocks.count, 2u);
+    // Complete the 2nd render request
+    viewModelRenderer.completionBlocks[1]();
+
+    // 3 render requests have now been made
+    XCTAssertEqual(viewModelRenderer.completionBlocks.count, 3u);
+    // Complete the 3rd render request
+    viewModelRenderer.completionBlocks[2]();
+}
+
 #pragma mark - HUBViewControllerDelegate
 
 - (void)viewController:(HUBViewController *)viewController willUpdateWithViewModel:(id<HUBViewModel>)viewModel


### PR DESCRIPTION
Replaces https://github.com/spotify/HubFramework/pull/256

@JohnSundell asked me to squash the changes and I kinda screwed up my branch, so I've applied this again to another PR.

There are no changes since the last review.