### PR TITLE
Delay observing of connectivity state until after view model should be loaded

### DIFF
--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -101,8 +101,6 @@ NS_ASSUME_NONNULL_BEGIN
         _cachedInitialViewModel = initialViewModel;
         _builderSnapshots = [NSMutableDictionary new];
         _errorSnapshots = [NSMutableDictionary new];
-        
-        [connectivityStateResolver addObserver:self];
     }
     
     return self;
@@ -174,6 +172,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadViewModel
 {
+    [self.connectivityStateResolver addObserver:self];
+
     if (self.contentReloadPolicy != nil) {
         if (self.previouslyLoadedViewModel != nil) {
             id<HUBViewModel> const previouslyLoadedViewModel = self.previouslyLoadedViewModel;


### PR DESCRIPTION
If connectivity state updates before the viewmodel has been explicitly
loaded (i.e. its viewcontroller has appeared) then it might be loaded
unnecessarily at this point simply by being initialized.

Fixed by only observing connectivity after the point the view model
should be loaded.