### PR TITLE
Live: Enable easier building & installation with SPM & Make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ documentation/output/
 
 # Ignore changes to our project.xcconfig that gets overridden by the build system
 project.xcconfig
+
+# Swift Package Manager
+.build

--- a/live/Makefile
+++ b/live/Makefile
@@ -1,0 +1,8 @@
+INSTALL_PATH = /usr/local/bin/hublive
+
+install:
+	swift build -c release -Xswiftc -static-stdlib
+	cp -f .build/release/hublive $(INSTALL_PATH)
+
+uninstall:
+	rm -f $(INSTALL_PATH)

--- a/live/Package.swift
+++ b/live/Package.swift
@@ -1,0 +1,3 @@
+import PackageDescription
+
+let package = Package(name: "hublive")


### PR DESCRIPTION
Hi everybody! 👋 Guess who's back? 😜

Played around a bit with Hubs & live editing again tonight, and realized we can make the command line tool for live editing a lot easier to install. This change makes `hublive` buildable using the Swift Package Manager, and installable through Make.

Instead of having users open and archive the Xcode project and manually move the built binary, `make` can now simply be run in the `live` folder, resulting in it being built using `swift build` and moved to `/usr/local/bin`.