### PR TITLE
Expose container view through API

### DIFF
--- a/HubFramework.xcodeproj/project.pbxproj
+++ b/HubFramework.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		652382BE1E7A9B3900B99784 /* HUBComponentWrapperImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 652382BB1E7A9B3900B99784 /* HUBComponentWrapperImageLoader.m */; };
 		655664051E7C08F8000C4B60 /* HUBComponentWrapperImageLoaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 655664041E7C08F8000C4B60 /* HUBComponentWrapperImageLoaderTests.m */; };
 		655664061E7C08F8000C4B60 /* HUBComponentWrapperImageLoaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 655664041E7C08F8000C4B60 /* HUBComponentWrapperImageLoaderTests.m */; };
+		6563FF481E97A4D000070763 /* HUBCollectionContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6563FF471E97A4D000070763 /* HUBCollectionContainerView.m */; };
+		6563FF491E97A4D000070763 /* HUBCollectionContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6563FF471E97A4D000070763 /* HUBCollectionContainerView.m */; };
+		6563FF4B1E97A7EB00070763 /* HUBContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 6563FF4A1E97A4F200070763 /* HUBContainerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6584D58A1E82BBA10042666A /* HUBViewControllerImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = 6584D5881E82BBA10042666A /* HUBViewControllerImplementation.h */; };
 		6584D58B1E82BBA10042666A /* HUBViewControllerImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6584D5891E82BBA10042666A /* HUBViewControllerImplementation.m */; };
 		6584D58C1E82BBA10042666A /* HUBViewControllerImplementation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6584D5891E82BBA10042666A /* HUBViewControllerImplementation.m */; };
@@ -354,7 +357,7 @@
 		8AE6C09B1DF6E4020063B2B1 /* HUBCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AFF0F981C85C73300D5535B /* HUBCollectionViewLayout.h */; };
 		8AE6C09C1DF6E4020063B2B1 /* HUBCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */; };
 		8AE6C09D1DF6E4020063B2B1 /* HUBViewURIPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A0E4B791CB562140019DE71 /* HUBViewURIPredicate.m */; };
-		8AE6C09E1DF6E4020063B2B1 /* HUBContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD009FC1CC64EF80012A9AF /* HUBContainerView.h */; };
+		8AE6C09E1DF6E4020063B2B1 /* HUBCollectionContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AD009FC1CC64EF80012A9AF /* HUBCollectionContainerView.h */; };
 		8AE6C09F1DF6E4020063B2B1 /* HUBContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD009FD1CC64EF80012A9AF /* HUBContainerView.m */; };
 		8AE6C0A11DF6E4020063B2B1 /* HUBViewControllerDefaultScrollHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEDA0991D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.m */; };
 		8AE6C0A21DF6E4020063B2B1 /* HUBViewModelDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = F66658D71D9925CC0097929F /* HUBViewModelDiff.h */; };
