### PR TITLE
Don’t register multiple times

### DIFF
--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -714,6 +714,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     
     if (![self.registeredCollectionViewCellReuseIdentifiers containsObject:cellReuseIdentifier]) {
         [collectionView registerClass:[HUBComponentCollectionViewCell class] forCellWithReuseIdentifier:cellReuseIdentifier];
+        [self.registeredCollectionViewCellReuseIdentifiers addObject:cellReuseIdentifier];
     }
     
     HUBComponentCollectionViewCell * const cell = [collectionView dequeueReusableCellWithReuseIdentifier:cellReuseIdentifier


### PR DESCRIPTION
`self.registeredCollectionViewCellReuseIdentifiers` was being set up and checked for an existing cell reuse identifier, but we never added the identifier to the collection to stop us registering multiple times.