### PR TITLE
Make HUBLiveService independent from HUBViewController

### DIFF
--- a/demo/sources/AppDelegate.swift
+++ b/demo/sources/AppDelegate.swift
@@ -75,11 +75,12 @@ import HubFramework
     }
     
     // MARK: - HUBLiveServiceDelegate
-    
-    func liveService(_ liveService: HUBLiveService, didCreateViewController viewController: HUBViewController) {
+    func liveService(_ liveService: HUBLiveService, didCreateContentOperation contentOperation: HUBContentOperation) {
+        let viewController = hubManager.viewControllerFactory.createViewController(withContentOperations: [contentOperation],
+                                                                                   featureTitle: "Live")
         prepareAndPush(viewController: viewController, animated: true)
     }
-    
+
     // MARK: - Private
     
     private func registerDefaultComponentFactory() {

--- a/include/HubFramework/HUBLiveService.h
+++ b/include/HubFramework/HUBLiveService.h
@@ -24,7 +24,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol HUBLiveService;
-@class HUBViewController;
+@protocol HUBContentOperation;
+
 
 /**
  *  Delegate protocol for `HUBLiveService`
@@ -35,18 +36,17 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol HUBLiveServiceDelegate
 
 /**
- *  Sent to the delegate whenever the live service created a new view controller
+ *  Sent to the delegate whenever the live service created a new content operation
  *
  *  @param liveService The live service in question
- *  @param viewController The view controller that was created
+ *  @param contentOperation The contentOperation that will feed live data
  *
- *  The live service will reuse any existing view controller if possible. The service does not
- *  retain the view controllers it creates. Whenever this method is called, you should perform
- *  any manual configuration of the view controller you wish to do, then push it onto your app's
- *  navigation stack.
+ *  The live service will reuse any existing content operation if possible. The service does not
+ *  retain the content operations it create. An implementor of this protocol should create a
+ *  view controller based on the provided content operation app's navigation stack.
  */
 - (void)liveService:(id<HUBLiveService>)liveService
-        didCreateViewController:(HUBViewController *)viewController;
+didCreateContentOperation:(id<HUBContentOperation>)contentOperation;
 
 @end
 

--- a/sources/HUBLiveServiceImplementation.h
+++ b/sources/HUBLiveServiceImplementation.h
@@ -34,13 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// The net service that the live service is using. Set up when the service is started.
 @property (nonatomic, strong, readonly, nullable) NSNetService *netService;
 
-/**
- *  Initialize an instance of this class
- *
- *  @param viewControllerFactory The factory to use to create view controllers
- */
-- (instancetype)initWithViewControllerFactory:(id<HUBViewControllerFactory>)viewControllerFactory HUB_DESIGNATED_INITIALIZER;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBLiveServiceImplementation.m
+++ b/sources/HUBLiveServiceImplementation.m
@@ -21,7 +21,6 @@
 
 #import "HUBLiveServiceImplementation.h"
 
-#import "HUBViewControllerFactory.h"
 #import "HUBLiveContentOperation.h"
 
 #if HUB_DEBUG
@@ -33,8 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite, nullable) NSNetService *netService;
 @property (nonatomic, strong, readonly) id<HUBViewControllerFactory> viewControllerFactory;
 @property (nonatomic, strong, nullable) NSInputStream *stream;
-@property (nonatomic, weak, nullable) HUBViewController *viewController;
-@property (nonatomic, strong, nullable) HUBLiveContentOperation *contentOperation;
+@property (nonatomic, weak, nullable) HUBLiveContentOperation *contentOperation;
 
 @end
 
@@ -43,19 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 @synthesize delegate = _delegate;
 
 #pragma mark - Lifecycle
-
-- (instancetype)initWithViewControllerFactory:(id<HUBViewControllerFactory>)viewControllerFactory
-{
-    NSParameterAssert(viewControllerFactory != nil);
-    
-    self = [super init];
-    
-    if (self) {
-        _viewControllerFactory = viewControllerFactory;
-    }
-    
-    return self;
-}
 
 - (void)dealloc
 {
@@ -128,24 +113,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     NSData * const data = [mutableData copy];
-    
-    if (self.viewController != nil && self.contentOperation != nil) {
-        self.contentOperation.JSONData = data;
+
+    HUBLiveContentOperation *existingContentOperation = self.contentOperation;
+    if (existingContentOperation != nil) {
+        existingContentOperation.JSONData = data;
         return;
     }
-    
-    NSURL * const viewURI = [NSURL URLWithString:@"hubframework:live"];
-    
+
     HUBLiveContentOperation * const contentOperation = [[HUBLiveContentOperation alloc] initWithJSONData:data];
     self.contentOperation = contentOperation;
-    
-    HUBViewController * const viewController = [self.viewControllerFactory createViewControllerForViewURI:viewURI
-                                                                                        contentOperations:@[contentOperation]
-                                                                                        featureIdentifier:@"live"
-                                                                                             featureTitle:@"Hub Framework Live"];
-    
-    self.viewController = viewController;
-    [self.delegate liveService:self didCreateViewController:viewController];
+
+    [self.delegate liveService:self didCreateContentOperation:contentOperation];
 }
 
 - (void)closeStream

--- a/sources/HUBManager.m
+++ b/sources/HUBManager.m
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
 #if HUB_DEBUG
     if (_liveService == nil) {
-        _liveService = [[HUBLiveServiceImplementation alloc] initWithViewControllerFactory:self.viewControllerFactory];
+        _liveService = [HUBLiveServiceImplementation new];
     }
 #endif
     


### PR DESCRIPTION
Instead of the HUBLiveService creating a view controller, have it emit a content operation and let the implementor setup and push the view controller. It makes the live service independent of the view controller and leaves the user in charge of what should be done (for example, add more content operations to the chain.

**NOTE:** This introduces a small API break in that it changes the `HUBLiveServiceDelegate` protocol. Given that this change makes sense even without the changes I'm making to the feature registry I deemed it made sense to clean this up on master even if we'll need to update the client when bumping this.

@cerihughes @spotify/objc-dev @rastersize @mumme