### PR TITLE
Fix some auto-layout breakages

### DIFF
--- a/sources/HUBComponentCollectionViewCell.m
+++ b/sources/HUBComponentCollectionViewCell.m
@@ -60,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     UIView * const componentView = HUBComponentLoadViewIfNeeded(nonNilComponent);
     componentView.autoresizingMask |= UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    componentView.frame = self.bounds;
 
     [self.contentView addSubview:componentView];
 }


### PR DESCRIPTION
In some case we’d still lay the cell’s view out with a `.zero` size. The problem occurred before the cell had a chance to resize the hosted view. This PR fixes the problem by making sure the view gets an initial size, so that no resize is required.

@spotify/objc-dev 