### PR TITLE
Bug: wrong argument is sent to HUBCollectionViewDelegate method

### DIFF
--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -717,6 +717,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 {
     HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
     UIView * const componentView = componentWrapper.view;
+    NSAssert(componentView != nil, @"Component view shouldn't be nil");
 
     if (componentView) {
         [self.delegate viewController:self

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -716,11 +716,14 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     forItemAtIndexPath:(NSIndexPath *)indexPath
 {
     HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
+    UIView * const componentView = componentWrapper.view;
 
-    [self.delegate viewController:self
-               componentWithModel:componentWrapper.model
-                     layoutTraits:componentWrapper.layoutTraits
-             didDisappearFromView:cell];
+    if (componentView) {
+        [self.delegate viewController:self
+                   componentWithModel:componentWrapper.model
+                         layoutTraits:componentWrapper.layoutTraits
+                 didDisappearFromView:componentView];
+    }
 
     [self removeComponentWrapperFromLookupTables:componentWrapper];
 }

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -727,11 +727,14 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     forItemAtIndexPath:(NSIndexPath *)indexPath
 {
     HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
+    UIView * const componentView = componentWrapper.view;
 
-    [self.delegate viewController:self
-               componentWithModel:componentWrapper.model
-                     layoutTraits:componentWrapper.layoutTraits
-             didDisappearFromView:cell];
+    if (componentView) {
+        [self.delegate viewController:self
+                   componentWithModel:componentWrapper.model
+                         layoutTraits:componentWrapper.layoutTraits
+                 didDisappearFromView:componentView];
+    }
 
     [self removeComponentWrapperFromLookupTables:componentWrapper];
 }

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -728,6 +728,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 {
     HUBComponentWrapper * const componentWrapper = [self componentWrapperFromCell:(HUBComponentCollectionViewCell *)cell];
     UIView * const componentView = componentWrapper.view;
+    NSAssert(componentView != nil, @"Component view shouldn't be nil");
 
     if (componentView) {
         [self.delegate viewController:self

--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -3070,6 +3070,7 @@
   didDisappearFromView:(UIView *)componentView
 {
     XCTAssertEqual(viewController, self.viewController);
+    XCTAssertFalse([componentView isKindOfClass:[HUBComponentCollectionViewCell class]]);
     
     [self.componentModelsFromDisapperanceDelegateMethod addObject:componentModel];
     [self.componentLayoutTraitsFromDisapperanceDelegateMethod addObject:layoutTraits];


### PR DESCRIPTION
The wrong argument is sent to the following HUBCollectionViewDelegate method:
```
- (void)collectionView:(UICollectionView *)collectionView
  didEndDisplayingCell:(UICollectionViewCell *)cell
    forItemAtIndexPath:(NSIndexPath *)indexPath
```

Instead of `HUBComponentCollectionViewCell` we should send a view from the component wrapper.
