### PR TITLE
Don’t reload the collection view if there is nothing in the diff.

### DIFF
--- a/sources/HUBViewModelDiff.h
+++ b/sources/HUBViewModelDiff.h
@@ -70,6 +70,9 @@ extern HUBViewModelDiff *HUBDiffMyersAlgorithm(id<HUBViewModel>, id<HUBViewModel
 /// The index paths of any body components that were modified in the new view model. 
 @property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *reloadedBodyComponentIndexPaths;
 
+/// A convenience property that returns YES if there are any inserts, deletes or reloads in this diff.
+@property (nonatomic, readonly) BOOL hasChanges;
+
 /**
  * Initializes a @c HUBViewModelDiff using the two view models by finding the longest common subsequence
  * between the two models' body components.

--- a/sources/HUBViewModelDiff.m
+++ b/sources/HUBViewModelDiff.m
@@ -66,6 +66,13 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
     return [self diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
 }
 
+- (BOOL)hasChanges
+{
+    return self.insertedBodyComponentIndexPaths.count > 0
+        || self.deletedBodyComponentIndexPaths.count > 0
+        || self.reloadedBodyComponentIndexPaths.count > 0;
+}
+
 - (NSString *)debugDescription
 {
     return [NSString stringWithFormat:@"\t{\n\

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -69,6 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
         diff = [HUBViewModelDiff diffFromViewModel:nonnullViewModel toViewModel:viewModel];
     }
 
+    BOOL const hasDiffChanges = (diff == nil || diff.hasChanges);
     HUBCollectionViewLayout * const layout = (HUBCollectionViewLayout *)collectionView.collectionViewLayout;
 
     /*
@@ -91,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
     };
 
     if (!usingBatchUpdates || diff == nil) {
-        if (diff == nil || diff.hasChanges) {
+        if (hasDiffChanges) {
             [collectionView reloadData];
         }
 
@@ -111,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         postLayoutBlock();
     } else {
-        if (diff == nil || diff.hasChanges) {
+        if (hasDiffChanges) {
             [collectionView performBatchUpdates:^{
                 [collectionView insertItemsAtIndexPaths:diff.insertedBodyComponentIndexPaths];
                 [collectionView deleteItemsAtIndexPaths:diff.deletedBodyComponentIndexPaths];

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -40,6 +40,29 @@ NS_ASSUME_NONNULL_BEGIN
         addHeaderMargin:(BOOL)addHeaderMargin
              completion:(void (^)(void))completionBlock
 {
+    __weak __typeof(self) weakSelf = self;
+    void (^renderBlock)() = ^{
+        __strong __typeof(self) strongSelf = weakSelf;
+        [strongSelf renderViewModel:viewModel
+                   inCollectionView:collectionView
+                  usingBatchUpdates:usingBatchUpdates
+                    addHeaderMargin:addHeaderMargin
+                         completion:completionBlock];
+    };
+
+    if (animated) {
+        renderBlock();
+    } else {
+        [UIView performWithoutAnimation:renderBlock];
+    }
+}
+
+- (void)renderViewModel:(id<HUBViewModel>)viewModel
+       inCollectionView:(UICollectionView *)collectionView
+      usingBatchUpdates:(BOOL)usingBatchUpdates
+        addHeaderMargin:(BOOL)addHeaderMargin
+             completion:(void (^)(void))completionBlock
+{
     HUBViewModelDiff *diff;
     if (self.lastRenderedViewModel != nil) {
         id<HUBViewModel> nonnullViewModel = self.lastRenderedViewModel;
@@ -48,50 +71,59 @@ NS_ASSUME_NONNULL_BEGIN
 
     HUBCollectionViewLayout * const layout = (HUBCollectionViewLayout *)collectionView.collectionViewLayout;
 
-    if (!usingBatchUpdates || diff == nil) {
-        [collectionView reloadData];
-        
+    /*
+     Because of the different ways we can trigger the layout and post-layout logic (i.e. whether it's being called
+     synchronously, or called from either of of the collection view's performBatchUpdates:completion: blocks), I've
+     tried to separate that logic out into 2 block methods: layoutBlock and postLayoutBlock.
+     */
+    void (^layoutBlock)() = ^{
         [layout computeForCollectionViewSize:collectionView.frame.size
                                    viewModel:viewModel
                                         diff:diff
                              addHeaderMargin:addHeaderMargin];
+    };
+
+    __weak __typeof(self) weakSelf = self;
+    void (^postLayoutBlock)() = ^{
+        __strong __typeof(self) strongSelf = weakSelf;
+        strongSelf.lastRenderedViewModel = viewModel;
+        completionBlock();
+    };
+
+    if (!usingBatchUpdates || diff == nil) {
+        if (diff == nil || diff.hasChanges) {
+            [collectionView reloadData];
+        }
+
+        layoutBlock();
 
         /* Below is a workaround for an issue caused by UICollectionView not asking for numberOfItemsInSection
-           before viewDidAppear is called or instantly after a call to reloadData. If reloadData is called
-           after viewDidAppear has been called, followed by a call to performBatchUpdates, UICollectionView will
-           ask for the initial number of items right before the batch updates, and for the new count while inside
-           the update block. This will often trigger an assertion if there are any insertions / deletions, as
-           the data model has already changed before the update. Forcing a layoutSubviews however, manually
-           triggers the numberOfItems call.
+         before viewDidAppear is called or instantly after a call to reloadData. If reloadData is called
+         after viewDidAppear has been called, followed by a call to performBatchUpdates, UICollectionView will
+         ask for the initial number of items right before the batch updates, and for the new count while inside
+         the update block. This will often trigger an assertion if there are any insertions / deletions, as
+         the data model has already changed before the update. Forcing a layoutSubviews however, manually
+         triggers the numberOfItems call.
          */
         if (usingBatchUpdates && diff == nil) {
             [collectionView setNeedsLayout];
             [collectionView layoutIfNeeded];
         }
-        self.lastRenderedViewModel = viewModel;
-        completionBlock();
+        postLayoutBlock();
     } else {
-        void (^updateBlock)() = ^{
+        if (diff == nil || diff.hasChanges) {
             [collectionView performBatchUpdates:^{
                 [collectionView insertItemsAtIndexPaths:diff.insertedBodyComponentIndexPaths];
                 [collectionView deleteItemsAtIndexPaths:diff.deletedBodyComponentIndexPaths];
                 [collectionView reloadItemsAtIndexPaths:diff.reloadedBodyComponentIndexPaths];
-                
-                [layout computeForCollectionViewSize:collectionView.frame.size
-                                           viewModel:viewModel
-                                                diff:diff
-                                     addHeaderMargin:addHeaderMargin];
-                
+
+                layoutBlock();
             } completion:^(BOOL finished) {
-                self.lastRenderedViewModel = viewModel;
-                completionBlock();
+                postLayoutBlock();
             }];
-        };
-        
-        if (animated) {
-            updateBlock();
         } else {
-            [UIView performWithoutAnimation:updateBlock];
+            layoutBlock();
+            postLayoutBlock();
         }
     }
 }

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -34,6 +34,33 @@
 
 @implementation HUBViewModelDiffTests
 
+- (void)testIdenticalModelMyers
+{
+    [self runIdenticalModelTestWithAlgorithm:HUBDiffMyersAlgorithm];
+}
+
+- (void)testIdenticalModelLCS
+{
+    [self runIdenticalModelTestWithAlgorithm:HUBDiffLCSAlgorithm];
+}
+
+- (void)runIdenticalModelTestWithAlgorithm:(HUBDiffAlgorithm)algorithm
+{
+    NSArray<id<HUBComponentModel>> *components = @[
+                                                   [HUBViewModelUtilities createComponentModelWithIdentifier:@"component-1" customData:nil],
+                                                   [HUBViewModelUtilities createComponentModelWithIdentifier:@"component-2" customData:nil],
+                                                   [HUBViewModelUtilities createComponentModelWithIdentifier:@"component-3" customData:nil],
+                                                   [HUBViewModelUtilities createComponentModelWithIdentifier:@"component-4" customData:nil]
+                                                   ];
+    id<HUBViewModel> viewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" components:components];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:viewModel toViewModel:viewModel algorithm:algorithm];
+    XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
+    XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
+    XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssertFalse(diff.hasChanges);
+}
+
 - (void)testInsertionsMyers
 {
     [self runInsertionsTestWithAlgorithm:HUBDiffMyersAlgorithm];
@@ -65,6 +92,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 4);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testReloadsMyers
@@ -103,6 +131,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testDeletionsMyers
@@ -138,6 +167,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testComplexChangeSetMyers
@@ -191,6 +221,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testInsertionOfSingleComponentModelAtStartWithDataChangesMyers
@@ -225,6 +256,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 1);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssertTrue(diff.hasChanges);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
@@ -264,6 +296,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
+    XCTAssertTrue(diff.hasChanges);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);