@@ -532,6 +535,8 @@
 		652382BA1E7A9B3900B99784 /* HUBComponentWrapperImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBComponentWrapperImageLoader.h; sourceTree = "<group>"; };
 		652382BB1E7A9B3900B99784 /* HUBComponentWrapperImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentWrapperImageLoader.m; sourceTree = "<group>"; };
 		655664041E7C08F8000C4B60 /* HUBComponentWrapperImageLoaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBComponentWrapperImageLoaderTests.m; sourceTree = "<group>"; };
+		6563FF471E97A4D000070763 /* HUBCollectionContainerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBCollectionContainerView.m; sourceTree = "<group>"; };
+		6563FF4A1E97A4F200070763 /* HUBContainerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBContainerView.h; sourceTree = "<group>"; };
 		6584D5881E82BBA10042666A /* HUBViewControllerImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerImplementation.h; sourceTree = "<group>"; };
 		6584D5891E82BBA10042666A /* HUBViewControllerImplementation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewControllerImplementation.m; sourceTree = "<group>"; };
 		6584D6281E82C6A30042666A /* HUBViewControllerExperimentalImplementation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBViewControllerExperimentalImplementation.h; sourceTree = "<group>"; };
@@ -722,7 +727,7 @@
 		8ACB2A791C6A2F7C000741D7 /* HUBIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBIdentifier.m; sourceTree = "<group>"; };
 		8ACB2A7B1C6A2F99000741D7 /* HUBIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBIdentifierTests.m; sourceTree = "<group>"; };
 		8ACE24C61C6B650B0036240A /* HUBViewControllerFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBViewControllerFactoryTests.m; sourceTree = "<group>"; };
-		8AD009FC1CC64EF80012A9AF /* HUBContainerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBContainerView.h; sourceTree = "<group>"; };
+		8AD009FC1CC64EF80012A9AF /* HUBCollectionContainerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HUBCollectionContainerView.h; sourceTree = "<group>"; };
 		8AD009FD1CC64EF80012A9AF /* HUBContainerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HUBContainerView.m; sourceTree = "<group>"; };
 		8AD00A051CC777EC0012A9AF /* HUBIconImageResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBIconImageResolver.h; sourceTree = "<group>"; };
 		8AD00A061CC77BD90012A9AF /* HUBIcon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HUBIcon.h; sourceTree = "<group>"; };
@@ -1125,7 +1130,6 @@
 			children = (
 				8A5D7A6C1CBD0F0D00B987BA /* HUBComponentDefaults+Testing.h */,
 				8A5D7A6D1CBD0F0D00B987BA /* HUBComponentDefaults+Testing.m */,
-				4E29FCF31DED2D9600856D20 /* HUBTestUtilities.h */,
 				6500561E1DF98B89006D957C /* HUBViewModelUtilities.h */,
 				6500561F1DF98B89006D957C /* HUBViewModelUtilities.m */,
 				8AC315821DED94790093AEA0 /* UIViewController+HUBSimulateLayoutCycle.h */,
@@ -1573,6 +1577,7 @@
 				8AD064761C69069A0086C081 /* HUBViewModelLoaderFactory.h */,
 				8A786B911C57D53600B2AB9E /* HUBViewModelBuilder.h */,
 				8A9CA05F1DDDD3230070258F /* HUBViewController.h */,
+				6563FF4A1E97A4F200070763 /* HUBContainerView.h */,
 				8AD064771C6906B00086C081 /* HUBViewControllerFactory.h */,
 				9902B7291E7C062900823187 /* HUBConfigViewControllerFactory.h */,
 				8A0E4B761CB561DE0019DE71 /* HUBViewURIPredicate.h */,
@@ -1614,8 +1619,9 @@
 				8AFF0F981C85C73300D5535B /* HUBCollectionViewLayout.h */,
 				8AFF0F991C85C73300D5535B /* HUBCollectionViewLayout.m */,
 				8A0E4B791CB562140019DE71 /* HUBViewURIPredicate.m */,
-				8AD009FC1CC64EF80012A9AF /* HUBContainerView.h */,
 				8AD009FD1CC64EF80012A9AF /* HUBContainerView.m */,
+				8AD009FC1CC64EF80012A9AF /* HUBCollectionContainerView.h */,
+				6563FF471E97A4D000070763 /* HUBCollectionContainerView.m */,
 				8AEDA0991D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.m */,
 				F66658D71D9925CC0097929F /* HUBViewModelDiff.h */,
 				F66658D81D9925CC0097929F /* HUBViewModelDiff.m */,
@@ -1730,6 +1736,7 @@
 				8AE6C0C71DF6E4100063B2B1 /* HUBDefaultImageLoader.h in Headers */,
 				8AE6C0891DF6E4020063B2B1 /* HUBViewModelImplementation.h in Headers */,
 				8AE6C0B01DF6E40D0063B2B1 /* HUBComponentImageDataImplementation.h in Headers */,
+				6563FF4B1E97A7EB00070763 /* HUBContainerView.h in Headers */,
 				8AE6C06B1DF6E3F90063B2B1 /* HUBComponentImageDataJSONSchemaImplementation.h in Headers */,
 				8AE6C0731DF6E3F90063B2B1 /* HUBMutableJSONPathImplementation.h in Headers */,
 				8AE6C0221DF6E3C40063B2B1 /* HUBFeatureRegistry.h in Headers */,
