### PR TITLE
Remove coupling of HUBViewController and HUBViewModelLoaderImpl

### DIFF
--- a/include/HubFramework/HUBViewModelLoader.h
+++ b/include/HubFramework/HUBViewModelLoader.h
@@ -94,13 +94,23 @@ NS_ASSUME_NONNULL_BEGIN
  *  Load a view model using this loader
  *
  *  Depending on the current connectivity state (determined by the current `HUBConnectivityStateResolver`),
- *  and the configuration of the feature that his view model is serving, a combination of remote and local
+ *  and the configuration of the feature that this view model is serving, a combination of remote and local
  *  content will be loaded using the respective content operations.
  *
  *  The loader will notify its delegate once the operation was completed or if it failed.
  *  See `HUBViewModelLoaderDelegate` for more information.
  */
 - (void)loadViewModel;
+
+/**
+ *  Force a reload of the view model
+ *
+ *  This is triggered by the `reload` action of `HUBViewController`. An implementation of this
+ *  protocol should disregard any reload policy that would prevent a reload.
+ *
+ *  See `loadViewModel` for more information of view model loading.
+ */
+- (void)reloadViewModel;
 
 /**
  *  Load the next set of paginated content for the current view model this loader is for

--- a/sources/HUBViewController+Initializer.h
+++ b/sources/HUBViewController+Initializer.h
@@ -27,7 +27,7 @@
 @protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
 @protocol HUBImageLoader;
-@class HUBViewModelLoaderImplementation;
+@protocol HUBViewModelLoader;
 @class HUBCollectionViewFactory;
 @class HUBComponentReusePool;
 @class HUBViewModelRenderer;
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithViewURI:(NSURL *)viewURI
                     featureInfo:(id<HUBFeatureInfo>)featureInfo
-                viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
+                viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
               viewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(id<HUBComponentRegistry>)componentRegistry

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 >
 
 @property (nonatomic, strong, readonly) id<HUBFeatureInfo> featureInfo;
-@property (nonatomic, strong, readonly) HUBViewModelLoaderImplementation *viewModelLoader;
+@property (nonatomic, strong, readonly) id<HUBViewModelLoader> viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
 @property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
 @property (nonatomic, strong, readonly) HUBComponentReusePool *componentReusePool;
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithViewURI:(NSURL *)viewURI
                     featureInfo:(id<HUBFeatureInfo>)featureInfo
-                viewModelLoader:(HUBViewModelLoaderImplementation *)viewModelLoader
+                viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
               viewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
               componentRegistry:(id<HUBComponentRegistry>)componentRegistry
@@ -150,7 +150,9 @@ NS_ASSUME_NONNULL_BEGIN
     _bounces = YES;
     
     viewModelLoader.delegate = self;
-    viewModelLoader.actionPerformer = self;
+    if (HUBConformsToProtocol(viewModelLoader, @protocol(HUBViewModelLoaderWithActions))) {
+        ((id<HUBViewModelLoaderWithActions>)viewModelLoader).actionPerformer = self;
+    }
     imageLoader.delegate = self;
     
     self.automaticallyAdjustsScrollViewInsets = [_scrollHandler shouldAutomaticallyAdjustContentInsetsInViewController:self];
@@ -428,7 +430,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 -(void)reload
 {
-    [self.viewModelLoader loadViewModelRegardlessOfReloadPolicy];
+    [self.viewModelLoader reloadViewModel];
 }
 
 #pragma mark - Bounce control

--- a/sources/HUBViewModelLoaderImplementation.h
+++ b/sources/HUBViewModelLoaderImplementation.h
@@ -34,11 +34,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// Concrete implementation of the `HUBViewModelLoader` API
-@interface HUBViewModelLoaderImplementation : NSObject <HUBViewModelLoader>
+
+/// Protocol used for the internal `HUBViewModelLoaderImplementation` to support content operations sending actions
+@protocol HUBViewModelLoaderWithActions <HUBViewModelLoader>
 
 /// Any object that performs actions on behalf of this view model loader
 @property (nonatomic, weak, nullable) id<HUBActionPerformer> actionPerformer;
+
+@end
+
+/// Concrete implementation of the `HUBViewModelLoader` API
+@interface HUBViewModelLoaderImplementation : NSObject <HUBViewModelLoaderWithActions>
+
 
 /**
  *  Initialize an instance of this class with its required dependencies & values
@@ -72,12 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  that an action was performed.
  */
 - (void)actionPerformedWithContext:(id<HUBActionContext>)context;
-
-
-/**
- *  Load a view model using this loader regard less of reload policy
- */
-- (void)loadViewModelRegardlessOfReloadPolicy;
 
 @end
 

--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -64,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation HUBViewModelLoaderImplementation
 
 @synthesize delegate = _delegate;
+@synthesize actionPerformer = _actionPerformer;
 
 #pragma mark - Lifecycle
 
@@ -132,7 +133,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setActionPerformer:(nullable id<HUBActionPerformer>)actionPerformer
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdirect-ivar-access"
     _actionPerformer = actionPerformer;
+#pragma clang diagnostic pop
     
     for (id<HUBContentOperation> const operation in self.contentOperations) {
         if (!HUBConformsToProtocol(operation, @protocol(HUBContentOperationActionPerformer))) {
@@ -187,8 +191,9 @@ NS_ASSUME_NONNULL_BEGIN
     [self scheduleContentOperationsFromIndex:0 executionMode:HUBContentOperationExecutionModeMain];
 }
 
-- (void)loadViewModelRegardlessOfReloadPolicy
+- (void)reloadViewModel
 {
+    // Ignore reload policy and always reload
     [self scheduleContentOperationsFromIndex:0 executionMode:HUBContentOperationExecutionModeMain];
 }
 


### PR DESCRIPTION
The HUBViewController was passed a concrete implementation of HUBViewModelLoader instead of the protocol which tightly couples it to the implementation.

This allows for a separate view model loader to be implemented (or passed in by the user of the framework).

I didn't want to expose the action performer on the HUBViewModel which is why the view controller checks for conformance to an internal subprotocol to HUBViewModelLoader.