### PR TITLE
Use the same logic as the renderer to prevent a crash

### DIFF
--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -220,6 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
     [notificationCenter removeObserver:self name:UIKeyboardWillHideNotification object:nil];
     
     self.viewHasBeenLaidOut = NO;
+    self.viewHasAppeared = NO;
 }
 
 - (void)viewDidLayoutSubviews
@@ -463,7 +464,6 @@ NS_ASSUME_NONNULL_BEGIN
         self.viewModel = viewModel;
         self.viewModelHasChangedSinceLastLayoutUpdate = YES;
         [self.view setNeedsLayout];
-        [self.view layoutIfNeeded];
     }];
     
     HUBOperation * const reloadCollectionViewOperation = [self createReloadCollectionViewOperation];

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -463,6 +463,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.viewModel = viewModel;
         self.viewModelHasChangedSinceLastLayoutUpdate = YES;
         [self.view setNeedsLayout];
+        [self.view layoutIfNeeded];
     }];
     
     HUBOperation * const reloadCollectionViewOperation = [self createReloadCollectionViewOperation];


### PR DESCRIPTION
In the iOS client, we have a tab bar controller which has a navigation controller as its root VC. There is a Hub VC as the root VC of this navigation controller and this is currently the active VC. We're seeing a crash when tapping the tab bar item for a VC that's already the active tab. The scenario is outlined below:

- A content operation runs, and generates a view model with (e.g.) 20 body component models. The Hub VC renders these and the internal UICollectionView creates cells for index paths 0-0, 0-1 and 0-2 (for example). 
- We navigate from this VC to a new VC (B) and wait for that to render.
- We then tap the active tab bar to invoke the standard OS behaviour to pop to the root VC in the navigation controller.
- As VC B is being popped, a content operation runs again inside VC A and this time, 0 body component models are returned (we're clearing out the VC 1st).
- The new view model is assigned to the VC with 0 body component models.
- A layout operation runs on the VC, and this eventually results in a layout being run on the UICollectionView.
- As part of this layout operation, the UICollectionView decides that it needs to re-render some cells, but for some reason, it doesn't query its UICollectionViewDelegate's collectionView:numberOfItemsInSection: method, so doesn't know that the underlying view model has changed.
- The UICollectionView tries to create a new cell for an index path that doesn't exist - frequently (but not always) the cell after the last one rendered, so 0-3 in this scenario.
- Crash.

The latest theory is that the layout operation is running on the `UIViewController` at this point as we've previously called `setNeedsLayout` on a view that contains it. Whether we're making the right assumptions about this is unclear. I'll see if I can create in a separate, standalone app in the meantime, and get some input from the Apple forums.

For now, I've noticed the following comment in the `HUBViewModelRenderer` which pretty much sums up the problems we're seeing. I've also noticed that this is the only instance in the framework of us calling `setNeedsLayout` without immediately calling `layoutIfNeeded` straight after:

```
        /* Below is a workaround for an issue caused by UICollectionView not asking for numberOfItemsInSection
           before viewDidAppear is called or instantly after a call to reloadData. If reloadData is called
           after viewDidAppear has been called, followed by a call to performBatchUpdates, UICollectionView will
           ask for the initial number of items right before the batch updates, and for the new count while inside
           the update block. This will often trigger an assertion if there are any insertions / deletions, as
           the data model has already changed before the update. Forcing a layoutSubviews however, manually
           triggers the numberOfItems call.
         */
        if (usingBatchUpdates && diff == nil) {
            [collectionView setNeedsLayout];
            [collectionView layoutIfNeeded];
        }
```

So, that's the basis of the fix for now. It's been proven to fix the crash we're seeing, but may not be the exact fix we're looking for. I'll update the framework with any suggestions that Apple give us.