### PR TITLE
Fix building the static library with Xcode 8.3 beta 3

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -2176,15 +2176,13 @@
 		8ABD6CAE1DF6EC36005BCB33 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				HUB_NON_ERROR_WARNINGS_0720 = "";
-				HUB_NON_ERROR_WARNINGS_0730 = "$(HUB_NON_ERROR_WARNING_0720) -Wno-error=partial-availability";
 				INFOPLIST_FILE = tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.HubFrameworkTests;
 				PRODUCT_NAME = HubFrameworkTests;
 				WARNING_CFLAGS = (
 					"$(inherited)",
-					"$(HUB_NON_ERROR_WARNINGS_$(XCODE_VERSION_MINOR))",
 					"-Wno-documentation-unknown-command",
+					"-Wno-partial-availability",
 				);
 			};
 			name = Debug;
@@ -2192,15 +2190,13 @@
 		8ABD6CAF1DF6EC36005BCB33 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				HUB_NON_ERROR_WARNINGS_0720 = "";
-				HUB_NON_ERROR_WARNINGS_0730 = "$(HUB_NON_ERROR_WARNING_0720) -Wno-error=partial-availability";
 				INFOPLIST_FILE = tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.HubFrameworkTests;
 				PRODUCT_NAME = HubFrameworkTests;
 				WARNING_CFLAGS = (
 					"$(inherited)",
-					"$(HUB_NON_ERROR_WARNINGS_$(XCODE_VERSION_MINOR))",
 					"-Wno-documentation-unknown-command",
+					"-Wno-partial-availability",
 				);
 			};
 			name = Release;
@@ -2209,15 +2205,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = NO;
-				HUB_NON_ERROR_WARNINGS_0720 = "";
-				HUB_NON_ERROR_WARNINGS_0730 = "$(HUB_NON_ERROR_WARNING_0720) -Wno-error=partial-availability";
 				INFOPLIST_FILE = tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.HubFrameworkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WARNING_CFLAGS = (
 					"$(inherited)",
-					"$(HUB_NON_ERROR_WARNINGS_$(XCODE_VERSION_MINOR))",
 					"-Wno-documentation-unknown-command",
+					"-Wno-partial-availability",
 				);
 			};
 			name = Debug;
@@ -2226,15 +2220,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = NO;
-				HUB_NON_ERROR_WARNINGS_0720 = "";
-				HUB_NON_ERROR_WARNINGS_0730 = "$(HUB_NON_ERROR_WARNING_0720) -Wno-error=partial-availability";
 				INFOPLIST_FILE = tests/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.spotify.HubFrameworkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WARNING_CFLAGS = (
 					"$(inherited)",
-					"$(HUB_NON_ERROR_WARNINGS_$(XCODE_VERSION_MINOR))",
 					"-Wno-documentation-unknown-command",
+					"-Wno-partial-availability",
 				);
 			};
 			name = Release;

--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -420,6 +420,9 @@
 		DD244A821E04520F005E5C68 /* HUBErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = DD244A811E04520D005E5C68 /* HUBErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD244B191E086958005E5C68 /* HUBErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD244B181E086958005E5C68 /* HUBErrors.m */; };
 		DD244B1A1E086958005E5C68 /* HUBErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = DD244B181E086958005E5C68 /* HUBErrors.m */; };
+		DD561C891E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD561C881E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m */; };
+		DD561C8A1E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD561C881E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m */; };
+		DD561C8B1E5BAE6A00BE0A5E /* CGFloat+HUBMath.h in Headers */ = {isa = PBXBuildFile; fileRef = DD561C871E5BA44500BE0A5E /* CGFloat+HUBMath.h */; };
 		DDBCF36C1C68DD2300693038 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36B1C68DD2300693038 /* UIKit.framework */; };
 		DDBCF36E1C68DE2C00693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
 		DDBCF36F1C68DE4900693038 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBCF36D1C68DE2C00693038 /* CoreGraphics.framework */; };
@@ -761,6 +764,8 @@
 		DD13758F1C68C76000AD3499 /* spotify_os.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = spotify_os.xcconfig; sourceTree = "<group>"; };
 		DD244A811E04520D005E5C68 /* HUBErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBErrors.h; sourceTree = "<group>"; };
 		DD244B181E086958005E5C68 /* HUBErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBErrors.m; sourceTree = "<group>"; };
+		DD561C871E5BA44500BE0A5E /* CGFloat+HUBMath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CGFloat+HUBMath.h"; sourceTree = "<group>"; };
+		DD561C881E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CGFloat+HUBMathTests.m"; sourceTree = "<group>"; };
 		DD79C3B91D9F0A8800FA77E5 /* HUBKeyPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBKeyPath.h; sourceTree = "<group>"; };
 		DD81AFEF1DF725040063DDE0 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		DDA41C8E1C6CB5C00056E511 /* HUBUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBUtilities.h; sourceTree = "<group>"; };
@@ -953,6 +958,7 @@
 			isa = PBXGroup;
 			children = (
 				8A2BD20E1E0AA2CF008A5050 /* Operations */,
+				DD561C871E5BA44500BE0A5E /* CGFloat+HUBMath.h */,
 				8ADA48551D784C1400C27F21 /* HUBAutoEquatable.h */,
 				8ADA48561D784C1400C27F21 /* HUBAutoEquatable.m */,
 				DD244B181E086958005E5C68 /* HUBErrors.m */,
@@ -1049,11 +1055,11 @@
 			children = (
 				8A5D7A6C1CBD0F0D00B987BA /* HUBComponentDefaults+Testing.h */,
 				8A5D7A6D1CBD0F0D00B987BA /* HUBComponentDefaults+Testing.m */,
+				4E29FCF31DED2D9600856D20 /* HUBTestUtilities.h */,
 				6500561E1DF98B89006D957C /* HUBViewModelUtilities.h */,
 				6500561F1DF98B89006D957C /* HUBViewModelUtilities.m */,
 				8AC315821DED94790093AEA0 /* UIViewController+HUBSimulateLayoutCycle.h */,
 				8AC315831DED94790093AEA0 /* UIViewController+HUBSimulateLayoutCycle.m */,
-				4E29FCF31DED2D9600856D20 /* HUBTestUtilities.h */,
 			);
 			name = Utilities;
 			path = utilities;
@@ -1066,6 +1072,7 @@
 				8ACB2A7B1C6A2F99000741D7 /* HUBIdentifierTests.m */,
 				8A2BD20F1E0AA444008A5050 /* HUBOperationQueueTests.m */,
 				344E43CF1E1D6A180016C7CC /* HUBUtilitiesTests.m */,
