### PR TITLE
Support components having different layouts on rotation.

### DIFF
--- a/sources/HUBComponentWrapper.h
+++ b/sources/HUBComponentWrapper.h
@@ -214,6 +214,13 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState;
  */
 - (nullable HUBComponentWrapper *)visibleChildComponentAtIndex:(NSUInteger)index;
 
+/**
+ *  Reconfigures the component's view to use the new container view size.
+ *
+ *  @param containerViewSize the new container view size.
+ */
+- (void)reconfigureViewWithContainerViewSize:(CGSize)containerViewSize;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -223,6 +223,11 @@ NS_ASSUME_NONNULL_BEGIN
     self.hasBeenConfigured = YES;
 }
 
+- (void)reconfigureViewWithContainerViewSize:(CGSize)containerViewSize
+{
+    [self.component configureViewWithModel:self.model containerViewSize:containerViewSize];
+}
+
 - (void)prepareViewForReuse
 {
     NSNumber * const index = @(self.model.index);

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -243,7 +243,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    [self.collectionView.collectionViewLayout invalidateLayout];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self reconfigureVisibleCellsForSize:size];
+        [self.collectionView.collectionViewLayout invalidateLayout];
+    } completion:nil];
 }
 
 - (void)didReceiveMemoryWarning
@@ -735,6 +739,14 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                              childIndex:nil];
 
     return cell;
+}
+
+- (void)reconfigureVisibleCellsForSize:(CGSize)size
+{
+    for (HUBComponentCollectionViewCell *visibleCell in [self.collectionView visibleCells]) {
+        HUBComponentWrapper * const componentWrapper = self.componentWrappersByCellIdentifier[visibleCell.identifier];
+        [componentWrapper reconfigureViewWithContainerViewSize:size];
+    }
 }
 
 #pragma mark - HUBCollectionViewDelegate


### PR DESCRIPTION
When the `HUBViewController` creates a cell, it creates the correct component for that cell and calls `configureViewWithModel:containerViewSize:` on that component, which can use this information to create a component-specific layout that takes the parent size into consideration.

However, when the VC is rotated / the VC is resized in other ways, there's no opportunity to recalculate that layout with the new parent size information.

This PR addresses this by forwarding this information to all component wrappers currently being displayed by the view controller's collection view.