### PR TITLE
Move layout logic into the collection view factory

### DIFF
--- a/sources/HUBCollectionViewFactory.h
+++ b/sources/HUBCollectionViewFactory.h
@@ -19,7 +19,11 @@
  *  under the License.
  */
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import "HUBHeaderMacros.h"
+
+@protocol HUBComponentLayoutManager;
+@protocol HUBComponentRegistry;
 
 @class HUBCollectionView;
 
@@ -27,6 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Factory used to create collection views for use in a `HUBViewController`
 @interface HUBCollectionViewFactory : NSObject
+
+/**
+ Designated initializer.
+
+ @param componentRegistry The registry to use to lookup component information
+ @param componentLayoutManager The object that manages layout for components in the view controller
+ */
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
+                   componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager HUB_DESIGNATED_INITIALIZER;
 
 /// Create a collection view. It will be setup with a default layout.
 - (HUBCollectionView *)createCollectionView;

--- a/sources/HUBCollectionViewFactory.m
+++ b/sources/HUBCollectionViewFactory.m
@@ -20,16 +20,42 @@
  */
 
 #import "HUBCollectionViewFactory.h"
+
 #import "HUBCollectionView.h"
+#import "HUBCollectionViewLayout.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface HUBCollectionViewFactory ()
+
+@property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
+@property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
+
+@end
+
 @implementation HUBCollectionViewFactory
+
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
+                   componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
+{
+    NSParameterAssert(componentRegistry != nil);
+    NSParameterAssert(componentLayoutManager != nil);
+
+    self = [super init];
+    if (self) {
+        _componentRegistry = componentRegistry;
+        _componentLayoutManager = componentLayoutManager;
+    }
+    return self;
+}
 
 - (HUBCollectionView *)createCollectionView
 {
+    HUBCollectionViewLayout *collectionViewLayout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
+                                                                                        componentLayoutManager:self.componentLayoutManager];
+
     HUBCollectionView *collectionView = [[HUBCollectionView alloc] initWithFrame:CGRectZero
-                                                            collectionViewLayout:[UICollectionViewLayout new]];
+                                                            collectionViewLayout:collectionViewLayout];
     
     collectionView.accessibilityIdentifier = @"collectionView";
     return collectionView;

--- a/sources/HUBConfigViewControllerFactory.m
+++ b/sources/HUBConfigViewControllerFactory.m
@@ -58,7 +58,8 @@
 
 
     HUBViewModelRenderer * const viewModelRenderer = [HUBViewModelRenderer new];
-    HUBCollectionViewFactory * const collectionViewFactory = [HUBCollectionViewFactory new];
+    HUBCollectionViewFactory * const collectionViewFactory = [[HUBCollectionViewFactory alloc] initWithComponentRegistry:config.componentRegistry
+                                                                                                  componentLayoutManager:config.componentLayoutManager];
     HUBComponentReusePool * const componentReusePool = [[HUBComponentReusePool alloc] initWithComponentRegistry:config.componentRegistry];
 
     id<HUBActionHandler> const actionHandlerWrapper = [[HUBActionHandlerWrapper alloc] initWithActionHandler:actionHandler
@@ -74,9 +75,7 @@
                                                     viewModelLoader:viewModelLoader
                                                   viewModelRenderer:viewModelRenderer
                                               collectionViewFactory:collectionViewFactory
-                                                  componentRegistry:config.componentRegistry
                                                  componentReusePool:componentReusePool
-                                             componentLayoutManager:config.componentLayoutManager
                                                       actionHandler:actionHandlerWrapper
                                                       scrollHandler:scrollHandlerToUse
                                                         imageLoader:imageLoader];

--- a/sources/HUBViewControllerExperimentalImplementation.h
+++ b/sources/HUBViewControllerExperimentalImplementation.h
@@ -22,8 +22,6 @@
 #import "HUBViewController.h"
 
 @protocol HUBFeatureInfo;
-@protocol HUBComponentRegistry;
-@protocol HUBComponentLayoutManager;
 @protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
 @protocol HUBImageLoader;
@@ -43,9 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param featureInfo Information about the feature that the view controller is for
  *  @param viewModelLoader The object to use to load view models for the view controller
  *  @param collectionViewFactory The factory to use to create collection views
- *  @param componentRegistry The registry to use to lookup component information
  *  @param componentReusePool The reuse pool to use to manage component wrappers