+				DD561C881E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m */,
 				8A6529E81D82B349007B1A15 /* JSON */,
 				8A6529E11D81B176007B1A15 /* View */,
 				8A6529E91D82B35F007B1A15 /* Feature */,
@@ -1540,6 +1547,7 @@
 				8AE6C0351DF6E3CE0063B2B1 /* HUBViewControllerScrollHandler.h in Headers */,
 				8AE6C0171DF6E3B10063B2B1 /* HUBConnectivityState.h in Headers */,
 				8AE6C0461DF6E3D40063B2B1 /* HUBComponentImageData.h in Headers */,
+				DD561C8B1E5BAE6A00BE0A5E /* CGFloat+HUBMath.h in Headers */,
 				8AE6C0201DF6E3BE0063B2B1 /* HUBJSONPath.h in Headers */,
 				8AE6C05A1DF6E3E00063B2B1 /* HUBActionPerformer.h in Headers */,
 				8AE6C0181DF6E3B10063B2B1 /* HUBConnectivityStateResolver.h in Headers */,
@@ -1907,6 +1915,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD561C8A1E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m in Sources */,
 				8ABD6CCB1DF6ECF3005BCB33 /* HUBManagerTests.m in Sources */,
 				650056211DF98B89006D957C /* HUBViewModelUtilities.m in Sources */,
 				8ABD6CC61DF6ECF3005BCB33 /* HUBURLSessionMock.m in Sources */,
@@ -2005,6 +2014,7 @@
 				8A2BD2101E0AA444008A5050 /* HUBOperationQueueTests.m in Sources */,
 				8AA29CF81C4FE59100E972B7 /* HUBComponentModelBuilderTests.m in Sources */,
 				8A6BA0561C89A00F0057485D /* HUBComponentLayoutManagerMock.m in Sources */,
+				DD561C891E5BAE6300BE0A5E /* CGFloat+HUBMathTests.m in Sources */,
 				344E43D11E1D6A230016C7CC /* HUBUtilitiesTests.m in Sources */,
 				B35E40F91DD4B32F00C0D4F9 /* HUBCollectionViewFactoryTests.m in Sources */,
 				8A1513311DB7B5B100DE8C7A /* HUBTouchMock.m in Sources */,

--- a/sources/CGFloat+HUBMath.h
+++ b/sources/CGFloat+HUBMath.h
@@ -47,8 +47,8 @@ static inline CGFloat HUBCGFloatFloor(CGFloat value)
 /**
  Returns the absolute value of the given floating `value`.
  
- - `HUBFabs(±0)` returns `0`
- - `HUBFabs(±infinity) returns `+infinity`.
+ - `HUBCGFloatAbs(±0)` returns `0`
+ - `HUBCGFloatAbs(±infinity) returns `+infinity`.
 
  @param value The value.
  @return The absolute value.
@@ -113,6 +113,8 @@ static const CGFloat HUBCGFloatDefaultEpsilon = (CGFloat)0.00001;
  @param rhs The second value.
  @param epsilon The epsilon (i.e. tolerated deviance from true equality).
  @return `YES` if the `lhs` is approximately equal to `rhs` (±epsilon); otherwise `NO`.
+ 
+ @seealso `HUBCGFloatIsZero(CGFloat)` for a function to check if a values is ≈0.
  */
 static inline BOOL HUBCGFloatIsNearlyEqual(CGFloat lhs, CGFloat rhs, CGFloat epsilon)
 {

--- a/sources/CGFloat+HUBMath.h
+++ b/sources/CGFloat+HUBMath.h
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <CoreGraphics/CoreGraphics.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Computing Values from CGFloats
+
+/**
+ Round to largest integral value not greater than `value`.
+ 
+ @note Consider using this function instead of the standard `floor` and `floorf` functions for `CGFloat` values. This
+       function helps avoid implicit double promotion and loss of precision. Keeping the types correct regardless of
+       if the backing type is `double` or `float`.
+
+ @param value The value that should be floored.
+ @return The largest integral value not greater than `value`.
+ */
+static inline CGFloat HUBCGFloatFloor(CGFloat value)
+{
+#if CGFLOAT_IS_DOUBLE
+    return floor(value);
+#else
+    return floorf(value);
+#endif // CGFLOAT_IS_DOUBLE
+}
+
+/**
+ Returns the absolute value of the given floating `value`.
+ 
+ - `HUBFabs(±0)` returns `0`
+ - `HUBFabs(±infinity) returns `+infinity`.
+
+ @param value The value.
+ @return The absolute value.
+ */
+static inline CGFloat HUBCGFloatAbs(CGFloat value)
+{
+#if CGFLOAT_IS_DOUBLE
+    return fabs(value);
+#else
+    return fabsf(value);
+#endif // CGFLOAT_IS_DOUBLE
+}
+
+/**
+ Returns the maximum value.
+
+ @param a The first value.
+ @param b The second value.
+ @return `a` if it’s larger than `b`; otherwise `b`.
+ */
+static inline CGFloat HUBCGFloatMax(CGFloat a, CGFloat b)
+{
+#if CGFLOAT_IS_DOUBLE
+    return fmax(a, b);
+#else
+    return fmaxf(a, b);
+#endif // CGFLOAT_IS_DOUBLE
+}
+
+/**
+ Returns the minimum value.
+
+ @param a The first value.
+ @param b The second value.
+ @return `a` if it’s smaller than `b`; otherwise `b`.
+ */
+static inline CGFloat HUBCGFloatMin(CGFloat a, CGFloat b)
+{
+#if CGFLOAT_IS_DOUBLE
+    return fmin(a, b);
+#else
+    return fminf(a, b);
+#endif // CGFLOAT_IS_DOUBLE
+}
+
+#pragma mark - Testing and Comparing CGFloats
+
+/**
+ The default epsilon value for `CGFloat` operations.
+ 
+ This value should be good enough for most UI geometry calculations.
+ */
+static const CGFloat HUBCGFloatDefaultEpsilon = (CGFloat)0.00001;
+
+/**
+ Returns a Boolean value indicating if the given `lhs` is approximately equal to `rhs`, given an `epsilon`.
+ 
+ @warning Do not use this function to test if a value is (nearly) equal to zero. Instead use
+          `BOOL HUBCGFloatIsZero(CGFLoat)` to test whether a value is (nearly) equal to zero.
+
+ @param lhs The first value.
+ @param rhs The second value.
+ @param epsilon The epsilon (i.e. tolerated deviance from true equality).
+ @return `YES` if the `lhs` is approximately equal to `rhs` (±epsilon); otherwise `NO`.
+ */
+static inline BOOL HUBCGFloatIsNearlyEqual(CGFloat lhs, CGFloat rhs, CGFloat epsilon)
+{
+    return HUBCGFloatAbs(lhs - rhs) <= epsilon * HUBCGFloatMax(HUBCGFloatAbs(lhs), HUBCGFloatAbs(lhs));
+}
+
+/**
+ Returns a Boolean value indicating if the given `value` is (approximately) zero.
+ 
+ @note The function uses the Hub Framework’s default epislon value. Which should be well enough for any geometry tests.
+
+ @param value The value that should be compared to zero (0)
+ @return `YES` if the `value` is (approximately; ±1e-5) equal to zero; otherwise `NO`.
+ 
+ @seealso `HUBCGFloatDefaultEpsilon` for the details of the default
+ */
+static inline BOOL HUBCGFloatIsZero(CGFloat value)
+{
+    return HUBCGFloatAbs(value) <= HUBCGFloatDefaultEpsilon;
+}
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -31,6 +31,8 @@
 #import "HUBViewModelDiff.h"
 #import "HUBUtilities.h"
 
+#import "CGFloat+HUBMath.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBCollectionViewLayout () <HUBComponentChildDelegate>
@@ -146,7 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                 margins:margins];
         
         currentPoint.x = CGRectGetMaxX(componentViewFrame);
