### PR TITLE
Apply the layout changes immediately in the VC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
     - master
     - /^release-.*$/
+    - /^spotify-release-.*$/
 
 language: objective-c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ branches:
   only:
     - master
     - /^release-.*$/
-    - /^spotify-release-.*$/
 
 language: objective-c
 

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -463,6 +463,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.viewModel = viewModel;
         self.viewModelHasChangedSinceLastLayoutUpdate = YES;
         [self.view setNeedsLayout];
+        [self.view layoutIfNeeded];
     }];
     
     HUBOperation * const reloadCollectionViewOperation = [self createReloadCollectionViewOperation];


### PR DESCRIPTION
In the iOS client, we have a tab bar controller which has a navigation controller as its root VC. There is a Hub VC as the root VC of this navigation controller and this is currently the active VC. We're seeing a crash when tapping the tab bar item for a VC that's already the active tab. The scenario is outlined below:

- A content operation runs, and generates a view model with (e.g.) 20 body component models. The Hub VC renders these and the internal UICollectionView creates cells for index paths 0-0, 0-1 and 0-2 (for example). 
- We navigate from this VC to a new VC (B) and wait for that to render.
- We then tap the active tab bar to invoke the standard OS behaviour to pop to the root VC in the navigation controller.
- As VC B is being popped, a content operation runs again inside VC A and this time, 0 body component models are returned (we're clearing out the VC 1st).
- The new view model is assigned to the VC with 0 body component models.
- A layout operation runs on the VC, and this eventually results in a layout being run on the UICollectionView.
- As part of this layout operation, the UICollectionView decides that it needs to re-render some cells, but for some reason, it doesn't query its UICollectionViewDelegate's collectionView:numberOfItemsInSection: method, so doesn't know that the underlying view model has changed.
- The UICollectionView tries to create a new cell for an index path that doesn't exist - frequently (but not always) the cell after the last one rendered, so 0-3 in this scenario.
- Crash.

The latest theory is that the layout operation is running on the `UIViewController` at this point as we've previously called `setNeedsLayout` on a view that contains it. Whether we're making the right assumptions about this is unclear. I'll see if I can create in a separate, standalone app in the meantime, and get some input from the Apple forums.

For now, I've noticed the following comment in the `HUBViewModelRenderer` which pretty much sums up the problems we're seeing. I've also noticed that this is the only instance in the framework of us calling `setNeedsLayout` without immediately calling `layoutIfNeeded` straight after.

So, that's the basis of the fix for now. It's been proven to fix the crash we're seeing, but may not be the exact fix we're looking for. I'll update the framework with any suggestions that Apple give us.