- *  @param componentLayoutManager The object that manages layout for components in the view controller
  *  @param actionHandler The object that will handle actions for this view controller
  *  @param scrollHandler The object that will handle scrolling for the view controller
  *  @param imageLoader The loader to use to load images for components
@@ -54,9 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
                     featureInfo:(id<HUBFeatureInfo>)featureInfo
                 viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
-              componentRegistry:(id<HUBComponentRegistry>)componentRegistry
              componentReusePool:(HUBComponentReusePool *)componentReusePool
-         componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader NS_DESIGNATED_INITIALIZER;

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -33,7 +33,6 @@
 #import "HUBComponentViewObserver.h"
 #import "HUBComponentWrapper.h"
 #import "HUBComponentWrapperImageLoader.h"
-#import "HUBComponentRegistry.h"
 #import "HUBComponentCollectionViewCell.h"
 #import "HUBUtilities.h"
 #import "HUBCollectionViewFactory.h"
@@ -62,9 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) id<HUBFeatureInfo> featureInfo;
 @property (nonatomic, strong, readonly) id<HUBViewModelLoader> viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
-@property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
 @property (nonatomic, strong, readonly) HUBComponentReusePool *componentReusePool;
-@property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
 @property (nonatomic, strong, readonly) id<HUBActionHandler> actionHandler;
 @property (nonatomic, strong, readonly) id<HUBViewControllerScrollHandler> scrollHandler;
 @property (nonatomic, strong, nullable, readonly) id<HUBContentReloadPolicy> contentReloadPolicy;
@@ -101,9 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
                     featureInfo:(id<HUBFeatureInfo>)featureInfo
                 viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
-              componentRegistry:(id<HUBComponentRegistry>)componentRegistry
              componentReusePool:(HUBComponentReusePool *)componentReusePool
-         componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader
@@ -112,9 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert(featureInfo != nil);
     NSParameterAssert(viewModelLoader != nil);
     NSParameterAssert(collectionViewFactory != nil);
-    NSParameterAssert(componentRegistry != nil);
     NSParameterAssert(componentReusePool != nil);
-    NSParameterAssert(componentLayoutManager != nil);
     NSParameterAssert(actionHandler != nil);
     NSParameterAssert(scrollHandler != nil);
     NSParameterAssert(imageLoader != nil);
@@ -127,9 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
     _featureInfo = featureInfo;
     _viewModelLoader = viewModelLoader;
     _collectionViewFactory = collectionViewFactory;
-    _componentRegistry = componentRegistry;
     _componentReusePool = componentReusePool;
-    _componentLayoutManager = componentLayoutManager;
     _actionHandler = actionHandler;
     _scrollHandler = scrollHandler;
     _componentWrapperImageLoader = [[HUBComponentWrapperImageLoader alloc] initWithImageLoader:imageLoader];
@@ -891,11 +882,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
         if (!self.viewHasBeenLaidOut) {
             completionHandler();
             return;
-        }
-
-        if (![self.collectionView.collectionViewLayout isKindOfClass:[HUBCollectionViewLayout class]]) {
-            self.collectionView.collectionViewLayout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
-                                                                                           componentLayoutManager:self.componentLayoutManager];
         }
 
         [self saveStatesForVisibleComponents];

--- a/sources/HUBViewControllerFactoryImplementation.m
+++ b/sources/HUBViewControllerFactoryImplementation.m
@@ -166,7 +166,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     HUBViewModelRenderer * const viewModelRenderer = [HUBViewModelRenderer new];
     id<HUBImageLoader> const imageLoader = [self.imageLoaderFactory createImageLoader];
-    HUBCollectionViewFactory * const collectionViewFactory = [HUBCollectionViewFactory new];
+    HUBCollectionViewFactory * const collectionViewFactory = [[HUBCollectionViewFactory alloc] initWithComponentRegistry:self.componentRegistry
+                                                                                                  componentLayoutManager:self.componentLayoutManager];
     HUBComponentReusePool * const componentReusePool = [[HUBComponentReusePool alloc] initWithComponentRegistry:self.componentRegistry];
     
     id<HUBActionHandler> const actionHandler = featureRegistration.actionHandler ?: self.defaultActionHandler;
@@ -182,9 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                     viewModelLoader:viewModelLoader
                                                   viewModelRenderer:viewModelRenderer
                                               collectionViewFactory:collectionViewFactory
