### PR TITLE
Trigger a load of images on rotation

### DIFF
--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -717,6 +717,8 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     for (HUBComponentCollectionViewCell *visibleCell in [self.collectionView visibleCells]) {
         HUBComponentWrapper * const componentWrapper = self.componentWrappersByCellIdentifier[visibleCell.identifier];
         [componentWrapper reconfigureViewWithContainerViewSize:size];
+        [self loadImagesForComponentWrapper:componentWrapper
+                                 childIndex:nil];
     }
 }
 


### PR DESCRIPTION
On rotation, we trigger a call to `[HUBComponentWrapper configureViewWithModel:containerViewSize:]`. This configures the cell to show the placeholder icon but doesn't reload the image.

Some components (e.g. the hugs carousel) will trigger a reload of images in all of its children at this point, but come components (e.g. the hugs entity card) don't. We should trigger a reload of components that support images at this point too.