@@ -1770,7 +1777,7 @@
 				8AE6C01D1DF6E3BE0063B2B1 /* HUBComponentTargetJSONSchema.h in Headers */,
 				8AE6C0D11DF6E4140063B2B1 /* HUBActionHandlerWrapper.h in Headers */,
 				8AE6C0B21DF6E40D0063B2B1 /* HUBComponentImageDataBuilderImplementation.h in Headers */,
-				8AE6C09E1DF6E4020063B2B1 /* HUBContainerView.h in Headers */,
+				8AE6C09E1DF6E4020063B2B1 /* HUBCollectionContainerView.h in Headers */,
 				9902B7461E82746E00823187 /* HUBJSONSchemaFactory.h in Headers */,
 				8AE6C0401DF6E3D40063B2B1 /* HUBComponentCollectionViewCell.h in Headers */,
 				8AE6C0581DF6E3E00063B2B1 /* HUBActionFactory.h in Headers */,
@@ -1970,6 +1977,7 @@
 				F66658D91D9925CC0097929F /* HUBViewModelDiff.m in Sources */,
 				8AEDA09A1D7710A300BEFD66 /* HUBViewControllerDefaultScrollHandler.m in Sources */,
 				521891EA1DEE3E4500FA3BF7 /* HUBContentOperationContextImplementation.m in Sources */,
+				6563FF481E97A4D000070763 /* HUBCollectionContainerView.m in Sources */,
 				521891E61DEE3C6E00FA3BF7 /* HUBBlockContentOperation.m in Sources */,
 				8ACB2A7A1C6A2F7C000741D7 /* HUBIdentifier.m in Sources */,
 				8A786BB81C5A4CB400B2AB9E /* HUBMutableJSONPathImplementation.m in Sources */,
@@ -2207,6 +2215,7 @@
 				8AE6C0CC1DF6E4100063B2B1 /* HUBIconImplementation.m in Sources */,
 				8AE6C07E1DF6E4020063B2B1 /* HUBFeatureInfoImplementation.m in Sources */,
 				8AE6C0CA1DF6E4100063B2B1 /* HUBComponentImageLoadingContext.m in Sources */,
+				6563FF491E97A4D000070763 /* HUBCollectionContainerView.m in Sources */,
 				8AE6C0C41DF6E40D0063B2B1 /* HUBComponentGestureRecognizer.m in Sources */,
 				8AE6C0A51DF6E40D0063B2B1 /* HUBComponentDefaults.m in Sources */,
 				8AE6C06A1DF6E3F90063B2B1 /* HUBComponentModelJSONSchemaImplementation.m in Sources */,

--- a/demo/sources/AppDelegate.swift
+++ b/demo/sources/AppDelegate.swift
@@ -199,7 +199,7 @@ import HubFramework
     private func prepareAndPush(viewController: HUBViewController, animated: Bool) {
         viewController.delegate = navigationController
         viewController.view.backgroundColor = .white
-        viewController.alwaysBounceVertical = (viewController.viewURI == URL.gitHubSearchViewURI)
+        viewController.view.contentView?.alwaysBounceVertical = (viewController.viewURI == URL.gitHubSearchViewURI)
         navigationController?.pushViewController(viewController, animated: animated)
     }
 }

--- a/include/HubFramework/HUBContainerView.h
+++ b/include/HubFramework/HUBContainerView.h
@@ -26,8 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// View that acts as a container view for a Hub Framework view controller
 @interface HUBContainerView : UIView
 
-///The content view of this container.
+/// The content view of this container.
 @property (nonatomic, strong, readonly, nullable) UIScrollView *contentView;
+
+/// A convenience getter to determine if the content view is scrolling.
+@property (nonatomic, readonly, getter=isContentViewScrolling) BOOL contentViewScrolling;
 
 @end
 