-                                                  componentRegistry:self.componentRegistry
                                                  componentReusePool:componentReusePool
-                                             componentLayoutManager:self.componentLayoutManager
                                                       actionHandler:actionHandlerWrapper
                                                       scrollHandler:scrollHandlerToUse
                                                         imageLoader:imageLoader];
@@ -200,7 +199,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                                         featureRegistration:featureRegistration];
 
     id<HUBImageLoader> const imageLoader = [self.imageLoaderFactory createImageLoader];
-    HUBCollectionViewFactory * const collectionViewFactory = [HUBCollectionViewFactory new];
+    HUBCollectionViewFactory * const collectionViewFactory = [[HUBCollectionViewFactory alloc] initWithComponentRegistry:self.componentRegistry
+                                                                                                  componentLayoutManager:self.componentLayoutManager];
     HUBComponentReusePool * const componentReusePool = [[HUBComponentReusePool alloc] initWithComponentRegistry:self.componentRegistry];
 
     id<HUBActionHandler> const actionHandler = featureRegistration.actionHandler ?: self.defaultActionHandler;
@@ -215,9 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                     featureInfo:featureInfo
                                                                 viewModelLoader:viewModelLoader
                                                           collectionViewFactory:collectionViewFactory
-                                                              componentRegistry:self.componentRegistry
                                                              componentReusePool:componentReusePool
-                                                         componentLayoutManager:self.componentLayoutManager
                                                                   actionHandler:actionHandlerWrapper
                                                                   scrollHandler:scrollHandlerToUse
                                                                     imageLoader:imageLoader];

--- a/sources/HUBViewControllerImplementation.h
+++ b/sources/HUBViewControllerImplementation.h
@@ -22,8 +22,6 @@
 #import "HUBViewController.h"
 
 @protocol HUBFeatureInfo;
-@protocol HUBComponentRegistry;
-@protocol HUBComponentLayoutManager;
 @protocol HUBActionHandler;
 @protocol HUBViewControllerScrollHandler;
 @protocol HUBImageLoader;
@@ -45,9 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param viewModelLoader The object to use to load view models for the view controller
  *  @param viewModelRenderer The object used to render the view model
  *  @param collectionViewFactory The factory to use to create collection views
- *  @param componentRegistry The registry to use to lookup component information
  *  @param componentReusePool The reuse pool to use to manage component wrappers
- *  @param componentLayoutManager The object that manages layout for components in the view controller
  *  @param actionHandler The object that will handle actions for this view controller
  *  @param scrollHandler The object that will handle scrolling for the view controller
  *  @param imageLoader The loader to use to load images for components
@@ -57,9 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
                 viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
               viewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
-              componentRegistry:(id<HUBComponentRegistry>)componentRegistry
              componentReusePool:(HUBComponentReusePool *)componentReusePool
-         componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader NS_DESIGNATED_INITIALIZER;

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -33,7 +33,6 @@
 #import "HUBComponentViewObserver.h"
 #import "HUBComponentWrapper.h"
 #import "HUBComponentWrapperImageLoader.h"
-#import "HUBComponentRegistry.h"
 #import "HUBComponentCollectionViewCell.h"
 #import "HUBUtilities.h"
 #import "HUBCollectionViewFactory.h"
@@ -62,9 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) id<HUBFeatureInfo> featureInfo;
 @property (nonatomic, strong, readonly) id<HUBViewModelLoader> viewModelLoader;
 @property (nonatomic, strong, readonly) HUBCollectionViewFactory *collectionViewFactory;
-@property (nonatomic, strong, readonly) id<HUBComponentRegistry> componentRegistry;
 @property (nonatomic, strong, readonly) HUBComponentReusePool *componentReusePool;
-@property (nonatomic, strong, readonly) id<HUBComponentLayoutManager> componentLayoutManager;
 @property (nonatomic, strong, readonly) id<HUBActionHandler> actionHandler;
 @property (nonatomic, strong, readonly) id<HUBViewControllerScrollHandler> scrollHandler;
 @property (nonatomic, strong, nullable, readonly) id<HUBContentReloadPolicy> contentReloadPolicy;
@@ -103,9 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
                 viewModelLoader:(id<HUBViewModelLoader>)viewModelLoader
               viewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
           collectionViewFactory:(HUBCollectionViewFactory *)collectionViewFactory
