### PR TITLE
Don’t track indexPathsByVerticalGroup

### DIFF
--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
 @property (nonatomic, strong, readonly) NSMutableDictionary<HUBIdentifier *, id<HUBComponent>> *componentCache;
 @property (nonatomic, strong, readonly) NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *layoutAttributesByIndexPath;
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSNumber *, NSMutableSet<NSIndexPath *> *> *indexPathsByVerticalGroup;
 @property (nonatomic, strong, nullable) NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *previousLayoutAttributesByIndexPath;
 @property (nonatomic, strong, nullable) HUBViewModelDiff *lastViewModelDiff;
 
@@ -60,7 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
         _componentLayoutManager = componentLayoutManager;
         _componentCache = [NSMutableDictionary new];
         _layoutAttributesByIndexPath = [NSMutableDictionary new];
-        _indexPathsByVerticalGroup = [NSMutableDictionary new];
     }
     
     return self;
@@ -77,7 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
     self.previousLayoutAttributesByIndexPath = [self.layoutAttributesByIndexPath copy];
 
     [self.layoutAttributesByIndexPath removeAllObjects];
-    [self.indexPathsByVerticalGroup removeAllObjects];
     
     BOOL componentIsInTopRow = YES;
     NSMutableArray<id<HUBComponent>> * const componentsOnCurrentRow = [NSMutableArray new];
@@ -246,17 +243,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect
 {
     NSMutableArray<UICollectionViewLayoutAttributes *> * const layoutAttributes = [NSMutableArray new];
-    
-    [self forEachVerticalGroupInRect:rect runBlock:^(NSInteger groupIndex) {
-        for (NSIndexPath * const indexPath in self.indexPathsByVerticalGroup[@(groupIndex)]) {
-            UICollectionViewLayoutAttributes * const layoutAttributesForIndexPath = [self layoutAttributesForItemAtIndexPath:indexPath];
 
-            if (layoutAttributesForIndexPath != nil) {
-                [layoutAttributes addObject:layoutAttributesForIndexPath];
-            }
+    for (UICollectionViewLayoutAttributes *attributes in self.layoutAttributesByIndexPath.allValues) {
+        if (CGRectIntersectsRect(rect, attributes.frame)) {
+            [layoutAttributes addObject:attributes];
         }
-    }];
-    
+    }
+
     return layoutAttributes;
 }
 
@@ -293,18 +286,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     return newComponent;
-}
-
-- (void)forEachVerticalGroupInRect:(CGRect)rect runBlock:(void(^)(NSInteger groupIndex))block
-{
-    CGFloat const verticalGroupSize = 100;
-    NSInteger const maxVerticalGroup = (NSInteger)(floor(CGRectGetMaxY(rect) / verticalGroupSize));
-    NSInteger currentVerticalGroup = (NSInteger)(floor(CGRectGetMinY(rect) / verticalGroupSize));
-    
-    while (currentVerticalGroup <= maxVerticalGroup) {
-        block(currentVerticalGroup);
-        currentVerticalGroup++;
-    }
 }
 
 - (UIEdgeInsets)defaultMarginsForComponent:(id<HUBComponent>)component
@@ -374,19 +355,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:(NSInteger)componentIndex inSection:0];
     UICollectionViewLayoutAttributes * const layoutAttributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
     layoutAttributes.frame = componentViewFrame;
-    self.layoutAttributesByIndexPath[indexPath] = layoutAttributes;
-    
-    [self forEachVerticalGroupInRect:componentViewFrame runBlock:^(NSInteger groupIndex) {
-        NSNumber * const encodedGroupIndex = @(groupIndex);
-        NSMutableSet<NSIndexPath *> *indexPathsInGroup = self.indexPathsByVerticalGroup[encodedGroupIndex];
-        
-        if (indexPathsInGroup == nil) {
-            indexPathsInGroup = [NSMutableSet new];
-            self.indexPathsByVerticalGroup[encodedGroupIndex] = indexPathsInGroup;
-        }
-        
-        [indexPathsInGroup addObject:indexPath];
-    }];
+    self.layoutAttributesByIndexPath[indexPath] = layoutAttributes;    
 }
 
 - (CGSize)contentSizeForContentHeight:(CGFloat)contentHeight

--- a/sources/HUBCollectionViewLayout.m
+++ b/sources/HUBCollectionViewLayout.m
@@ -355,7 +355,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSIndexPath * const indexPath = [NSIndexPath indexPathForItem:(NSInteger)componentIndex inSection:0];
     UICollectionViewLayoutAttributes * const layoutAttributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
     layoutAttributes.frame = componentViewFrame;
-    self.layoutAttributesByIndexPath[indexPath] = layoutAttributes;    
+    self.layoutAttributesByIndexPath[indexPath] = layoutAttributes;
 }
 
 - (CGSize)contentSizeForContentHeight:(CGFloat)contentHeight


### PR DESCRIPTION
The implementation of `layoutAttributesForElementsInRect:` produces several duplicates instances of `UICollectionViewLayoutAttributes`. Rewrote this implementation to just check frame intersections and in the tests that I ran, it produced exactly the same results but without duplication.

Removing this also allowed us to remove other private methods that are no longer needed. 