### PR DESCRIPTION
When we calculate a diff and there are no changes, we don't need to spend time reloading the collection view, either with `reloadData` or `performBatchUpdates:completion:`. These methods are already called too often and have been linked to crashes under certain conditions where we update content operations frequently. After I applied this patch, I didn't see any crashes under those same conditions.

The `HUBViewModelRenderer` patch is quite hard to follow, so here's a summary of what I did:

- Created a new `renderViewModel:inCollectionView:usingBatchUpdates:addHeaderMargin:completion:` method (i.e. the same as the existing method but without the `animated:` parameter.
- In the original method (with `animated:`, we now call the new method in a block, either directly (if we are animating), or through `[UIView performWithoutAnimation:renderBlock]` if we're not. This handles all animation specifics, allowing the new method to not care about that part.
- Moved all remaining logic to the new method.
- There are 4 common operations that happen in this class:
  - reloading the collection view
  - updating the layout
  - updating the view model
  - firing the completion
- Due to the nature of the calls to the collection view, the last 3 operations are called at different times, but we can break them down as
  - layout tasks (updating the layout)
  - post-layout tasks (updating the view model and firing the completion)
- The PR defines those 2 tasks as blocks and calls them from all of the same places where they used to be called from.
- The PR also now checks if the diff actually has any changes, and if it doesn't, it doesn't update the collection view - it just triggers the 2 blocks.