--- a/include/HubFramework/HUBContainerView.h
+++ b/include/HubFramework/HUBContainerView.h
@@ -19,11 +19,15 @@
  *  under the License.
  */
 
-#import "HUBContainerView.h"
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation HUBContainerView
+/// View that acts as a container view for a Hub Framework view controller
+@interface HUBContainerView : UIView
+
+///The content view of this container.
+@property (nonatomic, strong, readonly, nullable) UIScrollView *contentView;
 
 @end
 

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, nullable) id<HUBViewControllerDelegate> delegate;
 
 /// Redeclare the view property to be a HUBContainerView.
-@property(null_resettable, nonatomic, strong) HUBContainerView *view;
+@property (null_resettable, nonatomic, strong) HUBContainerView *view;
 
 /// The identifier of the feature that this view controller belongs to
 @property (nonatomic, copy, readonly) NSString *featureIdentifier;

--- a/include/HubFramework/HUBViewController.h
+++ b/include/HubFramework/HUBViewController.h
@@ -22,6 +22,7 @@
 #import "HUBHeaderMacros.h"
 #import "HUBComponentLayoutTraits.h"
 #import "HUBComponentType.h"
+#import "HUBContainerView.h"
 #import "HUBScrollPosition.h"
 #import "HUBActionPerformer.h"
 
@@ -174,6 +175,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The view controller's delegate. See `HUBViewControllerDelegate` for more information.
 @property (nonatomic, weak, nullable) id<HUBViewControllerDelegate> delegate;
 
+/// Redeclare the view property to be a HUBContainerView.
+@property(null_resettable, nonatomic, strong) HUBContainerView *view;
+
 /// The identifier of the feature that this view controller belongs to
 @property (nonatomic, copy, readonly) NSString *featureIdentifier;
 
@@ -187,12 +191,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  method. You can also use `-viewControllerDidUpdate`, which gets called once a new view model has been assigned.
  */
 @property (nonatomic, nullable, readonly) id<HUBViewModel> viewModel;
-
-/// Whether the view controller's content view is currently being scrolled
-@property (nonatomic, assign, readonly) BOOL isViewScrolling;
-
-/// Whether the view controller's content view should allow drag vertically even if content is smaller than bounds
-@property (nonatomic, assign) BOOL alwaysBounceVertical;
 
 /**
  *  Return the frame used to render a body component at a given index

--- a/include/HubFramework/HubFramework.h
+++ b/include/HubFramework/HubFramework.h
@@ -60,6 +60,7 @@
 #import "HUBViewModelLoader.h"
 #import "HUBViewModelLoaderFactory.h"
 #import "HUBViewModelBuilder.h"
+#import "HUBContainerView.h"
 #import "HUBViewControllerFactory.h"
 #import "HUBViewController.h"
 #import "HUBViewControllerScrollHandler.h"

--- a/sources/HUBCollectionContainerView.h
+++ b/sources/HUBCollectionContainerView.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface HUBCollectionContainerView : HUBContainerView
 
 /**
- *  Redefine the content view property to be a UICollectionView, and makde it readwrite for internal use.
+ *  Redefine the content view property to be a UICollectionView, and make it readwrite for internal use.
  *
  *  When a collectionView is set it's also added as a subview, and its pan gesture
  *  recognizer is added to this view.

--- a/sources/HUBCollectionContainerView.h
+++ b/sources/HUBCollectionContainerView.h
@@ -23,7 +23,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation HUBContainerView
+/// A collection view-based implementation of the container view.
+@interface HUBCollectionContainerView : HUBContainerView
+
+/**
+ *  Redefine the container view property to be a UICollectionView, and makde it readwrite for internal use.
+ *
+ *  When a collectionView is set it's also added as a subview, and its pan gesture
+ *  recognizer is added to this view.
+ */
+@property (nonatomic, strong, readwrite, nullable) UICollectionView *containerView;
 
 @end
 