-              componentRegistry:(id<HUBComponentRegistry>)componentRegistry
              componentReusePool:(HUBComponentReusePool *)componentReusePool
-         componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                   actionHandler:(id<HUBActionHandler>)actionHandler
                   scrollHandler:(id<HUBViewControllerScrollHandler>)scrollHandler
                     imageLoader:(id<HUBImageLoader>)imageLoader
@@ -115,9 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert(viewModelLoader != nil);
     NSParameterAssert(viewModelRenderer != nil);
     NSParameterAssert(collectionViewFactory != nil);
-    NSParameterAssert(componentRegistry != nil);
     NSParameterAssert(componentReusePool != nil);
-    NSParameterAssert(componentLayoutManager != nil);
     NSParameterAssert(actionHandler != nil);
     NSParameterAssert(scrollHandler != nil);
     NSParameterAssert(imageLoader != nil);
@@ -131,9 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
     _viewModelLoader = viewModelLoader;
     _viewModelRenderer = viewModelRenderer;
     _collectionViewFactory = collectionViewFactory;
-    _componentRegistry = componentRegistry;
     _componentReusePool = componentReusePool;
-    _componentLayoutManager = componentLayoutManager;
     _actionHandler = actionHandler;
     _scrollHandler = scrollHandler;
     _componentWrapperImageLoader = [[HUBComponentWrapperImageLoader alloc] initWithImageLoader:imageLoader];
@@ -853,11 +844,6 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
         if (!self.viewHasBeenLaidOut) {
             completionHandler();
             return;
-        }
-
-        if (![self.collectionView.collectionViewLayout isKindOfClass:[HUBCollectionViewLayout class]]) {
-            self.collectionView.collectionViewLayout = [[HUBCollectionViewLayout alloc] initWithComponentRegistry:self.componentRegistry
-                                                                                           componentLayoutManager:self.componentLayoutManager];
         }
 
         [self saveStatesForVisibleComponents];

--- a/tests/HUBCollectionViewFactoryTests.m
+++ b/tests/HUBCollectionViewFactoryTests.m
@@ -23,34 +23,51 @@
 
 #import "HUBCollectionViewFactory.h"
 #import "HUBCollectionView.h"
+#import "HUBComponentLayoutManagerMock.h"
+#import "HUBComponentRegistryMock.h"
 
 @interface HUBCollectionViewFactoryTests : XCTestCase
+
+@property (nonatomic, strong) HUBCollectionViewFactory *factory;
 
 @end
 
 @implementation HUBCollectionViewFactoryTests
 
+- (void)setUp
+{
+    [super setUp];
+
+    self.factory = [[HUBCollectionViewFactory alloc] initWithComponentRegistry:[HUBComponentRegistryMock new]
+                                                        componentLayoutManager:[HUBComponentLayoutManagerMock new]];
+
+}
+
+- (void)tearDown
+{
+    self.factory = nil;
+
+    [super tearDown];
+}
+
 - (void)testThatTheFactoryCreatesNonNilInstances
 {
-    HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
-    HUBCollectionView *collectionView = [factory createCollectionView];
+    HUBCollectionView *collectionView = [self.factory createCollectionView];
 
     XCTAssertNotNil(collectionView);
 }
 
 - (void)testThatTheCollectionViewHasAccessibilityId
 {
-    HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
-    HUBCollectionView *collectionView = [factory createCollectionView];
+    HUBCollectionView *collectionView = [self.factory createCollectionView];
 
     XCTAssertNotNil(collectionView.accessibilityIdentifier);
 }
 
 - (void)testThatTheFactoryCreatesNewCollectionViewInstances
 {
-    HUBCollectionViewFactory *factory = [HUBCollectionViewFactory new];
-    HUBCollectionView *collectionView1 = [factory createCollectionView];
-    HUBCollectionView *collectionView2 = [factory createCollectionView];
+    HUBCollectionView *collectionView1 = [self.factory createCollectionView];
+    HUBCollectionView *collectionView2 = [self.factory createCollectionView];
 
     XCTAssertNotEqual(collectionView1, collectionView2);
 }

--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -33,6 +33,7 @@
 #import "HUBImageLoaderMock.h"
 #import "HUBViewModelBuilder.h"
 #import "HUBViewModelRendererMock.h"
+#import "HUBCollectionViewLayoutMock.h"
 #import "HUBComponentModelBuilder.h"
 #import "HUBComponentModel.h"
 #import "HUBComponentImageDataBuilder.h"
