### PR TITLE
Tie cell class register to collection view.

### DIFF
--- a/sources/HUBCollectionView.h
+++ b/sources/HUBCollectionView.h
@@ -46,6 +46,20 @@ NS_ASSUME_NONNULL_BEGIN
 /// The collection view's delegate. See `HUBCollectionViewDelegate` for more information.
 @property (nonatomic, weak, nullable) id <HUBCollectionViewDelegate> delegate;
 
+/**
+ * Returns a reusable cell object located by the identifier. This method will register the cellClass
+ * if it is not already registered with the collection view.
+ *
+ * @param identifier The reuse identifier for the specified cell. This parameter must not be nil.
+ * @param indexPath The index path specifying the location of the cell. The data source receives this information when it is asked for the cell and should just pass it along. This method uses the index path to perform additional configuration based on the cell’s position in the collection view.
+ * @param cellClass The class of a cell that you want to use in the collection view.
+ *
+ * @return A valid UICollectionReusableView object.
+ */
+- (__kindof UICollectionViewCell *)dequeueReusableCellWithReuseIdentifier:(NSString *)identifier
+                                                             forIndexPath:(NSIndexPath *)indexPath
+                                                cellClassWhenUnregistered:(Class)cellClass;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBCollectionView.m
+++ b/sources/HUBCollectionView.m
@@ -23,8 +23,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation HUBCollectionView
+@interface HUBCollectionView ()
+@property (nonatomic, strong, readonly) NSMutableSet<NSString *> *registeredCollectionViewCellReuseIdentifiers;
+@end
 
+@implementation HUBCollectionView
+@synthesize registeredCollectionViewCellReuseIdentifiers = _registeredCollectionViewCellReuseIdentifiers;
 @dynamic delegate;
 
 - (void)setContentOffset:(CGPoint)contentOffset
@@ -40,6 +44,27 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     [super setContentOffset:contentOffset];
+}
+
+- (NSMutableSet<NSString *> *)registeredCollectionViewCellReuseIdentifiers
+{
+    if (!_registeredCollectionViewCellReuseIdentifiers) {
+        _registeredCollectionViewCellReuseIdentifiers = [NSMutableSet new];
+    }
+
+    return _registeredCollectionViewCellReuseIdentifiers;
+}
+
+- (__kindof UICollectionViewCell *)dequeueReusableCellWithReuseIdentifier:(NSString *)identifier
+                                                             forIndexPath:(NSIndexPath *)indexPath
+                                                cellClassWhenUnregistered:(Class)cellClass
+{
+    if (![self.registeredCollectionViewCellReuseIdentifiers containsObject:identifier]) {
+        [self registerClass:cellClass forCellWithReuseIdentifier:identifier];
+    }
+
+    return [self dequeueReusableCellWithReuseIdentifier:identifier
+                                           forIndexPath:indexPath];
 }
 
 @end

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -73,10 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) id<HUBViewControllerScrollHandler> scrollHandler;
 @property (nonatomic, strong, nullable, readonly) id<HUBContentReloadPolicy> contentReloadPolicy;
 @property (nonatomic, strong, nullable, readonly) id<HUBImageLoader> imageLoader;
-@property (nonatomic, strong, nullable) UICollectionView *collectionView;
+@property (nonatomic, strong, nullable) HUBCollectionView *collectionView;
 @property (nonatomic, strong, readonly) HUBViewModelRenderer *viewModelRenderer;
 @property (nonatomic, assign) BOOL collectionViewIsScrolling;
-@property (nonatomic, strong, readonly) NSMutableSet<NSString *> *registeredCollectionViewCellReuseIdentifiers;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSURL *, NSMutableArray<HUBComponentImageLoadingContext *> *> *componentImageLoadingContexts;
 @property (nonatomic, strong, readonly) NSHashTable<id<HUBComponentContentOffsetObserver>> *contentOffsetObservingComponentWrappers;
 @property (nonatomic, strong, readonly) NSHashTable<id<HUBComponentActionObserver>> *actionObservingComponentWrappers;
@@ -140,7 +139,6 @@ NS_ASSUME_NONNULL_BEGIN
     _actionHandler = actionHandler;
     _scrollHandler = scrollHandler;
     _imageLoader = imageLoader;
-    _registeredCollectionViewCellReuseIdentifiers = [NSMutableSet new];
     _componentImageLoadingContexts = [NSMutableDictionary new];
     _contentOffsetObservingComponentWrappers = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
     _actionObservingComponentWrappers = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
@@ -693,13 +691,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     id<HUBComponentModel> const componentModel = self.viewModel.bodyComponentModels[(NSUInteger)indexPath.item];
     NSString * const cellReuseIdentifier = componentModel.componentIdentifier.identifierString;
     
-    if (![self.registeredCollectionViewCellReuseIdentifiers containsObject:cellReuseIdentifier]) {
-        [collectionView registerClass:[HUBComponentCollectionViewCell class] forCellWithReuseIdentifier:cellReuseIdentifier];
-        [self.registeredCollectionViewCellReuseIdentifiers addObject:cellReuseIdentifier];
-    }
-    
-    HUBComponentCollectionViewCell * const cell = [collectionView dequeueReusableCellWithReuseIdentifier:cellReuseIdentifier
-                                                                                            forIndexPath:indexPath];
+    HUBComponentCollectionViewCell * const cell = [self.collectionView dequeueReusableCellWithReuseIdentifier:cellReuseIdentifier
+                                                                                                 forIndexPath:indexPath
+                                                                                    cellClassWhenUnregistered:[HUBComponentCollectionViewCell class]];
 
     HUBComponentWrapper * const componentWrapper = [self.componentReusePool componentWrapperForModel:componentModel
                                                                                             delegate:self


### PR DESCRIPTION
As noticed in #280 the registry that keeps track of registered reuse identifiers need to be better tied to the collection view. This makes it a property of `HUBCollectionView` which means that whenever we recreate the collection view in `HUBViewController` the registry will be recreated as well.

@spotify/objc-dev @cerihughes 