-        currentRowMaxY = MAX(currentRowMaxY, CGRectGetMaxY(componentViewFrame));
+        currentRowMaxY = HUBCGFloatMax(currentRowMaxY, CGRectGetMaxY(componentViewFrame));
         
         [self registerComponentViewFrame:componentViewFrame forIndex:componentIndex];
         
@@ -206,10 +208,10 @@ NS_ASSUME_NONNULL_BEGIN
     
     // Making sure the content offset doesn't go through the roof.
     CGFloat const minContentOffset = -self.collectionView.contentInset.top;
-    offset.y = MAX(minContentOffset, offset.y);
+    offset.y = HUBCGFloatMax(minContentOffset, offset.y);
     // ...or beyond the bottom.
     CGFloat maxContentOffset = MAX(self.contentSize.height + self.collectionView.contentInset.bottom - CGRectGetHeight(self.collectionView.frame), minContentOffset);
-    offset.y = MIN(maxContentOffset, offset.y);
+    offset.y = HUBCGFloatMin(maxContentOffset, offset.y);
     
     self.previousLayoutAttributesByIndexPath = nil;
     self.lastViewModelDiff = nil;
@@ -298,8 +300,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)forEachVerticalGroupInRect:(CGRect)rect runBlock:(void(^)(NSInteger groupIndex))block
 {
     CGFloat const verticalGroupSize = 100;
-    NSInteger const maxVerticalGroup = (NSInteger)(floor(CGRectGetMaxY(rect) / verticalGroupSize));
-    NSInteger currentVerticalGroup = (NSInteger)(floor(CGRectGetMinY(rect) / verticalGroupSize));
+    NSInteger const maxVerticalGroup = (NSInteger)(HUBCGFloatFloor(CGRectGetMaxY(rect) / verticalGroupSize));
+    NSInteger currentVerticalGroup = (NSInteger)(HUBCGFloatFloor(CGRectGetMinY(rect) / verticalGroupSize));
     
     while (currentVerticalGroup <= maxVerticalGroup) {
         block(currentVerticalGroup);
@@ -400,10 +402,10 @@ NS_ASSUME_NONNULL_BEGIN
         CGFloat const componentBottomMargin = [self.componentLayoutManager marginBetweenComponentWithLayoutTraits:component.layoutTraits
                                                                                                    andContentEdge:HUBComponentLayoutContentEdgeBottom];
         
-        viewBottomMargin = MAX(viewBottomMargin, componentBottomMargin);
+        viewBottomMargin = HUBCGFloatMax(viewBottomMargin, componentBottomMargin);
     }
     
-    contentHeight += MAX(viewBottomMargin, minimumBottomMargin);
+    contentHeight += HUBCGFloatMax(viewBottomMargin, minimumBottomMargin);
     
     return CGSizeMake(collectionViewSize.width, contentHeight);
 }
@@ -437,7 +439,7 @@ NS_ASSUME_NONNULL_BEGIN
                        horizontalAdjustment:(CGFloat)horizontalAdjustment
                          lastComponentIndex:(NSInteger)lastComponentIndex
 {
-    if (horizontalAdjustment == 0.0 || lastComponentIndex < 0) {
+    if (HUBCGFloatIsZero(horizontalAdjustment) || lastComponentIndex < 0) {
         return;
     }
 

--- a/sources/HUBDefaultComponentLayoutManager.m
+++ b/sources/HUBDefaultComponentLayoutManager.m
@@ -20,6 +20,7 @@
  */
 
 #import "HUBDefaultComponentLayoutManager.h"
+#import "CGFloat+HUBMath.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -118,7 +119,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     /// Center the component
-    return (CGFloat)floor((firstComponentLeadingOffsetX + lastComponentTrailingOffsetX) / 2 - firstComponentLeadingOffsetX);
+    return HUBCGFloatFloor((firstComponentLeadingOffsetX + lastComponentTrailingOffsetX) / 2 - firstComponentLeadingOffsetX);
 }
 
 #pragma mark - Private utilities

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -22,6 +22,8 @@
 #import "HUBViewControllerDefaultScrollHandler.h"
 #import "HUBViewController.h"
 
+#import "CGFloat+HUBMath.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerDefaultScrollHandler
@@ -83,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
     CGFloat targetOffset = 0.0;
 
     if (scrollPosition & HUBScrollPositionCenteredVertically) {
-        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0);
+        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / (CGFloat)2.0);
     } else if (scrollPosition & HUBScrollPositionBottom) {
         targetOffset = CGRectGetMaxY(componentFrame) - viewHeight;
     } else {
@@ -91,8 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
         targetOffset = CGRectGetMinY(componentFrame);
     }
 
-    targetOffset = MAX(-contentInset.top, MIN(contentSize.height - viewHeight, targetOffset));
-    return CGPointMake(0.0, (CGFloat)floor((double)targetOffset));
+    targetOffset = HUBCGFloatMax(-contentInset.top, MIN(contentSize.height - viewHeight, targetOffset));
+    return CGPointMake(0.0, HUBCGFloatFloor(targetOffset));
 }
 
 @end

