### PR TITLE
Always create collection view in load view

### DIFF
--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -191,9 +191,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether the view controller's content view is currently being scrolled
 @property (nonatomic, assign, readonly) BOOL isViewScrolling;
 
-/// Whether the view controller's content view should bounce when scrolled
-@property (nonatomic, assign) BOOL bounces;
-
 /// Whether the view controller's content view should allow drag vertically even if content is smaller than bounds
 @property (nonatomic, assign) BOOL alwaysBounceVertical;
 

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -92,7 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerExperimentalImplementation
 
-@synthesize bounces = _bounces;
 @synthesize alwaysBounceVertical = _alwaysBounceVertical;
 @synthesize viewModel = _viewModel;
 @synthesize viewURI = _viewURI;
@@ -141,7 +140,6 @@ NS_ASSUME_NONNULL_BEGIN
     _componentWrappersByCellIdentifier = [NSMutableDictionary new];
     _componentWrappersByModelIdentifier = [NSMutableDictionary new];
     _renderingOperationQueue = [HUBOperationQueue new];
-    _bounces = YES;
 
     viewModelLoader.delegate = self;
     if (HUBConformsToProtocol(viewModelLoader, @protocol(HUBViewModelLoaderWithActions))) {
@@ -171,6 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
     collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.bounces = YES;
     collectionView.dataSource = self;
     collectionView.delegate = self;
     [self updateCollectionViewBounceSettings];
@@ -433,15 +432,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Bounce control
 
-- (void)setBounces:(BOOL)bounces
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _bounces = bounces;
-#pragma clang diagnostic pop
-    [self updateCollectionViewBounceSettings];
-}
-
 - (void)setAlwaysBounceVertical:(BOOL)alwaysBounceVertical
 {
 #pragma clang diagnostic push
@@ -453,7 +443,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateCollectionViewBounceSettings
 {
-    self.collectionView.bounces = self.bounces;
     self.collectionView.alwaysBounceVertical = self.alwaysBounceVertical;
 }
 

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -163,9 +163,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    self.view = [[HUBContainerView alloc] initWithFrame:CGRectZero];
+    HUBContainerView *containerView = [[HUBContainerView alloc] initWithFrame:CGRectZero];
 
-    [self createCollectionViewIfNeeded];
+    HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
+    self.collectionView = collectionView;
+    collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
+    collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
+    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
+    collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.dataSource = self;
+    collectionView.delegate = self;
+    [self updateCollectionViewBounceSettings];
+
+    self.lastContentOffset = self.collectionView.contentOffset;
+
+    containerView.collectionView = self.collectionView;
+    self.view = containerView;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -188,7 +201,6 @@ NS_ASSUME_NONNULL_BEGIN
         self.viewModel = self.viewModelLoader.initialViewModel;
     }
 
-    [self createCollectionViewIfNeeded];
     [self.viewModelLoader loadViewModel];
 
     for (NSIndexPath * const indexPath in self.collectionView.indexPathsForVisibleItems) {
@@ -906,29 +918,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 }
 
 #pragma mark - Private utilities
