### PR TITLE
Don’t discard important objects in low memory conditions

### DIFF
--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -250,29 +250,6 @@ NS_ASSUME_NONNULL_BEGIN
     } completion:nil];
 }
 
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-
-    if (!self.isViewLoaded) {
-        return;
-    }
-
-    if (self.view.window != nil) {
-        return;
-    }
-
-    if (self.collectionView != nil) {
-        UICollectionView * const collectionView = self.collectionView;
-        [collectionView removeFromSuperview];
-        [self.view removeGestureRecognizer:collectionView.panGestureRecognizer];
-        
-        self.collectionView = nil;
-    }
-    
-    self.viewModel = nil;
-}
-
 #pragma mark - HUBViewController
 
 - (NSString *)featureIdentifier


### PR DESCRIPTION
Setting the view model and collection view to `nil` under low memory conditions doesn't seem like a very safe thing to do. We're seeing crashes because:
-  collection views are reporting that they don't have a reuse identifier registered 
- collection views are reporting discrepancies between models and cells currently visible

Both could be caused by a collection view / view model being set to `nil` and recreated at some point in the middle of an important operation.

Let's try removing the `didReceiveMemoryWarning` implementation and see if we see a reduction in crash reports.