--- a/sources/HUBViewControllerDefaultScrollHandler.m
+++ b/sources/HUBViewControllerDefaultScrollHandler.m
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
     CGFloat targetOffset = 0.0;
 
     if (scrollPosition & HUBScrollPositionCenteredVertically) {
-        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0f);
+        targetOffset = CGRectGetMidY(componentFrame) - (viewHeight / 2.0);
     } else if (scrollPosition & HUBScrollPositionBottom) {
         targetOffset = CGRectGetMaxY(componentFrame) - viewHeight;
     } else {

--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -80,13 +80,7 @@ GCC_PREPROCESSOR_DEFINITIONS = $SPOTIFY_OS_CONFIG_PREPROCESSOR_DEFINITIONS
 // Warnings:
 // Attribution: https://github.com/jonreid/XcodeWarnings
 
-// Warnings, by Xcode version, we want to ignore.
-HF_IGNORED_WARNINGS_0730 = -Wno-double-promotion -Wno-partial-availability
-HF_IGNORED_WARNINGS_0800 = $(HF_IGNORED_WARNINGS_0730)
-HF_IGNORED_WARNINGS_0810 = $(HF_IGNORED_WARNINGS_0800)
-HF_IGNORED_WARNINGS_0820 = $(HF_IGNORED_WARNINGS_0810)
-
-WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Wno-vla -Werror $(HF_IGNORED_WARNINGS_$(XCODE_VERSION_MINOR))
+WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Wno-vla -Werror
 
 // Apple LLVM 8.0 - Warnings - All languages
 CLANG_WARN_INFINITE_RECURSION = YES

--- a/tests/CGFloat+HUBMathTests.m
+++ b/tests/CGFloat+HUBMathTests.m
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (c) 2016 Spotify AB.
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "HUBTestUtilities.h"
+
+#import "CGFloat+HUBMath.h"
+
+@interface CGFloatHUBMathTests : XCTestCase
+@end
+
+@implementation CGFloatHUBMathTests
+
+#pragma mark HUBCGFloatFloor
+
+- (void)testFloorZeroIsZero
+{
+    XCTAssertLessThanOrEqual(HUBCGFloatFloor((CGFloat)0.0), (CGFloat)0.0, @"Flooring 0.0 should yield 0.0");
+}
+
+- (void)testFloorLowFraction
+{
+    XCTAssertLessThanOrEqual(HUBCGFloatFloor((CGFloat)3.1415), (CGFloat)3.0, @"Flooring 3.1415 should yield 3.0");
+}
+
+- (void)testFloorMidFraction
+{
+    XCTAssertLessThanOrEqual(HUBCGFloatFloor((CGFloat)25.5), (CGFloat)25.0, @"Flooring 25.5 should yield 25.0");
+}
+
+- (void)testFloorHighFraction
+{
+    XCTAssertLessThanOrEqual(HUBCGFloatFloor((CGFloat)3.8585), (CGFloat)3.0, @"Flooring 3.8585 should yield 3.0");
+}
+
+
+#pragma mark HUBCGFloatAbs
+
+- (void)testAbsZeroIsZero
+{
+    XCTAssertLessThanOrEqual(HUBCGFloatAbs((CGFloat)0.0), (CGFloat)0.0, @"Absolute of ±0.0 should yield +0.0");
+}
+
+- (void)testAbsPositiveIsSame
+{
+    const CGFloat original = (CGFloat)3.1415;
+    const CGFloat actual = HUBCGFloatAbs(original);
+    const CGFloat epsilon = (CGFloat)0.00001;
+
+    XCTAssertTrue((actual >= (original - epsilon)) || (actual <= (original + epsilon)), @"Absolute of +3.1415 should yield +3.1415");
+}
+
+- (void)testAbsNegativeIsPositive
+{
+    const CGFloat original = (CGFloat)-3.1415;
+    const CGFloat actual = HUBCGFloatAbs(original);
+    const CGFloat epsilon = (CGFloat)0.00001;
+
+    XCTAssertTrue((actual >= (original - epsilon)) || (actual <= (original + epsilon)), @"Absolute of -3.1415 should yield +3.1415");
+}
+
+
+#pragma mark HUBCGFloatMax
+
+- (void)testMaxWhenBothValuesAreEqual
+{
+    const CGFloat a = (CGFloat)12.2;
+    const CGFloat b = (CGFloat)12.2;
+
+    HUBAssertEqualCGFloatValues(HUBCGFloatMax(a, b), 12.2);
+}
+
+- (void)testMaxWhenFirstValueIsLarger
+{
+    const CGFloat a = (CGFloat)10.0;
+    const CGFloat b = (CGFloat)9.9;
+
+    HUBAssertEqualCGFloatValues(HUBCGFloatMax(a, b), 10.0);
+}
+
+- (void)testMaxWhenSecondValueIsLarger
+{
+    const CGFloat a = (CGFloat)9.8;
+    const CGFloat b = (CGFloat)9.9;
+
+    HUBAssertEqualCGFloatValues(HUBCGFloatMax(a, b), 9.9);
+}
+
+
+#pragma mark HUBCGFloatMin
+
+- (void)testMinWhenBothValuesAreEqual
+{
+    const CGFloat a = (CGFloat)12.2;
+    const CGFloat b = (CGFloat)12.2;
+
+    HUBAssertEqualCGFloatValues(HUBCGFloatMin(a, b), 12.2);
+}
+
+- (void)testMinWhenFirstValueIsSmaller
+{
+    const CGFloat a = (CGFloat)4.1;
+    const CGFloat b = (CGFloat)4.2;
+
+    HUBAssertEqualCGFloatValues(HUBCGFloatMin(a, b), 4.1);
+}
+
+- (void)testMinWhenSecondValueIsSmaller
+{
+    const CGFloat a = (CGFloat)-3.13;
+    const CGFloat b = (CGFloat)-3.14;
+
+    HUBAssertEqualCGFloatValues(HUBCGFloatMin(a, b), -3.14);
+}
+
+
+#pragma mark HUBCGFloatIsNearlyEqual
+
+- (void)testIsNearlyEqualForTruthyValues
+{
+    const CGFloat epsilon = (CGFloat)0.00001;
+    const CGFloat lhs = (CGFloat)12.34;
+    const CGFloat rhs = (CGFloat)(12.34 + 0.000001);
+
+    XCTAssertTrue(HUBCGFloatIsNearlyEqual(lhs, rhs, epsilon), @"Almost equal values should be reported as such");
+}
+
+- (void)testIsNotNearlyEqualForFalseyValues
+{
+    const CGFloat epsilon = (CGFloat)0.00001;
+    const CGFloat lhs = (CGFloat)12.34;
+    const CGFloat rhs = (CGFloat)(12.34 + 0.0009);
+
+    XCTAssertFalse(HUBCGFloatIsNearlyEqual(lhs, rhs, epsilon), @"Values that are apart greater than the epsilon should not be considered equal");
+}
+
+
+#pragma mark HUBCGFloatIsZero
+
+- (void)testIsZeroForZero
+{
+    XCTAssertTrue(HUBCGFloatIsZero(0.0), @"The literal 0.0 should be reported as zero");
+}
+
+- (void)testIsZeroForAlmostZero
+{
+    const CGFloat original = HUBCGFloatDefaultEpsilon - HUBCGFloatDefaultEpsilon / (CGFloat)10.0;
+    XCTAssertTrue(HUBCGFloatIsZero(original), @"A value within the tolerance (epsilon) should be reported as zero");
+}
+
+- (void)testIsZeroForAlmostButNotZero
+{
+    const CGFloat original = HUBCGFloatDefaultEpsilon * 2;
+    XCTAssertFalse(HUBCGFloatIsZero(original), @"A value just outside of the tolerance (epsilon) should yield false");
+}
+
+- (void)testIsZeroForNotZero
+{
+    XCTAssertFalse(HUBCGFloatIsZero(4), @"A non-zero value should yield false");
+}
+
+@end

--- a/tests/HUBCollectionViewLayoutTests.m
+++ b/tests/HUBCollectionViewLayoutTests.m
@@ -283,11 +283,11 @@
 
     NSIndexPath * const componentIndexPath1 = [NSIndexPath indexPathForItem:0 inSection:0];
     CGRect const componentViewFrame1 = [layout layoutAttributesForItemAtIndexPath:componentIndexPath1].frame;
-    HUBAssertEqualFloatValues(componentViewFrame1.origin.x, 110);
+    HUBAssertEqualCGFloatValues(componentViewFrame1.origin.x, 110);
     
     NSIndexPath * const componentIndexPath2 = [NSIndexPath indexPathForItem:1 inSection:0];
     CGRect const componentViewFrame2 = [layout layoutAttributesForItemAtIndexPath:componentIndexPath2].frame;
-    HUBAssertEqualFloatValues(componentViewFrame2.origin.x, 160);
+    HUBAssertEqualCGFloatValues(componentViewFrame2.origin.x, 160);
 }
 
 - (void)testProposedContentOffsetWithoutRecomputing