@@ -69,6 +70,7 @@
 @property (nonatomic, strong) HUBComponentMock *component;
 @property (nonatomic, strong) HUBComponentFactoryMock *componentFactory;
 @property (nonatomic, strong) HUBCollectionViewMock *collectionView;
+@property (nonatomic, strong) HUBCollectionViewLayoutMock *collectionViewLayout;
 @property (nonatomic, strong) HUBCollectionViewFactoryMock *collectionViewFactory;
 @property (nonatomic, strong) HUBComponentRegistryImplementation *componentRegistry;
 @property (nonatomic, strong) HUBComponentReusePoolMock *componentReusePool;
@@ -134,8 +136,9 @@
     self.component = [HUBComponentMock new];
     self.componentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{componentDefaults.componentName: self.component}];
     [self.componentRegistry registerComponentFactory:self.componentFactory forNamespace:componentDefaults.componentNamespace];
-    
-    self.collectionView = [HUBCollectionViewMock new];
+
+    self.collectionViewLayout = [[HUBCollectionViewLayoutMock alloc] initWithComponentRegistry:self.componentRegistry];
+    self.collectionView = [[HUBCollectionViewMock alloc] initWithCollectionViewLayout:self.collectionViewLayout];
     self.collectionViewFactory = [[HUBCollectionViewFactoryMock alloc] initWithCollectionView:self.collectionView
                                                                             componentRegistry:self.componentRegistry];
     

--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -43,7 +43,6 @@
 #import "HUBComponentWrapper.h"
 #import "HUBCollectionViewFactoryMock.h"
 #import "HUBCollectionViewMock.h"
-#import "HUBComponentLayoutManagerMock.h"
 #import "HUBActionHandlerMock.h"
 #import "HUBInitialViewModelRegistry.h"
 #import "HUBActionRegistryImplementation.h"
@@ -137,7 +136,8 @@
     [self.componentRegistry registerComponentFactory:self.componentFactory forNamespace:componentDefaults.componentNamespace];
     
     self.collectionView = [HUBCollectionViewMock new];
-    self.collectionViewFactory = [[HUBCollectionViewFactoryMock alloc] initWithCollectionView:self.collectionView];
+    self.collectionViewFactory = [[HUBCollectionViewFactoryMock alloc] initWithCollectionView:self.collectionView
+                                                                            componentRegistry:self.componentRegistry];
     
     self.viewURI = [NSURL URLWithString:@"spotify:hub:framework"];
     self.featureInfo = [[HUBFeatureInfoImplementation alloc] initWithIdentifier:@"id" title:@"title"];
