### PR TITLE
Fix component wrapper reuse, enables UISegmentedControl touch and call super on prepareForReuse

### DIFF
--- a/sources/HUBComponentCollectionViewCell.m
+++ b/sources/HUBComponentCollectionViewCell.m
@@ -69,6 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)prepareForReuse
 {
+    [super prepareForReuse];
+
     [self.component prepareViewForReuse];
     self.component = nil;
 }

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -432,6 +432,11 @@ NS_ASSUME_NONNULL_BEGIN
     UIView *currentView = touch.view;
     
     while (currentView != nil && currentView != self.view) {
+
+        if ([currentView isKindOfClass:[UISegmentedControl class]]) {
+            return NO;
+        }
+
         if ([currentView isKindOfClass:[UIButton class]]) {
             return NO;
         }

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -724,10 +724,13 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     HUBComponentCollectionViewCell * const cell = [collectionView dequeueReusableCellWithReuseIdentifier:cellReuseIdentifier
                                                                                             forIndexPath:indexPath];
 
-    HUBComponentWrapper * const componentWrapper = [self.componentReusePool componentWrapperForModel:componentModel
-                                                                                            delegate:self
-                                                                                              parent:nil];
+    HUBComponentWrapper * componentWrapper = self.componentWrappersByModelIdentifier[componentModel.identifier];
 
+    if (componentWrapper == nil) {
+        componentWrapper = [self.componentReusePool componentWrapperForModel:componentModel
+                                                                    delegate:self
+                                                                      parent:nil];
+    }
     self.componentWrappersByCellIdentifier[cell.identifier] = componentWrapper;
     cell.component = componentWrapper;
     [componentWrapper viewDidMoveToSuperview:cell];


### PR DESCRIPTION
This PR adds:

. adds the ability to have a UISegmentedControl in a hub component (touch event should propagate)
. adds call to super on prepareForReuse of hub cells

It also fixes an issue that happens when the `viewModel` is updated by a `contentOperation` and the reloading cell does not add the latest rendered wrapper/model to the `componentReusePool`. When `cellForIndexAtPath` is called it ends up creating a new wrapper instead of reusing the last one and comparing with the new one received.

To reproduce the issue, simply create a content operation that gets called after the view is rendered. The content operation should toggle a `metadata` property. On every `metadata` change, `configureView` of the hub component should be called.