@@ -299,7 +299,7 @@
     HUBCollectionViewLayout * const layout = [self computeLayoutWithHeaderMargin:NO];
 
     CGPoint const proposedOffset = CGPointMake(0.0, 1200.0);
-    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:proposedOffset].y, proposedOffset.y);
+    HUBAssertEqualCGFloatValues([layout targetContentOffsetForProposedContentOffset:proposedOffset].y, proposedOffset.y);
 }
 
 - (void)testProposedContentOffsetForInitiallyAddedComponents
@@ -384,7 +384,7 @@
 
     CGFloat expectedOffset = contentOffset.y - deletionHeight + insertionHeight;
     
-    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:contentOffset].y, expectedOffset);
+    HUBAssertEqualCGFloatValues([layout targetContentOffsetForProposedContentOffset:contentOffset].y, expectedOffset);
 }
 
 - (void)testProposedContentOffsetBeyondBounds
@@ -411,7 +411,7 @@
     [layout computeForCollectionViewSize:self.collectionViewSize viewModel:secondViewModel diff:firstDiff addHeaderMargin:YES];
 
     CGFloat expectedOffset = layout.collectionViewContentSize.height + collectionView.contentInset.bottom - self.collectionViewSize.height;
-    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset);
+    HUBAssertEqualCGFloatValues([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset);
     
     for (NSUInteger i = 0; i < 10; i++) {
         [self removeBodyComponentAtIndex:i];
@@ -425,7 +425,7 @@
     [layout computeForCollectionViewSize:self.collectionViewSize viewModel:newViewModel diff:secondDiff addHeaderMargin:YES];
 
     expectedOffset = -collectionView.contentInset.top;
-    HUBAssertEqualFloatValues([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset);
+    HUBAssertEqualCGFloatValues([layout targetContentOffsetForProposedContentOffset:collectionView.contentOffset].y, expectedOffset);
 }
 
 #pragma mark - Utilities

--- a/tests/HUBDefaultComponentLayoutManagerTests.m
+++ b/tests/HUBDefaultComponentLayoutManagerTests.m
@@ -41,8 +41,8 @@
     CGFloat const verticalMargin = [manager verticalMarginBetweenComponentWithLayoutTraits:layoutTraits
                                                         andHeaderComponentWithLayoutTraits:layoutTraits];
     
-    HUBAssertEqualFloatValues(horizontalMargin, 10);
-    HUBAssertEqualFloatValues(verticalMargin, 10);
+    HUBAssertEqualCGFloatValues(horizontalMargin, 10);
+    HUBAssertEqualCGFloatValues(verticalMargin, 10);
 }
 
 - (void)testApplyingMarginBetweenCompactWithComponentAndContentEdge
@@ -50,10 +50,10 @@
     HUBDefaultComponentLayoutManager * const manager = [[HUBDefaultComponentLayoutManager alloc] initWithMargin:10];
     NSSet * const layoutTraits = [NSSet setWithObject:HUBComponentLayoutTraitCompactWidth];
     
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeTop], 10);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeRight], 10);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeBottom], 10);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeLeft], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeTop], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeRight], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeBottom], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeLeft], 10);
 }
 
 - (void)testNotApplyingHorizontalMarginBetweenFullWidthComponents
@@ -67,8 +67,8 @@
     CGFloat const verticalMargin = [manager verticalMarginBetweenComponentWithLayoutTraits:layoutTraits
                                                         andHeaderComponentWithLayoutTraits:layoutTraits];
     
-    HUBAssertEqualFloatValues(horizontalMargin, 0);
-    HUBAssertEqualFloatValues(verticalMargin, 10);
+    HUBAssertEqualCGFloatValues(horizontalMargin, 0);
+    HUBAssertEqualCGFloatValues(verticalMargin, 10);
 }
 
 - (void)testNotApplyingHorizontalMarginBetweenFullWidthComponentAndContentEdge
