### PR TITLE
Fix duplicate selection logic

### DIFF
--- a/sources/HUBSingleGestureRecognizerSynchronizer.m
+++ b/sources/HUBSingleGestureRecognizerSynchronizer.m
@@ -22,24 +22,28 @@
 #import "HUBSingleGestureRecognizerSynchronizer.h"
 
 @interface HUBSingleGestureRecognizerSynchronizer ()
-@property (nonatomic, assign) BOOL shouldPreventGestureRecognizersFromHandlingTouches;
+@property (nonatomic, weak, nullable) HUBComponentGestureRecognizer *recognizingGestureRecognizer;
 @end
 
 @implementation HUBSingleGestureRecognizerSynchronizer
 
 - (void)gestureRecognizerDidBeginHandlingTouches:(HUBComponentGestureRecognizer *)gestureRecognizer
 {
-    self.shouldPreventGestureRecognizersFromHandlingTouches = YES;
+    if (self.recognizingGestureRecognizer == nil) {
+        self.recognizingGestureRecognizer = gestureRecognizer;
+    }
 }
 
 - (void)gestureRecognizerDidFinishHandlingTouches:(HUBComponentGestureRecognizer *)gestureRecognizer
 {
-    self.shouldPreventGestureRecognizersFromHandlingTouches = NO;
+    if (gestureRecognizer == self.recognizingGestureRecognizer) {
+        self.recognizingGestureRecognizer = nil;
+    }
 }
 
 - (BOOL)gestureRecognizerShouldBeginHandlingTouches:(HUBComponentGestureRecognizer *)gestureRecognizer
 {
-    return self.shouldPreventGestureRecognizersFromHandlingTouches == NO;
+    return self.recognizingGestureRecognizer == nil;
 }
 
 @end

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -168,6 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
     collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.allowsSelection = NO;
     collectionView.bounces = YES;
     collectionView.dataSource = self;
     collectionView.delegate = self;

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -172,6 +172,7 @@ NS_ASSUME_NONNULL_BEGIN
     collectionView.showsHorizontalScrollIndicator = collectionView.showsVerticalScrollIndicator;
     collectionView.keyboardDismissMode = [self.scrollHandler keyboardDismissModeForViewController:self];
     collectionView.decelerationRate = [self.scrollHandler scrollDecelerationRateForViewController:self];
+    collectionView.allowsSelection = NO;
     collectionView.bounces = YES;
     collectionView.dataSource = self;
     collectionView.delegate = self;


### PR DESCRIPTION
The logic to stop multiple gesture recognizers where a bit flawed. When a recognizer was told to not recognize it would immediately reset the state of the synchronizer. Such that the next recognizer would be able to recognize. Even if the original recognizer hadn’t stopped recognizing. We now compare the finished gesture recognizer with the one that began handling the gesture. Only if it’s the same do we reset it; allowing another one to recognize.

Both the collection view and our custom selection logic was firing. This could cause a component to stay selected visually until the view was interacted with again. As such `allowsSelection` has been set to `NO` allowing HubFramework to do its custom selection and highlighting management.

@spotify/objc-dev 