### PR TITLE
Fix not messaging super in -prepareForReuse

### DIFF
--- a/sources/HUBComponentCollectionViewCell.m
+++ b/sources/HUBComponentCollectionViewCell.m
@@ -69,6 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)prepareForReuse
 {
+    [super prepareForReuse];
+
     [self.component prepareViewForReuse];
     self.component = nil;
 }


### PR DESCRIPTION
**tl;dr** Subclasses of `UICollectionReusableView`, and especially subclasses of e.g. `UICollectionViewCell`, should message super in `-prepareForReuse`.

---

The implementation of `-prepareForReuse` is documented in as part of `UICollectionReusableView` and it states that the method doesn’t do anything. So it should be safe to not message super, right Not really. The API docs does recommend that subclasses messages super anyhow.

> The default implementation of this method does nothing. However, when overriding this method, it is recommended that you call super anyway.

Further the documentation notes that subclasses, such as, `UICollectionViewCell` overrides the method to perform relevant actions. Since `HUBComponentCollectionViewCell` subclasses `UICollectionViewCell` it _must_ message super.

> Subclasses such as `UICollectionViewCell` override this method and use it to perform relevant actions. So if your subclass descends from `UICollectionViewCell` or some other intermediate class, calling `super` ensures that your class gets the parent’s behavior.

---

@spotify/objc-dev 