@@ -76,10 +76,10 @@
     HUBDefaultComponentLayoutManager * const manager = [[HUBDefaultComponentLayoutManager alloc] initWithMargin:10];
     NSSet * const layoutTraits = [NSSet setWithObject:HUBComponentLayoutTraitFullWidth];
     
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeTop], 10);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeRight], 0);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeBottom], 10);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeLeft], 0);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeTop], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeRight], 0);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeBottom], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeLeft], 0);
 }
 
 - (void)testNotApplyingVerticalMarginBetweenStackableComponents
@@ -93,8 +93,8 @@
     CGFloat const verticalMargin = [manager verticalMarginBetweenComponentWithLayoutTraits:layoutTraits
                                                         andHeaderComponentWithLayoutTraits:layoutTraits];
     
-    HUBAssertEqualFloatValues(horizontalMargin, 10);
-    HUBAssertEqualFloatValues(verticalMargin, 0);
+    HUBAssertEqualCGFloatValues(horizontalMargin, 10);
+    HUBAssertEqualCGFloatValues(verticalMargin, 0);
 }
 
 - (void)testNotApplyingVerticalMarginBetweenStackableComponentAndContentEdge
@@ -102,10 +102,10 @@
     HUBDefaultComponentLayoutManager * const manager = [[HUBDefaultComponentLayoutManager alloc] initWithMargin:10];
     NSSet * const layoutTraits = [NSSet setWithObject:HUBComponentLayoutTraitStackable];
     
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeTop], 0);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeRight], 10);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeBottom], 0);
-    HUBAssertEqualFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeLeft], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeTop], 0);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeRight], 10);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeBottom], 0);
+    HUBAssertEqualCGFloatValues([manager marginBetweenComponentWithLayoutTraits:layoutTraits andContentEdge:HUBComponentLayoutContentEdgeLeft], 10);
 }
 
 - (void)testApplyingVerticalMarginBetweenStackableAndNonStackableComponent
@@ -121,8 +121,8 @@
     CGFloat const marginB = [manager verticalMarginForComponentWithLayoutTraits:layoutTraitsB
                                                  precedingComponentLayoutTraits:layoutTraitsA];
     
-    HUBAssertEqualFloatValues(marginA, 10);
-    HUBAssertEqualFloatValues(marginB, 10);
+    HUBAssertEqualCGFloatValues(marginA, 10);
+    HUBAssertEqualCGFloatValues(marginB, 10);
 }
 
 - (void)testNotApplyingVerticalMarginUpwardsForAlwaysStackUpwardsComponent
@@ -137,8 +137,8 @@
     CGFloat const downwardsMargin = [manager verticalMarginForComponentWithLayoutTraits:layoutTraitsB
                                                          precedingComponentLayoutTraits:layoutTraitsA];
     
-    HUBAssertEqualFloatValues(upwardsMargin, 0);
-    HUBAssertEqualFloatValues(downwardsMargin, 10);
+    HUBAssertEqualCGFloatValues(upwardsMargin, 0);
+    HUBAssertEqualCGFloatValues(downwardsMargin, 10);
 }
 
 - (void)testCentering
@@ -150,7 +150,7 @@
                                             firstComponentLeadingHorizontalOffset:10
                                             lastComponentTrailingHorizontalOffset:300];
     
-    HUBAssertEqualFloatValues(offset, 145);
+    HUBAssertEqualCGFloatValues(offset, 145);
 }
 
 @end

--- a/tests/HUBManagerTests.m
+++ b/tests/HUBManagerTests.m
@@ -107,8 +107,8 @@
     
     // Assert that the component margin given when setting up the manager is used
     CGRect const componentFrame = [viewController frameForBodyComponentAtIndex:0];
-    HUBAssertEqualFloatValues(componentFrame.origin.x, 15);
-    HUBAssertEqualFloatValues(componentFrame.origin.y, 15);
+    HUBAssertEqualCGFloatValues(componentFrame.origin.x, 15);
+    HUBAssertEqualCGFloatValues(componentFrame.origin.y, 15);
     
     // Assert that the fallback component was used
     XCTAssertTrue(fallbackComponentUsed);

--- a/tests/HUBViewControllerTests.m
+++ b/tests/HUBViewControllerTests.m
@@ -1924,12 +1924,12 @@
 
     [self simulateViewControllerLayoutCycle];
     
-    HUBAssertEqualFloatValues(self.collectionView.contentInset.top, 0);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentInset.top, 0);
     
     // Now, let's enable and reload - content inset should now be reset
     self.viewControllerShouldAutomaticallyManageTopContentInset = ^{ return YES; };
     [self.viewController reload];
-    HUBAssertEqualFloatValues(self.collectionView.contentInset.top, 44);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentInset.top, 44);
 }
 
 - (void)testDisablingAutomaticTopInsetManagementWithHeaderComponent
@@ -1959,15 +1959,15 @@
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     UICollectionViewLayoutAttributes * const layoutAttributesA = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
     
-    HUBAssertEqualFloatValues(self.collectionView.contentInset.top, 0);
-    HUBAssertEqualFloatValues(layoutAttributesA.frame.origin.y, 0);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentInset.top, 0);
+    HUBAssertEqualCGFloatValues(layoutAttributesA.frame.origin.y, 0);
     
     // Now, let's enable and reload - the first component should now have been pushed down by the header
     self.viewControllerShouldAutomaticallyManageTopContentInset = ^{ return YES; };
     [self.viewController reload];
     
     UICollectionViewLayoutAttributes * const layoutAttributesB = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
-    HUBAssertEqualFloatValues(layoutAttributesB.frame.origin.y, 400);
+    HUBAssertEqualCGFloatValues(layoutAttributesB.frame.origin.y, 400);
 }
 
 - (void)testHeaderMarginAlwaysBasedOnComponentPreferredViewSize
@@ -2000,7 +2000,7 @@
     
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     UICollectionViewLayoutAttributes * const layoutAttributesA = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
-    HUBAssertEqualFloatValues(layoutAttributesA.frame.origin.y, 400);
+    HUBAssertEqualCGFloatValues(layoutAttributesA.frame.origin.y, 400);
     
     // If the header height is changed (for example, by the header itself, it shouldn't affect content inset)
     self.component.view.frame = CGRectMake(0, 0, 320, 100);
@@ -2010,7 +2010,7 @@
     XCTAssertEqual(self.contentOperation.performCount, 2u);
     
     UICollectionViewLayoutAttributes * const layoutAttributesB = [self.collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath];
-    HUBAssertEqualFloatValues(layoutAttributesB.frame.origin.y, 400);
+    HUBAssertEqualCGFloatValues(layoutAttributesB.frame.origin.y, 400);
 }
 
 - (void)testScrollingToRootComponentUsesScrollHandler