-
-- (void)createCollectionViewIfNeeded
-{
-    if (self.collectionView != nil) {
-        return;
-    }
-
-    HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
-    self.collectionView = collectionView;
-    collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
-    collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
-    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
-    collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
-    collectionView.dataSource = self;
-    collectionView.delegate = self;
-    [self updateCollectionViewBounceSettings];
-
-    self.lastContentOffset = self.collectionView.contentOffset;
-
-    HUBContainerView *containerView = (HUBContainerView *)self.view;
-    containerView.collectionView = self.collectionView;
-}
-
 
 - (HUBOperation *)createReloadCollectionViewOperation
 {

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -93,7 +93,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerImplementation
 
-@synthesize bounces = _bounces;
 @synthesize alwaysBounceVertical = _alwaysBounceVertical;
 @synthesize viewModel = _viewModel;
 @synthesize viewURI = _viewURI;
@@ -145,7 +144,6 @@ NS_ASSUME_NONNULL_BEGIN
     _componentWrappersByCellIdentifier = [NSMutableDictionary new];
     _componentWrappersByModelIdentifier = [NSMutableDictionary new];
     _renderingOperationQueue = [HUBOperationQueue new];
-    _bounces = YES;
 
     viewModelLoader.delegate = self;
     if (HUBConformsToProtocol(viewModelLoader, @protocol(HUBViewModelLoaderWithActions))) {
@@ -175,6 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
     collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.bounces = YES;
     collectionView.dataSource = self;
     collectionView.delegate = self;
     [self updateCollectionViewBounceSettings];
@@ -444,15 +443,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Bounce control
 
-- (void)setBounces:(BOOL)bounces
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _bounces = bounces;
-#pragma clang diagnostic pop
-    [self updateCollectionViewBounceSettings];
-}
-
 - (void)setAlwaysBounceVertical:(BOOL)alwaysBounceVertical
 {
 #pragma clang diagnostic push
@@ -464,7 +454,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateCollectionViewBounceSettings
 {
-    self.collectionView.bounces = self.bounces;
     self.collectionView.alwaysBounceVertical = self.alwaysBounceVertical;
 }
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -167,9 +167,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    self.view = [[HUBContainerView alloc] initWithFrame:CGRectZero];
+    HUBContainerView *containerView = [[HUBContainerView alloc] initWithFrame:CGRectZero];
 
-    [self createCollectionViewIfNeeded];
+    HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
+    self.collectionView = collectionView;
+    collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
+    collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
+    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
+    collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.dataSource = self;
+    collectionView.delegate = self;
+    [self updateCollectionViewBounceSettings];
+
+    self.lastContentOffset = self.collectionView.contentOffset;
+
+    containerView.collectionView = self.collectionView;
+    self.view = containerView;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -192,7 +205,6 @@ NS_ASSUME_NONNULL_BEGIN
         self.viewModel = self.viewModelLoader.initialViewModel;
     }
 
-    [self createCollectionViewIfNeeded];
     [self.viewModelLoader loadViewModel];
 
     for (NSIndexPath * const indexPath in self.collectionView.indexPathsForVisibleItems) {
@@ -868,29 +880,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 }
 
 #pragma mark - Private utilities
-
-- (void)createCollectionViewIfNeeded
-{
-    if (self.collectionView != nil) {
-        return;
-    }
-
-    HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
-    self.collectionView = collectionView;
-    collectionView.showsVerticalScrollIndicator = [self.scrollHandler shouldShowScrollIndicatorsInViewController:self];
-    collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
-    collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
-    collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
-    collectionView.dataSource = self;
-    collectionView.delegate = self;
-    [self updateCollectionViewBounceSettings];
-
-    self.lastContentOffset = self.collectionView.contentOffset;
-
-    HUBContainerView *containerView = (HUBContainerView *)self.view;
-    containerView.collectionView = self.collectionView;
-}
-
 
 - (HUBOperation *)createReloadCollectionViewOperation
 {

--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -2310,28 +2310,10 @@
     XCTAssertFalse(self.collectionView.alwaysBounceVertical);
 }
 
-- (void)testSettingBounces
-{
-    [self simulateViewControllerLayoutCycle];
-
-    self.viewController.bounces = NO;
-    XCTAssertFalse(self.collectionView.bounces);
-    self.viewController.bounces = YES;
-    XCTAssertTrue(self.collectionView.bounces);
-}
-
 - (void)testEnablingBouncesBeforeLoadingView
 {
-    self.viewController.bounces = YES;
     [self simulateViewControllerLayoutCycle];
     XCTAssertTrue(self.collectionView.bounces);
-}
-
-- (void)testDisablingBouncesBeforeLoadingView
-{
-    self.viewController.bounces = NO;
-    [self simulateViewControllerLayoutCycle];
-    XCTAssertFalse(self.collectionView.bounces);
 }
 
 - (void)testFrameForBodyComponentAtIndex


### PR DESCRIPTION
We removed the code that released the collection view on low memory. It makes sense to have a single point of creation for the view again as it simplifies the VC.

I've also removed the configuration of the `bounce` property. It's currently never set to anything other than the default. I'll work on a PR that exposes the view through the API, so clients can set things directly on the view in future - this will mean that we don't have to write so much "pass through" code.