### PR TITLE
Copy the parameter as it has a copy attribute on the property.

### DIFF
--- a/sources/HUBFeatureRegistration.m
+++ b/sources/HUBFeatureRegistration.m
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
         _customJSONSchemaIdentifier = [customJSONSchemaIdentifier copy];
         _actionHandler = actionHandler;
         _viewControllerScrollHandler = viewControllerScrollHandler;
-        _options = options;
+        _options = [options copy];
     }
     
     return self;


### PR DESCRIPTION
Fixes some code that was introduced in https://github.com/spotify/HubFramework/pull/308 and caught in review after the merge.