### PR TITLE
Specify to use 2.x branch for Carthage users

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ pod update
 First, add `HubFramework` to your `Cartfile`:
 
 ```
-github "spotify/HubFramework"
+github "spotify/HubFramework" "hubframework-2.x"
 ```
 
 Then, run Carthage:


### PR DESCRIPTION
With master starting to work towards 3.x it's better for external users to use 2.x until we have a better idea for what the 3.x API will look like.

@spotify/objc-dev @cerihughes 