@@ -218,7 +218,6 @@
 
 - (void)createViewControllerWithViewModelRenderer:(HUBViewModelRenderer *)viewModelRenderer
 {
-    id<HUBComponentLayoutManager> const componentLayoutManager = [HUBComponentLayoutManagerMock new];
     id<HUBActionHandler> const actionHandler = [[HUBActionHandlerWrapper alloc] initWithActionHandler:self.actionHandler
                                                                                        actionRegistry:self.actionRegistry
                                                                              initialViewModelRegistry:self.initialViewModelRegistry
@@ -229,9 +228,7 @@
                                                                    viewModelLoader:self.viewModelLoader
                                                                  viewModelRenderer:viewModelRenderer
                                                              collectionViewFactory:self.collectionViewFactory
-                                                                 componentRegistry:self.componentRegistry
                                                                 componentReusePool:self.componentReusePool
-                                                            componentLayoutManager:componentLayoutManager
                                                                      actionHandler:actionHandler
                                                                      scrollHandler:self.scrollHandler
                                                                        imageLoader:self.imageLoader];

--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -33,7 +33,6 @@
 #import "HUBImageLoaderMock.h"
 #import "HUBViewModelBuilder.h"
 #import "HUBViewModelRendererMock.h"
-#import "HUBCollectionViewLayoutMock.h"
 #import "HUBComponentModelBuilder.h"
 #import "HUBComponentModel.h"
 #import "HUBComponentImageDataBuilder.h"
@@ -44,6 +43,7 @@
 #import "HUBComponentWrapper.h"
 #import "HUBCollectionViewFactoryMock.h"
 #import "HUBCollectionViewMock.h"
+#import "HUBCollectionViewLayoutMock.h"
 #import "HUBActionHandlerMock.h"
 #import "HUBInitialViewModelRegistry.h"
 #import "HUBActionRegistryImplementation.h"
@@ -70,7 +70,6 @@
 @property (nonatomic, strong) HUBComponentMock *component;
 @property (nonatomic, strong) HUBComponentFactoryMock *componentFactory;
 @property (nonatomic, strong) HUBCollectionViewMock *collectionView;
-@property (nonatomic, strong) HUBCollectionViewLayoutMock *collectionViewLayout;
 @property (nonatomic, strong) HUBCollectionViewFactoryMock *collectionViewFactory;
 @property (nonatomic, strong) HUBComponentRegistryImplementation *componentRegistry;
 @property (nonatomic, strong) HUBComponentReusePoolMock *componentReusePool;
@@ -137,8 +136,8 @@
     self.componentFactory = [[HUBComponentFactoryMock alloc] initWithComponents:@{componentDefaults.componentName: self.component}];
     [self.componentRegistry registerComponentFactory:self.componentFactory forNamespace:componentDefaults.componentNamespace];
 
-    self.collectionViewLayout = [[HUBCollectionViewLayoutMock alloc] initWithComponentRegistry:self.componentRegistry];
-    self.collectionView = [[HUBCollectionViewMock alloc] initWithCollectionViewLayout:self.collectionViewLayout];
+    HUBCollectionViewLayoutMock *layout = [[HUBCollectionViewLayoutMock alloc] initWithComponentRegistry:self.componentRegistry];
+    self.collectionView = [[HUBCollectionViewMock alloc] initWithCollectionViewLayout:layout];
     self.collectionViewFactory = [[HUBCollectionViewFactoryMock alloc] initWithCollectionView:self.collectionView
                                                                             componentRegistry:self.componentRegistry];
     

--- a/tests/HUBViewModelRendererTests.m
+++ b/tests/HUBViewModelRendererTests.m
@@ -24,6 +24,7 @@
 #import "HUBCollectionViewLayoutMock.h"
 #import "HUBCollectionViewMock.h"
 #import "HUBComponentLayoutManagerMock.h"
+#import "HUBComponentRegistryMock.h"
 #import "HUBViewModelDiff.h"
 #import "HUBViewModelRenderer.h"
 #import "HUBViewModelUtilities.h"
@@ -69,8 +70,8 @@
 {
     [super setUp];
 
-    self.collectionView = [HUBCollectionViewMockWithoutBatchUpdates new];
-    self.collectionViewLayout = [[HUBCollectionViewLayoutMock alloc] init];
+    self.collectionViewLayout = [[HUBCollectionViewLayoutMock alloc] initWithComponentRegistry:[HUBComponentRegistryMock new]];
+    self.collectionView = [[HUBCollectionViewMockWithoutBatchUpdates alloc] initWithCollectionViewLayout:self.collectionViewLayout];
     self.collectionView.collectionViewLayout = self.collectionViewLayout;
     self.viewModelRenderer = [HUBViewModelRenderer new];
 }

--- a/tests/mocks/HUBCollectionViewFactoryMock.h
+++ b/tests/mocks/HUBCollectionViewFactoryMock.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Mocked collection view factory, for use in tests only
 @interface HUBCollectionViewFactoryMock : HUBCollectionViewFactory
+
 /**
  *  Initialize an instance of this class with a collection view
  *

--- a/tests/mocks/HUBCollectionViewFactoryMock.h
+++ b/tests/mocks/HUBCollectionViewFactoryMock.h
@@ -26,13 +26,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Mocked collection view factory, for use in tests only
 @interface HUBCollectionViewFactoryMock : HUBCollectionViewFactory
-
 /**
  *  Initialize an instance of this class with a collection view
  *
  *  @param collectionView A collection view that this factory will always create
  */
-- (instancetype)initWithCollectionView:(HUBCollectionView *)collectionView HUB_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCollectionView:(HUBCollectionView *)collectionView
+                     componentRegistry:(id<HUBComponentRegistry>)componentRegistry HUB_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
+                   componentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager NS_UNAVAILABLE;
 
 @end
 

--- a/tests/mocks/HUBCollectionViewFactoryMock.m
+++ b/tests/mocks/HUBCollectionViewFactoryMock.m
@@ -21,6 +21,9 @@
 
 #import "HUBCollectionViewFactoryMock.h"
 
+#import "HUBComponentLayoutManagerMock.h"
+#import "HUBComponentRegistryMock.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBCollectionViewFactoryMock ()
@@ -32,8 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation HUBCollectionViewFactoryMock
 
 - (instancetype)initWithCollectionView:(HUBCollectionView *)collectionView
+                     componentRegistry:(id<HUBComponentRegistry>)componentRegistry
 {
-    self = [super init];
+    self = [super initWithComponentRegistry:componentRegistry
+                     componentLayoutManager:[HUBComponentLayoutManagerMock new]];
     
     if (self) {
         _collectionView = collectionView;

--- a/tests/mocks/HUBCollectionViewLayoutMock.h
+++ b/tests/mocks/HUBCollectionViewLayoutMock.h
@@ -30,8 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface HUBCollectionViewLayoutMock : HUBCollectionViewLayout
 
-/// Default constructor takes no arguments.
-- (instancetype)init;
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry;
 
 /**
  *  Returns the number of times that computeForCollectionViewSize:viewModel:diff:addHeaderMargin: was called.

--- a/tests/mocks/HUBCollectionViewLayoutMock.m
+++ b/tests/mocks/HUBCollectionViewLayoutMock.m
@@ -22,7 +22,6 @@
 #import "HUBCollectionViewLayoutMock.h"
 
 #import "HUBComponentLayoutManagerMock.h"
-#import "HUBComponentRegistryMock.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBCollectionViewLayoutMock
 
-- (instancetype)init
+- (instancetype)initWithComponentRegistry:(id<HUBComponentRegistry>)componentRegistry
 {
-    self = [super initWithComponentRegistry:[HUBComponentRegistryMock new] componentLayoutManager:[HUBComponentLayoutManagerMock new]];
+    self = [super initWithComponentRegistry:componentRegistry componentLayoutManager:[HUBComponentLayoutManagerMock new]];
     if (self) {
         _capturedViewModels = [NSMutableArray array];
         _capturedViewModelDiffs = [NSMutableArray array];
@@ -50,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 diff:(nullable HUBViewModelDiff *)diff
                      addHeaderMargin:(BOOL)addHeaderMargin
 {
+    [super computeForCollectionViewSize:collectionViewSize viewModel:viewModel diff:diff addHeaderMargin:addHeaderMargin];
     [self.capturedViewModels addObject:viewModel];
     HUBViewModelDiff *nonNullDiff = (diff == nil) ? (HUBViewModelDiff *)[NSNull null] : diff;
     [self.capturedViewModelDiffs addObject:nonNullDiff];

--- a/tests/mocks/HUBCollectionViewMock.h
+++ b/tests/mocks/HUBCollectionViewMock.h
@@ -50,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether the collection view should act like the user is dragging its content
 @property (nonatomic) BOOL mockedIsDragging;
 
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/mocks/HUBCollectionViewMock.m
+++ b/tests/mocks/HUBCollectionViewMock.m
@@ -21,8 +21,6 @@
 
 #import "HUBCollectionViewMock.h"
 
-#import "HUBCollectionViewLayoutMock.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBCollectionViewMock ()

--- a/tests/mocks/HUBCollectionViewMock.m
+++ b/tests/mocks/HUBCollectionViewMock.m
@@ -21,6 +21,8 @@
 
 #import "HUBCollectionViewMock.h"
 
+#import "HUBCollectionViewLayoutMock.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface HUBCollectionViewMock ()
@@ -34,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init
 {
-    UICollectionViewLayout * const layout = [UICollectionViewFlowLayout new];
+    HUBCollectionViewLayoutMock * const layout = [[HUBCollectionViewLayoutMock alloc] init];
     
     if (!(self = [super initWithFrame:CGRectZero collectionViewLayout:layout])) {
         return nil;

--- a/tests/mocks/HUBCollectionViewMock.m
+++ b/tests/mocks/HUBCollectionViewMock.m
@@ -34,10 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation HUBCollectionViewMock
 
-- (instancetype)init
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout
 {
-    HUBCollectionViewLayoutMock * const layout = [[HUBCollectionViewLayoutMock alloc] init];
-    
     if (!(self = [super initWithFrame:CGRectZero collectionViewLayout:layout])) {
         return nil;
     }


### PR DESCRIPTION
Create a collection view layout in the collection view factory when we create the collection view, and absolve the view controller of that responsibility. The VC now also doesn't need to create a "temporary" `UICollectionViewLayout` class for the collection view.