@@ -2350,7 +2350,7 @@
     XCTAssertEqual(self.collectionView.showsHorizontalScrollIndicator, YES);
     XCTAssertEqual(self.collectionView.showsVerticalScrollIndicator, YES);
     XCTAssertEqual(self.collectionView.keyboardDismissMode, UIScrollViewKeyboardDismissModeOnDrag);
-    HUBAssertEqualFloatValues(self.collectionView.decelerationRate, UIScrollViewDecelerationRateNormal);
+    HUBAssertEqualCGFloatValues(self.collectionView.decelerationRate, UIScrollViewDecelerationRateNormal);
     XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.collectionView.contentInset, UIEdgeInsetsMake(100, 30, 40, 200)));
 }
 
@@ -2365,32 +2365,32 @@
     id<UIScrollViewDelegate> const scrollViewDelegate = self.collectionView.delegate;
     [scrollViewDelegate scrollViewWillBeginDragging:self.collectionView];
     
-    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
-    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.startContentRect), 200);
-    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.startContentRect), 320);
-    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.startContentRect), 480);
+    HUBAssertEqualCGFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
+    HUBAssertEqualCGFloatValues(CGRectGetMinY(self.scrollHandler.startContentRect), 200);
+    HUBAssertEqualCGFloatValues(CGRectGetWidth(self.scrollHandler.startContentRect), 320);
+    HUBAssertEqualCGFloatValues(CGRectGetHeight(self.scrollHandler.startContentRect), 480);
     
     self.collectionView.contentOffset = CGPointMake(0, 800);
     [scrollViewDelegate scrollViewWillBeginDragging:self.collectionView];
     
-    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
-    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.startContentRect), 800);
-    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.startContentRect), 320);
-    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.startContentRect), 480);
+    HUBAssertEqualCGFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
+    HUBAssertEqualCGFloatValues(CGRectGetMinY(self.scrollHandler.startContentRect), 800);
+    HUBAssertEqualCGFloatValues(CGRectGetWidth(self.scrollHandler.startContentRect), 320);
+    HUBAssertEqualCGFloatValues(CGRectGetHeight(self.scrollHandler.startContentRect), 480);
 
     self.collectionView.contentOffset = CGPointMake(0, 1200);
     [scrollViewDelegate scrollViewDidEndDragging:self.collectionView willDecelerate:NO];
-    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
-    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.endContentRect), 1200);
-    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.endContentRect), 320);
-    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.endContentRect), 400);
+    HUBAssertEqualCGFloatValues(CGRectGetMinX(self.scrollHandler.startContentRect), 0);
+    HUBAssertEqualCGFloatValues(CGRectGetMinY(self.scrollHandler.endContentRect), 1200);
+    HUBAssertEqualCGFloatValues(CGRectGetWidth(self.scrollHandler.endContentRect), 320);
+    HUBAssertEqualCGFloatValues(CGRectGetHeight(self.scrollHandler.endContentRect), 400);
 
     self.collectionView.contentOffset = CGPointMake(0, 1240);
     [scrollViewDelegate scrollViewDidEndDecelerating:self.collectionView];
-    HUBAssertEqualFloatValues(CGRectGetMinX(self.scrollHandler.endContentRect), 0);
-    HUBAssertEqualFloatValues(CGRectGetMinY(self.scrollHandler.endContentRect), 1240);
-    HUBAssertEqualFloatValues(CGRectGetWidth(self.scrollHandler.endContentRect), 320);
-    HUBAssertEqualFloatValues(CGRectGetHeight(self.scrollHandler.endContentRect), 360);
+    HUBAssertEqualCGFloatValues(CGRectGetMinX(self.scrollHandler.endContentRect), 0);
+    HUBAssertEqualCGFloatValues(CGRectGetMinY(self.scrollHandler.endContentRect), 1240);
+    HUBAssertEqualCGFloatValues(CGRectGetWidth(self.scrollHandler.endContentRect), 320);
+    HUBAssertEqualCGFloatValues(CGRectGetHeight(self.scrollHandler.endContentRect), 360);
 }
 
 - (void)testScrollHandlerModifyingTargetContentOffset
@@ -2404,8 +2404,8 @@
                                                withVelocity:CGPointZero
                                         targetContentOffset:&targetContentOffset];
     
-    HUBAssertEqualFloatValues(targetContentOffset.x, 300);
-    HUBAssertEqualFloatValues(targetContentOffset.y, 500);
+    HUBAssertEqualCGFloatValues(targetContentOffset.x, 300);
+    HUBAssertEqualCGFloatValues(targetContentOffset.y, 500);
 }
 
 - (void)testIsViewScrolling
@@ -2809,8 +2809,8 @@
     // Sets view controller's view frame to {0, 0, 320, 400}
     [self simulateViewControllerLayoutCycle];
     
-    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
-    HUBAssertEqualFloatValues(self.component.view.center.y, 200);
+    HUBAssertEqualCGFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualCGFloatValues(self.component.view.center.y, 200);
     
     CGRect const keyboardEndFrame = CGRectMake(0, 200, 320, 200);
     NSDictionary * const notificationUserInfo = @{
@@ -2824,25 +2824,25 @@
     NSNotificationCenter * const notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter postNotification:keyboardNotification];
     
-    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
-    HUBAssertEqualFloatValues(self.component.view.center.y, 100);
+    HUBAssertEqualCGFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualCGFloatValues(self.component.view.center.y, 100);
     
     // Hide keyboard, which should pull the overlay component back down
     [notificationCenter postNotificationName:UIKeyboardWillHideNotification object:nil];
     
-    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
-    HUBAssertEqualFloatValues(self.component.view.center.y, 200);
+    HUBAssertEqualCGFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualCGFloatValues(self.component.view.center.y, 200);
 
     self.centerPointForOverlayComponents = [NSValue valueWithCGPoint:CGPointMake(80, 100)];
     [notificationCenter postNotification:keyboardNotification];
-    HUBAssertEqualFloatValues(self.component.view.center.x, 80);
-    HUBAssertEqualFloatValues(self.component.view.center.y, 100);
+    HUBAssertEqualCGFloatValues(self.component.view.center.x, 80);
+    HUBAssertEqualCGFloatValues(self.component.view.center.y, 100);
 
     self.viewController.delegate = nil;
     self.centerPointForOverlayComponents = nil;
     [notificationCenter postNotificationName:UIKeyboardWillHideNotification object:nil];
