### PR TITLE
Delay observing of connectivity state

### DIFF
--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -101,8 +101,6 @@ NS_ASSUME_NONNULL_BEGIN
         _cachedInitialViewModel = initialViewModel;
         _builderSnapshots = [NSMutableDictionary new];
         _errorSnapshots = [NSMutableDictionary new];
-        
-        [connectivityStateResolver addObserver:self];
     }
     
     return self;
@@ -174,6 +172,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadViewModel
 {
+    [self connectivityStateResolverStateDidChange:self.connectivityStateResolver];
+    [self.connectivityStateResolver addObserver:self];
+
     if (self.contentReloadPolicy != nil) {
         if (self.previouslyLoadedViewModel != nil) {
             id<HUBViewModel> const previouslyLoadedViewModel = self.previouslyLoadedViewModel;

--- a/tests/HUBViewModelLoaderTests.m
+++ b/tests/HUBViewModelLoaderTests.m
@@ -614,6 +614,65 @@
     XCTAssertEqual(contentOperationB.performCount, 1u);
 }
 
+- (void)testConnectivityStateChangeDoesNotStartLoadingUntilRequested
+{
+    self.connectivityStateResolver.state = HUBConnectivityStateOffline;
+
+    HUBContentOperationMock * const contentOperationA = [HUBContentOperationMock new];
+    contentOperationA.initialContentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"initial"].title = @"Initial component";
+    };
+
+    HUBContentOperationMock * const contentOperationB = [HUBContentOperationMock new];
+    contentOperationB.contentLoadingBlock = ^BOOL(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"final"].title = @"Final component";
+        return YES;
+    };
+
+    [self createLoaderWithContentOperations:@[contentOperationA, contentOperationB]
+                          connectivityState:HUBConnectivityStateOffline
+                           initialViewModel:nil];
+
+    self.connectivityStateResolver.state = HUBConnectivityStateOnline;
+    [self.connectivityStateResolver callObservers];
+
+    XCTAssertEqual(contentOperationA.performCount, 0u);
+    XCTAssertEqual(contentOperationB.performCount, 0u);
+
+    [self.loader loadViewModel];
+
+    XCTAssertEqual(contentOperationA.performCount, 1u);
+    XCTAssertEqual(contentOperationB.performCount, 1u);
+}
+
+- (void)testResolveConnectivityStateWhenLoading
+{
+    self.connectivityStateResolver.state = HUBConnectivityStateOnline;
+
+    HUBContentOperationMock * const contentOperationA = [HUBContentOperationMock new];
+    contentOperationA.initialContentLoadingBlock = ^(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"initial"].title = @"Initial component";
+    };
+
+    HUBContentOperationMock * const contentOperationB = [HUBContentOperationMock new];
+    contentOperationB.contentLoadingBlock = ^BOOL(id<HUBViewModelBuilder> viewModelBuilder) {
+        [viewModelBuilder builderForBodyComponentModelWithIdentifier:@"final"].title = @"Final component";
+        return YES;
+    };
+
+    [self createLoaderWithContentOperations:@[contentOperationA, contentOperationB]
+                          connectivityState:HUBConnectivityStateOnline
+                           initialViewModel:nil];
+
+    self.connectivityStateResolver.state = HUBConnectivityStateOffline;
+    [self.connectivityStateResolver callObservers];
+
+    [self.loader loadViewModel];
+
+    XCTAssertEqual(contentOperationA.connectivityState, HUBConnectivityStateOffline);
+    XCTAssertEqual(contentOperationB.connectivityState, HUBConnectivityStateOffline);
+}
+
 - (void)testCorrectFeatureInfoSentToContentOperations
 {
     HUBContentOperationMock * const contentOperation = [HUBContentOperationMock new];


### PR DESCRIPTION
If connectivity state updates before the viewmodel has been explicitly
loaded (i.e. its viewcontroller has appeared) then it might be loaded
unnecessarily at this point simply by being initialized.

Fixed by only observing connectivity after the point the view model
should be loaded.