### PR TITLE
HubViewModelRenderer: Add simple check for Header changes to diffing

### DIFF
--- a/sources/HUBViewModelDiff.h
+++ b/sources/HUBViewModelDiff.h
@@ -70,8 +70,12 @@ extern HUBViewModelDiff *HUBDiffMyersAlgorithm(id<HUBViewModel>, id<HUBViewModel
 /// The index paths of any body components that were modified in the new view model. 
 @property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *reloadedBodyComponentIndexPaths;
 
-/// A convenience property that returns YES if there are any inserts, deletes or reloads in this diff.
-@property (nonatomic, readonly) BOOL hasChanges;
+/// A convenience property that returns YES if there are any inserts, deletes or reloads in body components of this diff.
+@property (nonatomic, readonly) BOOL hasBodyChanges;
+
+/// A convenience property that returns YES if there is change in header component of this diff.
+@property (nonatomic, readonly) BOOL hasHeaderChanges;
+
 
 /**
  * Initializes a @c HUBViewModelDiff using the two view models by finding the longest common subsequence

--- a/sources/HUBViewModelDiff.h
+++ b/sources/HUBViewModelDiff.h
@@ -70,12 +70,8 @@ extern HUBViewModelDiff *HUBDiffMyersAlgorithm(id<HUBViewModel>, id<HUBViewModel
 /// The index paths of any body components that were modified in the new view model. 
 @property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *reloadedBodyComponentIndexPaths;
 
-/// A convenience property that returns YES if there are any inserts, deletes or reloads in body components of this diff.
-@property (nonatomic, readonly) BOOL hasBodyChanges;
-
-/// A convenience property that returns YES if there is change in header component of this diff.
-@property (nonatomic, readonly) BOOL hasHeaderChanges;
-
+/// A convenience property that returns YES if there are any inserts, deletes or reloads in body or header components of this diff.
+@property (nonatomic, readonly) BOOL hasChanges;
 
 /**
  * Initializes a @c HUBViewModelDiff using the two view models by finding the longest common subsequence

--- a/sources/HUBViewModelDiff.m
+++ b/sources/HUBViewModelDiff.m
@@ -75,16 +75,12 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
     return [self diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
 }
 
-- (BOOL)hasBodyChanges
+- (BOOL)hasChanges
 {
     return self.insertedBodyComponentIndexPaths.count > 0
         || self.deletedBodyComponentIndexPaths.count > 0
-        || self.reloadedBodyComponentIndexPaths.count > 0;
-}
-
-- (BOOL)hasHeaderChanges
-{
-    return self.headerComponentIdentifierHasChanged;
+        || self.reloadedBodyComponentIndexPaths.count > 0
+        || self.headerComponentIdentifierHasChanged;
 }
 
 - (void)calculateHeaderChangesFromViewModel:(id<HUBViewModel>)fromViewModel toViewModel:(id<HUBViewModel>)toViewModel

--- a/sources/HUBViewModelDiff.m
+++ b/sources/HUBViewModelDiff.m
@@ -22,7 +22,6 @@
 
 #import "HUBViewModelDiff.h"
 #import "HUBComponentModel.h"
-#import "HUBIdentifier.h"
 
 #import <UIKit/UIKit.h>
 
@@ -40,7 +39,7 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
 
 @interface  HUBViewModelDiff ()
 
-@property (nonatomic, assign) BOOL headerComponentIdentifierHasChanged;
+@property (nonatomic, assign) BOOL headerComponentHasChanged;
 
 @end
 
@@ -80,7 +79,7 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
     return self.insertedBodyComponentIndexPaths.count > 0
         || self.deletedBodyComponentIndexPaths.count > 0
         || self.reloadedBodyComponentIndexPaths.count > 0
-        || self.headerComponentIdentifierHasChanged;
+        || self.headerComponentHasChanged;
 }
 
 - (void)calculateHeaderChangesFromViewModel:(id<HUBViewModel>)fromViewModel toViewModel:(id<HUBViewModel>)toViewModel
@@ -93,7 +92,7 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
     }
 
     if (![fromHeaderModel isEqual:toHeaderModel]) {
-        self.headerComponentIdentifierHasChanged = YES;
+        self.headerComponentHasChanged = YES;
     }
 }
 
@@ -104,7 +103,7 @@ static inline NSArray<NSIndexPath *> *HUBIndexSetToIndexPathArray(NSIndexSet *in
         insertions: %@\n\
         reloads: %@\n\
         header: %d\n\
-    \t}", self.deletedBodyComponentIndexPaths, self.insertedBodyComponentIndexPaths, self.reloadedBodyComponentIndexPaths, self.headerComponentIdentifierHasChanged];
+    \t}", self.deletedBodyComponentIndexPaths, self.insertedBodyComponentIndexPaths, self.reloadedBodyComponentIndexPaths, self.headerComponentHasChanged];
 }
 
 @end

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
         diff = [HUBViewModelDiff diffFromViewModel:nonnullViewModel toViewModel:viewModel];
     }
 
-    BOOL const hasDiffChanges = (diff == nil || diff.hasBodyChanges || diff.hasHeaderChanges);
+    BOOL const hasDiffChanges = (diff == nil || diff.hasChanges);
     HUBCollectionViewLayout * const layout = (HUBCollectionViewLayout *)collectionView.collectionViewLayout;
 
     /*

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
         diff = [HUBViewModelDiff diffFromViewModel:nonnullViewModel toViewModel:viewModel];
     }
 
-    BOOL const hasDiffChanges = (diff == nil || diff.hasChanges);
+    BOOL const hasDiffChanges = (diff == nil || diff.hasBodyChanges || diff.hasHeaderChanges);
     HUBCollectionViewLayout * const layout = (HUBCollectionViewLayout *)collectionView.collectionViewLayout;
 
     /*

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -58,7 +58,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertFalse(diff.hasChanges);
+    XCTAssertFalse(diff.hasBodyChanges);
 }
 
 - (void)testInsertionsMyers
@@ -92,7 +92,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 4);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasChanges);
+    XCTAssertTrue(diff.hasBodyChanges);
 }
 
 - (void)testReloadsMyers
@@ -131,7 +131,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasChanges);
+    XCTAssertTrue(diff.hasBodyChanges);
 }
 
 - (void)testDeletionsMyers
@@ -167,7 +167,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
-    XCTAssertTrue(diff.hasChanges);
+    XCTAssertTrue(diff.hasBodyChanges);
 }
 
 - (void)testComplexChangeSetMyers
@@ -221,7 +221,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
-    XCTAssertTrue(diff.hasChanges);
+    XCTAssertTrue(diff.hasBodyChanges);
 }
 
 - (void)testInsertionOfSingleComponentModelAtStartWithDataChangesMyers
@@ -256,7 +256,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 1);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasChanges);
+    XCTAssertTrue(diff.hasBodyChanges);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
@@ -296,12 +296,67 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasChanges);
+    XCTAssertTrue(diff.hasBodyChanges);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:2 inSection:0]]);
+}
+
+#pragma mark - Header changes tests
+
+- (id<HUBViewModel>)viewModelWithHeaderComponentName:(NSString *)headerComponentIdentifierName
+{
+    HUBIdentifier * const componentIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"Test" name:headerComponentIdentifierName];
+    id<HUBComponentModel> headerComponent = [HUBViewModelUtilities createComponentModelWithIdentifier:@"header" type:HUBComponentTypeHeader componentIdentifier:componentIdentifier customData:nil];
+    id<HUBViewModel> viewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:headerComponent];
+    return viewModel;
+}
+
+- (void)testHeaderChangeIsFalseWhenFromAndToAreEmpty
+{
+    id<HUBViewModel> fromViewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:nil];
+    id<HUBViewModel> toViewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:nil];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
+    XCTAssertFalse(diff.hasHeaderChanges);
+}
+
+- (void)testHeaderChangeIsTrueWhenFromAndToAreDifferent
+{
+    id<HUBViewModel> fromViewModel = [self viewModelWithHeaderComponentName:@"I"];
+    id<HUBViewModel> toViewModel = [self viewModelWithHeaderComponentName:@"L"];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
+    XCTAssertTrue(diff.hasHeaderChanges);
+}
+
+- (void)testHeaderChangeIsFalseWhenFromAndToAreSame
+{
+    id<HUBViewModel> fromViewModel = [self viewModelWithHeaderComponentName:@"U"];
+    id<HUBViewModel> toViewModel = [self viewModelWithHeaderComponentName:@"U"];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
+    XCTAssertFalse(diff.hasHeaderChanges);
+}
+
+- (void)testHeaderChangeIsTrueWhenFromIsEmpty
+{
+    id<HUBViewModel> fromViewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:nil];
+    id<HUBViewModel> toViewModel = [self viewModelWithHeaderComponentName:@"C"];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
+    XCTAssertTrue(diff.hasHeaderChanges);
+}
+
+- (void)testHeaderChangeIsTrueWhenToIsEmpty
+{
+    id<HUBViewModel> fromViewModel = [self viewModelWithHeaderComponentName:@"T"];
+    id<HUBViewModel> toViewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:nil];
+
+    HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
+    XCTAssertTrue(diff.hasHeaderChanges);
 }
 
 @end

--- a/tests/HUBViewModelDiffTests.m
+++ b/tests/HUBViewModelDiffTests.m
@@ -58,7 +58,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertFalse(diff.hasBodyChanges);
+    XCTAssertFalse(diff.hasChanges);
 }
 
 - (void)testInsertionsMyers
@@ -92,7 +92,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 4);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasBodyChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testReloadsMyers
@@ -131,7 +131,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasBodyChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testDeletionsMyers
@@ -167,7 +167,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 0);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
-    XCTAssertTrue(diff.hasBodyChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testComplexChangeSetMyers
@@ -221,7 +221,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 2);
-    XCTAssertTrue(diff.hasBodyChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testInsertionOfSingleComponentModelAtStartWithDataChangesMyers
@@ -256,7 +256,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 1);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasBodyChanges);
+    XCTAssertTrue(diff.hasChanges);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
@@ -296,7 +296,7 @@
     XCTAssert(diff.reloadedBodyComponentIndexPaths.count == 3);
     XCTAssert(diff.insertedBodyComponentIndexPaths.count == 2);
     XCTAssert(diff.deletedBodyComponentIndexPaths.count == 0);
-    XCTAssertTrue(diff.hasBodyChanges);
+    XCTAssertTrue(diff.hasChanges);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssert([diff.insertedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:1 inSection:0]]);
     XCTAssert([diff.reloadedBodyComponentIndexPaths containsObject:[NSIndexPath indexPathForItem:0 inSection:0]]);
@@ -320,7 +320,7 @@
     id<HUBViewModel> toViewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:nil];
 
     HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
-    XCTAssertFalse(diff.hasHeaderChanges);
+    XCTAssertFalse(diff.hasChanges);
 }
 
 - (void)testHeaderChangeIsTrueWhenFromAndToAreDifferent
@@ -329,7 +329,7 @@
     id<HUBViewModel> toViewModel = [self viewModelWithHeaderComponentName:@"L"];
 
     HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
-    XCTAssertTrue(diff.hasHeaderChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testHeaderChangeIsFalseWhenFromAndToAreSame
@@ -338,7 +338,7 @@
     id<HUBViewModel> toViewModel = [self viewModelWithHeaderComponentName:@"U"];
 
     HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
-    XCTAssertFalse(diff.hasHeaderChanges);
+    XCTAssertFalse(diff.hasChanges);
 }
 
 - (void)testHeaderChangeIsTrueWhenFromIsEmpty
@@ -347,7 +347,7 @@
     id<HUBViewModel> toViewModel = [self viewModelWithHeaderComponentName:@"C"];
 
     HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
-    XCTAssertTrue(diff.hasHeaderChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 - (void)testHeaderChangeIsTrueWhenToIsEmpty
@@ -356,7 +356,7 @@
     id<HUBViewModel> toViewModel = [HUBViewModelUtilities createViewModelWithIdentifier:@"Test" bodyComponents:@[] headerComponent:nil];
 
     HUBViewModelDiff *diff = [HUBViewModelDiff diffFromViewModel:fromViewModel toViewModel:toViewModel algorithm:HUBDiffMyersAlgorithm];
-    XCTAssertTrue(diff.hasHeaderChanges);
+    XCTAssertTrue(diff.hasChanges);
 }
 
 @end

--- a/tests/utilities/HUBViewModelUtilities.h
+++ b/tests/utilities/HUBViewModelUtilities.h
@@ -21,16 +21,31 @@
 
 #import <Foundation/Foundation.h>
 
+#import "HUBComponentType.h"
+
 @protocol HUBComponentModel;
 @protocol HUBViewModel;
+@class HUBIdentifier;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBViewModelUtilities : NSObject
 
+
+/// Creates a component model with given identifier, type, component identifier and custom data
++ (id<HUBComponentModel>)createComponentModelWithIdentifier:(NSString *)identifier
+                                                       type:(HUBComponentType)type
+                                        componentIdentifier:(HUBIdentifier *)componentIdentifier
+                                                 customData:(nullable NSDictionary *)customData;
+
 /// Creates a component model with the given identifier and custom data.
 + (id<HUBComponentModel>)createComponentModelWithIdentifier:(NSString *)identifier
                                                  customData:(nullable NSDictionary *)customData;
+
+/// Creates a view model with the given identifier and body components and header component
++ (id<HUBViewModel>)createViewModelWithIdentifier:(NSString *)identifier
+                                   bodyComponents:(NSArray<id<HUBComponentModel>> *)components
+                                  headerComponent:(nullable id<HUBComponentModel>)headerComponent;
 
 /// Creates a view model with the given identifier and components.
 + (id<HUBViewModel>)createViewModelWithIdentifier:(NSString *)identifier components:(NSArray<id<HUBComponentModel>> *)components;

--- a/tests/utilities/HUBViewModelUtilities.m
+++ b/tests/utilities/HUBViewModelUtilities.m
@@ -32,11 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation HUBViewModelUtilities
 
 + (id<HUBComponentModel>)createComponentModelWithIdentifier:(NSString *)identifier
+                                                       type:(HUBComponentType)type
+                                        componentIdentifier:(HUBIdentifier *)componentIdentifier
                                                  customData:(nullable NSDictionary *)customData
 {
-    HUBIdentifier * const componentIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];
     return [[HUBComponentModelImplementation alloc] initWithIdentifier:identifier
-                                                                  type:HUBComponentTypeBody
+                                                                  type:type
                                                                  index:0
                                                        groupIdentifier:nil
                                                    componentIdentifier:componentIdentifier
@@ -56,16 +57,35 @@ NS_ASSUME_NONNULL_BEGIN
                                                                 parent:nil];
 }
 
-+ (id<HUBViewModel>)createViewModelWithIdentifier:(NSString *)identifier components:(NSArray<id<HUBComponentModel>> *)components
+
++ (id<HUBComponentModel>)createComponentModelWithIdentifier:(NSString *)identifier
+                                                 customData:(nullable NSDictionary *)customData
+{
+    HUBIdentifier * const componentIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"namespace" name:@"name"];
+    return [self createComponentModelWithIdentifier:identifier
+                                               type:HUBComponentTypeBody
+                                componentIdentifier:componentIdentifier
+                                         customData:customData];
+}
+
++ (id<HUBViewModel>)createViewModelWithIdentifier:(NSString *)identifier
+                                   bodyComponents:(NSArray<id<HUBComponentModel>> *)components
+                                  headerComponent:(nullable id<HUBComponentModel>)headerComponent
 {
     UINavigationItem * const navigationItem = [[UINavigationItem alloc] initWithTitle:@"Title"];
 
     return [[HUBViewModelImplementation alloc] initWithIdentifier:identifier
                                                    navigationItem:navigationItem
-                                             headerComponentModel:nil
+                                             headerComponentModel:headerComponent
                                               bodyComponentModels:components
                                            overlayComponentModels:@[]
                                                        customData:@{@"custom": @"data"}];
+}
+
+
++ (id<HUBViewModel>)createViewModelWithIdentifier:(NSString *)identifier components:(NSArray<id<HUBComponentModel>> *)components
+{
+    return [self createViewModelWithIdentifier:identifier bodyComponents:components headerComponent:nil];
 }
 
 @end


### PR DESCRIPTION
Account for changes of header component model.
Supplements PR https://github.com/spotify/HubFramework/pull/277 ( Don’t reload the collection view if there is nothing in the diff. )

Core of the change logic in `HubViewModelRenderer` :  "When header changes, do reload"
```objc  
BOOL const hasDiffChanges = (diff == nil || diff.hasBodyChanges || diff.hasHeaderChanges);
```

Added property `hasHeaderChanges` to HUBViewModelDiff class
Renamed property `hasChanges` to `hasBodyChanges` to be more specific
Added test cases for basic header changes
Expanded helper methods in  HUBViewModelUtilities.m to for creating header component easily