--- a/sources/HUBCollectionContainerView.h
+++ b/sources/HUBCollectionContainerView.h
@@ -27,12 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface HUBCollectionContainerView : HUBContainerView
 
 /**
- *  Redefine the container view property to be a UICollectionView, and makde it readwrite for internal use.
+ *  Redefine the content view property to be a UICollectionView, and makde it readwrite for internal use.
  *
  *  When a collectionView is set it's also added as a subview, and its pan gesture
  *  recognizer is added to this view.
  */
-@property (nonatomic, strong, readwrite, nullable) UICollectionView *containerView;
+@property (nonatomic, strong, readwrite, nullable) UICollectionView *contentView;
 
 @end
 

--- a/sources/HUBCollectionContainerView.m
+++ b/sources/HUBCollectionContainerView.m
@@ -19,20 +19,35 @@
  *  under the License.
  */
 
-#import <UIKit/UIKit.h>
+#import "HUBCollectionContainerView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/// View that acts as a container view for a Hub Framework view controller
-@interface HUBContainerView : UIView
+@implementation HUBCollectionContainerView
 
-/**
- *  Collection view contained by the container.
- *
- *  When a collectionView is set it's also added as a subview, and its pan gesture
- *  recognizer is added to this view.
- */
-@property (nonatomic, strong, nullable) UICollectionView *collectionView;
+- (void)setContainerView:(nullable UICollectionView *)containerView
+{
+    if (_containerView == containerView) {
+        return;
+    }
+
+    [_containerView removeFromSuperview];
+    _containerView = nil;
+
+    if (containerView != nil) {
+        UICollectionView * const nonNilContainerView = containerView;
+        _containerView = nonNilContainerView;
+        [self insertSubview:nonNilContainerView atIndex:0];
+        [self addGestureRecognizer:nonNilContainerView.panGestureRecognizer];
+    }
+}
+
+- (void)setBackgroundColor:(nullable UIColor *)backgroundColor
+{
+    [super setBackgroundColor:backgroundColor];
+
+    self.containerView.backgroundColor = backgroundColor;
+}
 
 @end
 

--- a/sources/HUBCollectionContainerView.m
+++ b/sources/HUBCollectionContainerView.m
@@ -25,20 +25,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBCollectionContainerView
 