-    HUBAssertEqualFloatValues(self.component.view.center.x, 160);
-    HUBAssertEqualFloatValues(self.component.view.center.y, 200);
+    HUBAssertEqualCGFloatValues(self.component.view.center.x, 160);
+    HUBAssertEqualCGFloatValues(self.component.view.center.y, 200);
 }
 
 - (void)testScrollingToComponentAfterViewModelFinishesRendering
@@ -2916,7 +2916,7 @@
     
     // Here we force update the collection view's content size as it doesn't do it automatically when not attached to a proper window
     self.collectionView.contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize;
-    HUBAssertEqualFloatValues(self.collectionView.contentSize.height, 500);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentSize.height, 500);
     
     CGPoint targetContentOffset = CGPointMake(0, 500);
     self.scrollHandler.targetContentOffset = targetContentOffset;
@@ -2931,7 +2931,7 @@
     XCTAssertEqualObjects(self.viewController.viewModel.bodyComponentModels[5].identifier, @"extended-component-page-1");
     
     self.collectionView.contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize;
-    HUBAssertEqualFloatValues(self.collectionView.contentSize.height, 600);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentSize.height, 600);
     
     targetContentOffset = CGPointMake(0, 600);
     self.scrollHandler.targetContentOffset = targetContentOffset;
@@ -2968,16 +2968,16 @@
     
     // First verify that we can scroll the view per default
     self.collectionView.contentOffset = CGPointMake(0, 500);
-    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 500);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentOffset.y, 500);
     
     self.viewControllerShouldStartScrollingBlock = ^{ return NO; };
     self.collectionView.contentOffset = CGPointMake(0, 600);
-    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 500);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentOffset.y, 500);
     
     // Verify that scrolling works again as soon as we switch back
     self.viewControllerShouldStartScrollingBlock = ^{ return YES; };
     self.collectionView.contentOffset = CGPointMake(0, 700);
-    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 700);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentOffset.y, 700);
 }
 
 - (void)testViewControllerWithoutDelegateIsAlwaysScrollable
@@ -3006,11 +3006,11 @@
     
     // Here we force update the collection view's content size as it doesn't do it automatically when not attached to a proper window
     self.collectionView.contentSize = self.collectionView.collectionViewLayout.collectionViewContentSize;
-    HUBAssertEqualFloatValues(self.collectionView.contentSize.height, 1000);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentSize.height, 1000);
     XCTAssertGreaterThan(self.collectionView.contentSize.height, CGRectGetHeight(self.collectionView.frame));
     
     self.collectionView.contentOffset = CGPointMake(0, 500);
-    HUBAssertEqualFloatValues(self.collectionView.contentOffset.y, 500);
+    HUBAssertEqualCGFloatValues(self.collectionView.contentOffset.y, 500);
 }
 
 - (void)testThatDelegateIsNotifiedWhenOverlayAppears

--- a/tests/utilities/HUBTestUtilities.h
+++ b/tests/utilities/HUBTestUtilities.h
@@ -19,6 +19,5 @@
  *  under the License.
  */
 
-
-//Macro that wraps assertion of equal values with accuracy
-#define HUBAssertEqualFloatValues(realValue, expectedValue) XCTAssertEqualWithAccuracy(realValue, expectedValue, 0.001)
+/// Assert that a CGFloat value is (approximately) equal to the expected value.
+#define HUBAssertEqualCGFloatValues(realValue, expectedValue, ...) XCTAssertEqualWithAccuracy(realValue, (CGFloat)expectedValue, (CGFloat)0.001, __VA_ARGS__)


### PR DESCRIPTION
Fix building with Xcode 8.3 and by doing so fix all 32 vs 64 bit `CGFloat` issues. The new Xcode version once again bumped into our “ignore warnings per Xcode version” hack. Instead of applying the easy fix I opted to instead fix all 32 vs 64 bit issues.

### Remove all usage of the `f` floating point suffix
The usage of the `f` suffix results in a wonkiness with `float` values either being implicitly converted to `double`s. Or in a worse scenario causing `double` values to lose precision implicitly in certain operations.

In general we should never use the floating point specifier (i.e. the `f` suffix). Unless it’s an edge case where it’s actually needed. We should let the compiler figure out which trivial type should be used.

### Fix 32 vs. 64 bit issues with CGFloat
`CGFloat` can be a bit of a pain to work with since all the functions operating on floating points are bound to `float`, `double` and variants of those. To make it better I’ve introduced a set of `HUBCGFloat` prefixed functions. These functions should make it quite a bit nicer to work with `CGFloat` while staying true to the underlying type.

Instead of type casting the functions makes sure to use the correct function as provided by the OS. Depending on whether `CGFloat` is defined as a `double` or `float`.

Adds the following functions:
- `CGFloat HUBCGFloatFloor(CGFloat)` – returns the value, rounded down.
- `CGFloat HUBCGFloatAbs(CGFloat)` – returns the absolute value.
- `CGFloat HUBCGFloatMax(CGFloat, CGFloat)` – return the maximum value.
- `CGFloat HUBCGFloatMin(CGFloat, CGFloat)` – return the minimum value.
- `BOOL HUBCGFloatFloor(CGFloat, CGFloat, CGFloat)` – tests whether two values are approximately equal (±epsilon). Caveat: it doesn’t work if one of the values is `0.0`.
- `BOOL HUBCGFloatIsZero(CGFloat)` – tests whether the given value is approximately zero (±epsilon).
  - Should be used instead of `someFloatingPoint == 0.0` since that will likely yield a different result than expected. It also triggers a new build warning in Xcode 8.3.

### Additionally
Also fixes a newly introduced warning about comparing floating point values against 0. Given that floating point values and equality checks might yield in unexpected results. Such as:

```
10.0 == 10.0 + DBL_EPSILON  [yields true]
```

Xcode now warns about this:
![screen shot 2017-02-20 at 17 53 07](https://cloud.githubusercontent.com/assets/23453/23168730/28a9ff04-f817-11e6-87ff-edeabb20c55b.png)

The PR changes all current usage of the “normal” math variants of these functions have been updated. There are still some places where casting to `CGFloat` is necessary for the code to build for both 32 and 64 bit architectures.

Furthermore it fixes the type (and name) of the test helper macro to specify that it works on `CGFloats`.

Also removes the ignored warnings. Only the tests targets need to ignore partial availability (due to Apple’s XCTest bug). We didn’t catch the issue run into with Xcode 8.3 due to it being ignored for Xcode 7.3 -> 8.2. This is no longer the case.


### Review
I’ve tested the code and ran the tests using the iPhone 7 (64 bit, iOS 10.3) and iPhone 4s (32 bit, iOS 9.3) simulators.

For review by @spotify/objc-dev please 😸 