-- (void)setContainerView:(nullable UICollectionView *)containerView
+@synthesize contentView = _contentView;
+
+- (void)setContentView:(nullable UICollectionView *)contentView
 {
-    if (_containerView == containerView) {
+    if (_contentView == contentView) {
         return;
     }
 
-    [_containerView removeFromSuperview];
-    _containerView = nil;
+    [_contentView removeFromSuperview];
+    _contentView = nil;
 
-    if (containerView != nil) {
-        UICollectionView * const nonNilContainerView = containerView;
-        _containerView = nonNilContainerView;
-        [self insertSubview:nonNilContainerView atIndex:0];
-        [self addGestureRecognizer:nonNilContainerView.panGestureRecognizer];
+    if (contentView != nil) {
+        UICollectionView * const nonNilContentView = contentView;
+        _contentView = nonNilContentView;
+        [self insertSubview:nonNilContentView atIndex:0];
+        [self addGestureRecognizer:nonNilContentView.panGestureRecognizer];
     }
 }
 
@@ -46,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     [super setBackgroundColor:backgroundColor];
 
-    self.containerView.backgroundColor = backgroundColor;
+    self.contentView.backgroundColor = backgroundColor;
 }
 
 @end

--- a/sources/HUBContainerView.m
+++ b/sources/HUBContainerView.m
@@ -25,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBContainerView
 
+- (BOOL)isContentViewScrolling
+{
+    return self.contentView.isDragging || self.contentView.isDecelerating;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sources/HUBViewController.m
+++ b/sources/HUBViewController.m
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewController
 
+@dynamic view;
+
 - (NSDictionary<NSIndexPath *, UIView *> *)visibleComponentViewsForComponentType:(HUBComponentType)componentType
 {
     return @{};

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -39,7 +39,7 @@
 #import "HUBCollectionViewFactory.h"
 #import "HUBCollectionView.h"
 #import "HUBCollectionViewLayout.h"
-#import "HUBContainerView.h"
+#import "HUBCollectionContainerView.h"
 #import "HUBContentReloadPolicy.h"
 #import "HUBViewControllerScrollHandler.h"
 #import "HUBComponentReusePool.h"
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    HUBContainerView *containerView = [[HUBContainerView alloc] initWithFrame:CGRectZero];
+    HUBCollectionContainerView *containerView = [[HUBCollectionContainerView alloc] initWithFrame:CGRectZero];
 
     HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
     self.collectionView = collectionView;
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.lastContentOffset = self.collectionView.contentOffset;
 
-    containerView.collectionView = self.collectionView;
+    containerView.containerView = self.collectionView;
     self.view = containerView;
 }
 

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.lastContentOffset = self.collectionView.contentOffset;
 
-    containerView.containerView = self.collectionView;
+    containerView.contentView = self.collectionView;
     self.view = containerView;
 }
 

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -160,7 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    HUBCollectionContainerView *containerView = [[HUBCollectionContainerView alloc] initWithFrame:CGRectZero];
+    HUBCollectionContainerView * const containerView = [[HUBCollectionContainerView alloc] initWithFrame:CGRectZero];
 
     HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
     self.collectionView = collectionView;

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -92,7 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerExperimentalImplementation
 
-@synthesize alwaysBounceVertical = _alwaysBounceVertical;
 @synthesize viewModel = _viewModel;
 @synthesize viewURI = _viewURI;
 
@@ -172,7 +171,6 @@ NS_ASSUME_NONNULL_BEGIN
     collectionView.bounces = YES;
     collectionView.dataSource = self;
     collectionView.delegate = self;
-    [self updateCollectionViewBounceSettings];
 
     self.lastContentOffset = self.collectionView.contentOffset;
 
@@ -253,11 +251,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)featureIdentifier
 {
     return self.featureInfo.identifier;
-}
-
-- (BOOL)isViewScrolling
-{
-    return self.collectionView.isDragging || self.collectionView.isDecelerating;
 }
 
 - (NSDictionary<NSIndexPath *, UIView *> *)visibleComponentViewsForComponentType:(HUBComponentType)componentType
@@ -428,22 +421,6 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)reload
 {
     [self.viewModelLoader reloadViewModel];
-}
-
-#pragma mark - Bounce control
-
-- (void)setAlwaysBounceVertical:(BOOL)alwaysBounceVertical
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _alwaysBounceVertical = alwaysBounceVertical;
-#pragma clang diagnostic pop
-    [self updateCollectionViewBounceSettings];
-}
-
-- (void)updateCollectionViewBounceSettings
-{
-    self.collectionView.alwaysBounceVertical = self.alwaysBounceVertical;
 }
 
 #pragma mark - HUBViewModelLoaderDelegate

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.lastContentOffset = self.collectionView.contentOffset;
 
-    containerView.containerView = self.collectionView;
+    containerView.contentView = self.collectionView;
     self.view = containerView;
 }
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -39,7 +39,7 @@
 #import "HUBCollectionViewFactory.h"
 #import "HUBCollectionView.h"
 #import "HUBCollectionViewLayout.h"
-#import "HUBContainerView.h"
+#import "HUBCollectionContainerView.h"
 #import "HUBContentReloadPolicy.h"
 #import "HUBViewControllerScrollHandler.h"
 #import "HUBComponentReusePool.h"
@@ -165,7 +165,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    HUBContainerView *containerView = [[HUBContainerView alloc] initWithFrame:CGRectZero];
+    HUBCollectionContainerView *containerView = [[HUBCollectionContainerView alloc] initWithFrame:CGRectZero];
 
     HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
     self.collectionView = collectionView;
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.lastContentOffset = self.collectionView.contentOffset;
 
-    containerView.collectionView = self.collectionView;
+    containerView.containerView = self.collectionView;
     self.view = containerView;
 }
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -164,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadView
 {
-    HUBCollectionContainerView *containerView = [[HUBCollectionContainerView alloc] initWithFrame:CGRectZero];
+    HUBCollectionContainerView * const containerView = [[HUBCollectionContainerView alloc] initWithFrame:CGRectZero];
 
     HUBCollectionView * const collectionView = [self.collectionViewFactory createCollectionView];
     self.collectionView = collectionView;

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -93,7 +93,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBViewControllerImplementation
 
-@synthesize alwaysBounceVertical = _alwaysBounceVertical;
 @synthesize viewModel = _viewModel;
 @synthesize viewURI = _viewURI;
 
@@ -176,7 +175,6 @@ NS_ASSUME_NONNULL_BEGIN
     collectionView.bounces = YES;
     collectionView.dataSource = self;
     collectionView.delegate = self;
-    [self updateCollectionViewBounceSettings];
 
     self.lastContentOffset = self.collectionView.contentOffset;
 
@@ -264,11 +262,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)featureIdentifier
 {
     return self.featureInfo.identifier;
-}
-
-- (BOOL)isViewScrolling
-{
-    return self.collectionView.isDragging || self.collectionView.isDecelerating;
 }
 
 - (NSDictionary<NSIndexPath *, UIView *> *)visibleComponentViewsForComponentType:(HUBComponentType)componentType
@@ -439,22 +432,6 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)reload
 {
     [self.viewModelLoader reloadViewModel];
-}
-
-#pragma mark - Bounce control
-
-- (void)setAlwaysBounceVertical:(BOOL)alwaysBounceVertical
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdirect-ivar-access"
-    _alwaysBounceVertical = alwaysBounceVertical;
-#pragma clang diagnostic pop
-    [self updateCollectionViewBounceSettings];
-}
-
-- (void)updateCollectionViewBounceSettings
-{
-    self.collectionView.alwaysBounceVertical = self.alwaysBounceVertical;
 }
 
 #pragma mark - HUBViewModelLoaderDelegate

--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -2277,45 +2277,6 @@
     HUBAssertEqualCGFloatValues(targetContentOffset.y, 500);
 }
 
-- (void)testIsViewScrolling
-{
-    [self simulateViewControllerLayoutCycle];
-    
-    XCTAssertFalse(self.viewController.isViewScrolling);
-    self.collectionView.mockedIsDragging = YES;
-    XCTAssertTrue(self.viewController.isViewScrolling);
-}
-
-- (void)testSettingAlwaysBounceVertically
-{
-    [self simulateViewControllerLayoutCycle];
-
-    self.viewController.alwaysBounceVertical = YES;
-    XCTAssertTrue(self.collectionView.alwaysBounceVertical);
-    self.viewController.alwaysBounceVertical = NO;
-    XCTAssertFalse(self.collectionView.alwaysBounceVertical);
-}
-
-- (void)testEnablingAlwaysBounceVerticallyBeforeLoadingView
-{
-    self.viewController.alwaysBounceVertical = YES;
-    [self simulateViewControllerLayoutCycle];
-    XCTAssertTrue(self.collectionView.alwaysBounceVertical);
-}
-
-- (void)testDisablingAlwaysBounceVerticallyBeforeLoadingView
-{
-    self.viewController.alwaysBounceVertical = NO;
-    [self simulateViewControllerLayoutCycle];
-    XCTAssertFalse(self.collectionView.alwaysBounceVertical);
-}
-
-- (void)testEnablingBouncesBeforeLoadingView
-{
-    [self simulateViewControllerLayoutCycle];
-    XCTAssertTrue(self.collectionView.bounces);
-}
-
 - (void)testFrameForBodyComponentAtIndex
 {
     HUBComponentMock * const componentA = [HUBComponentMock new];


### PR DESCRIPTION
This PR:

- Simplifies the `HUBContainerView` API to just declare a "content view" as a `readonly` `UIScrollView`
- Exposes `HUBContainerView` through the public API via the `HUBViewController`
- Takes all `UIScrollView`-specific pass-through logic out of the VCs. Clients should directly modify the the view's contentView now.
- Internally, we use `HUBCollectionContainerView` as the `UICollectionView`-specific subclass of `HUBContainerView`. We can move more `UICollectionView`-specific code into this subclass in future PRs.

Note: This is an API breaking change.