### PR TITLE
Fix warnings from Infer

### DIFF
--- a/sources/HUBComponentModelBuilderImplementation.m
+++ b/sources/HUBComponentModelBuilderImplementation.m
@@ -285,8 +285,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.childBuilders[identifier] = nil;
     [self.childIdentifierOrder removeObject:identifier];
 
-    if (builder.groupIdentifier) {
-        NSString *groupIdentifier = builder.groupIdentifier;
+    NSString *groupIdentifier = builder.groupIdentifier;
+    if (groupIdentifier) {
         NSMutableArray *childBuildersInGroup = self.childBuildersByGroupIdentifier[groupIdentifier];
         [childBuildersInGroup removeObject:builder];
 
@@ -474,7 +474,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (childBuilder.groupIdentifier != nil) {
             NSString *groupIdentifier = childBuilder.groupIdentifier;
 
-            if (copy.childBuildersByGroupIdentifier[groupIdentifier] == nil) {
+            if (groupIdentifier != nil && copy.childBuildersByGroupIdentifier[groupIdentifier] == nil) {
                 copy.childBuildersByGroupIdentifier[groupIdentifier] = [NSMutableArray array];
             }
 

--- a/sources/HUBComponentModelImplementation.m
+++ b/sources/HUBComponentModelImplementation.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
             
             if (childrenInGroup != nil) {
                 [childrenInGroup addObject:child];
-            } else {
+            } else if (groupIdentifier != nil) {
                 childrenByGroupIdentifier[groupIdentifier] = [NSMutableArray arrayWithObject:child];
             }
         }

--- a/sources/HUBComponentReusePool.m
+++ b/sources/HUBComponentReusePool.m
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     if (existingWrappers != nil) {
         [existingWrappers addObject:componentWrapper];
-    } else {
+    } else if (componentIdentifier != nil) {
         self.componentWrappers[componentIdentifier] = [NSMutableSet setWithObject:componentWrapper];
     }
 }

--- a/sources/HUBOperation.h
+++ b/sources/HUBOperation.h
@@ -21,6 +21,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// Block type for completion handlers used with Hub Framework operations
 typedef void(^HUBOperationCompletionBlock)(void);
 
@@ -28,7 +30,7 @@ typedef void(^HUBOperationCompletionBlock)(void);
 typedef void(^HUBOperationSynchronousBlock)(void);
 
 /// Block type for asynchronous Hub Framework operations
-typedef void(^HUBOperationAsynchronousBlock)(HUBOperationCompletionBlock);
+typedef void(^HUBOperationAsynchronousBlock)(HUBOperationCompletionBlock _Nonnull);
 
 /**
  *  Class used to define atomic bodies of work as operations, that can either be synchronous or asynchronous
@@ -68,3 +70,5 @@ typedef void(^HUBOperationAsynchronousBlock)(HUBOperationCompletionBlock);
 - (void)performWithCompletionHandler:(HUBOperationCompletionBlock)completionHandler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBOperation.m
+++ b/sources/HUBOperation.m
@@ -21,6 +21,8 @@
 
 #import "HUBOperation.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface HUBOperation ()
 
 @property (nonatomic, copy, readonly) HUBOperationAsynchronousBlock block;
@@ -33,7 +35,7 @@
 
 + (HUBOperation *)synchronousOperationWithBlock:(HUBOperationSynchronousBlock)block
 {
-    return [[HUBOperation alloc] initWithBlock:^(HUBOperationCompletionBlock completionHandler) {
+    return [[HUBOperation alloc] initWithBlock:^(HUBOperationCompletionBlock _Nonnull completionHandler) {
         block();
         completionHandler();
     }];
@@ -67,3 +69,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -887,7 +887,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 
 - (HUBOperation *)createReloadCollectionViewOperation
 {
-    return [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler){
+    return [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock _Nonnull completionHandler){
         if (!self.viewHasBeenLaidOut) {
             completionHandler();
             return;
@@ -937,7 +937,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 {
     NSString * const currentModelIdentifier = wrapper.model.identifier;
 
-    if (self.componentWrappersByModelIdentifier[currentModelIdentifier] == wrapper) {
+    if (currentModelIdentifier != nil && self.componentWrappersByModelIdentifier[currentModelIdentifier] == wrapper) {
         self.componentWrappersByModelIdentifier[currentModelIdentifier] = nil;
     }
 

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -849,7 +849,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 
 - (HUBOperation *)createReloadCollectionViewOperation
 {
-    return [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler){
+    return [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock _Nonnull completionHandler){
         if (!self.viewHasBeenLaidOut) {
             completionHandler();
             return;
@@ -902,7 +902,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 {
     NSString * const currentModelIdentifier = wrapper.model.identifier;
 
-    if (self.componentWrappersByModelIdentifier[currentModelIdentifier] == wrapper) {
+    if (currentModelIdentifier != nil && self.componentWrappersByModelIdentifier[currentModelIdentifier] == wrapper) {
         self.componentWrappersByModelIdentifier[currentModelIdentifier] = nil;
     }
 

--- a/tests/HUBOperationQueueTests.m
+++ b/tests/HUBOperationQueueTests.m
@@ -59,7 +59,7 @@
     __block HUBOperationCompletionBlock asyncOperationCompletionHandler = nil;
     __block BOOL syncOperationPerformed = NO;
     
-    HUBOperation * const asyncOperation = [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler) {
+    HUBOperation * const asyncOperation = [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock _Nonnull completionHandler) {
         asyncOperationCompletionHandler = completionHandler;
     }];
     
@@ -80,7 +80,7 @@
     __block HUBOperationCompletionBlock asyncOperationCompletionHandler = nil;
     __block BOOL syncOperationPerformed = NO;
     
-    HUBOperation * const asyncOperation = [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock completionHandler) {
+    HUBOperation * const asyncOperation = [HUBOperation asynchronousOperationWithBlock:^(HUBOperationCompletionBlock _Nonnull completionHandler) {
         asyncOperationCompletionHandler = completionHandler;
     }];
     


### PR DESCRIPTION
Ran the project through [Infer](http://fbinfer.com) and cleaned up the errors and warnings.

Not sure if this is an Infer quirk or not, but it seemed to complain about block params being nullable, even when `nonnull` is assumed.

Better safe than sorry I suppose ¯\\\_(ツ)\_/¯ 

The following is the Infer CSV report:

```csv
class,kind,type,qualifier,severity,line,procedure,procedure_id,file,trace,key,qualifier_tags,hash,bug_id,always_report,advice
,WARNING,PARAMETER_NOT_NULL_CHECKED,"Parameter `completionHandler` is not checked for null, there could be a null pointer dereference: pointer `completionHandler` could be null and is dereferenced at line 38, column 9",MEDIUM,38,"__objc_anonymous_block_HUBOperation_synchronousOperationWithBlock:______1","__objc_anonymous_block_HUBOperation_synchronousOperationWithBlock:______1.ddc0be7f62a58d1a2062c46b167aa7e0",sources/HUBOperation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBOperation.m"",""line_number"":36,""description"":""start of procedure block"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""__objc_anonymous_block_HUBOperation_synchronousOperationWithBlock:______1""},{""tag"":""name_id"",""value"":""__objc_anonymous_block_HUBOperation_synchronousOperationWithBlock:______1.ddc0be7f62a58d1a2062c46b167aa7e0""}]},{""level"":0,""filename"":""sources/HUBOperation.m"",""line_number"":37,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBOperation.m"",""line_number"":38,""description"":"""",""node_tags"":[]}]}","141050084","<qualifier_tags><bucket>B1</bucket><parameter_not_null_checked>completionHandler</parameter_not_null_checked><line>38</line><value>completionHandler</value></qualifier_tags>","41416583","1","false",""
,WARNING,PARAMETER_NOT_NULL_CHECKED,"Parameter `completionHandler` is not checked for null, there could be a null pointer dereference: pointer `completionHandler` could be null and is dereferenced at line 892, column 13",MEDIUM,892,"__objc_anonymous_block_HUBViewControllerExperimentalImplementation_createReloadCollectionViewOperation______7","__objc_anonymous_block_HUBViewControllerExperimentalImplementation_createReloadCollectionViewOperati.fad0d6b29eca3213a640c28921200740",sources/HUBViewControllerExperimentalImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":890,""description"":""start of procedure block"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""__objc_anonymous_block_HUBViewControllerExperimentalImplementation_createReloadCollectionViewOperation______7""},{""tag"":""name_id"",""value"":""__objc_anonymous_block_HUBViewControllerExperimentalImplementation_createReloadCollectionViewOperati.fad0d6b29eca3213a640c28921200740""}]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":891,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":891,""description"":""Condition is false"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""false""}]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":891,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":892,""description"":"""",""node_tags"":[]}]}","61291839","<qualifier_tags><bucket>B1</bucket><parameter_not_null_checked>completionHandler</parameter_not_null_checked><line>892</line><value>completionHandler</value></qualifier_tags>","582266255","2","false",""
,WARNING,PARAMETER_NOT_NULL_CHECKED,"Parameter `completionHandler` is not checked for null, there could be a null pointer dereference: pointer `completionHandler` could be null and is dereferenced at line 854, column 13",MEDIUM,854,"__objc_anonymous_block_HUBViewControllerImplementation_createReloadCollectionViewOperation______6","__objc_anonymous_block_HUBViewControllerImplementation_createReloadCollectionViewOperation______6.3eaad1023124d555acb294433994ed74",sources/HUBViewControllerImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":852,""description"":""start of procedure block"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""__objc_anonymous_block_HUBViewControllerImplementation_createReloadCollectionViewOperation______6""},{""tag"":""name_id"",""value"":""__objc_anonymous_block_HUBViewControllerImplementation_createReloadCollectionViewOperation______6.3eaad1023124d555acb294433994ed74""}]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":853,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":853,""description"":""Condition is false"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""false""}]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":853,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":854,""description"":"""",""node_tags"":[]}]}","61291839","<qualifier_tags><bucket>B1</bucket><parameter_not_null_checked>completionHandler</parameter_not_null_checked><line>854</line><value>completionHandler</value></qualifier_tags>","686352510","3","false",""
PROVER,ERROR,NULL_DEREFERENCE,"pointer `componentIdentifier` last assigned on line 63 could be null and is dereferenced by call to `setObject:forKeyedSubscript:` at line 69, column 9",HIGH,69,"HUBComponentReusePool_addComponentWrappper:","addComponentWrappper:#HUBComponentReusePool#instance.a10d79c97aa0cd6186d496dc59982db5",sources/HUBComponentReusePool.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBComponentReusePool.m"",""line_number"":61,""description"":""start of procedure addComponentWrappper:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBComponentReusePool_addComponentWrappper:""},{""tag"":""name_id"",""value"":""addComponentWrappper:#HUBComponentReusePool#instance.a10d79c97aa0cd6186d496dc59982db5""}]},{""level"":0,""filename"":""sources/HUBComponentReusePool.m"",""line_number"":63,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentReusePool.m"",""line_number"":64,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentReusePool.m"",""line_number"":66,""description"":""Condition is false"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""false""}]},{""level"":0,""filename"":""sources/HUBComponentReusePool.m"",""line_number"":69,""description"":""Skipped call: function or method not found"",""node_tags"":[]}]}","694081859","<qualifier_tags><bucket>B2</bucket><line>69</line><assigned_line>63</assigned_line><value>componentIdentifier</value><call_procedure>setObject:forKeyedSubscript:</call_procedure></qualifier_tags>","31679865","4","false",""
PROVER,ERROR,NULL_DEREFERENCE,"pointer `currentModelIdentifier` last assigned on line 938 could be null and is dereferenced by call to `setObject:forKeyedSubscript:` at line 941, column 9",HIGH,941,"HUBViewControllerExperimentalImplementation_configureComponentWrapper:withModel:containerViewSize:","configureComponentWrapper:withModel:containerViewSize:#HUBViewControllerExperimentalImplementation#i.750cc99f382b0e875c0d25e5ff852e7a",sources/HUBViewControllerExperimentalImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":936,""description"":""start of procedure configureComponentWrapper:withModel:containerViewSize:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBViewControllerExperimentalImplementation_configureComponentWrapper:withModel:containerViewSize:""},{""tag"":""name_id"",""value"":""configureComponentWrapper:withModel:containerViewSize:#HUBViewControllerExperimentalImplementation#i.750cc99f382b0e875c0d25e5ff852e7a""}]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":938,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":940,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBViewControllerExperimentalImplementation.m"",""line_number"":941,""description"":""Skipped call: function or method not found"",""node_tags"":[]}]}","132155902","<qualifier_tags><bucket>B2</bucket><line>941</line><assigned_line>938</assigned_line><value>currentModelIdentifier</value><call_procedure>setObject:forKeyedSubscript:</call_procedure></qualifier_tags>","744818922","5","false",""
PROVER,ERROR,NULL_DEREFERENCE,"pointer `currentModelIdentifier` last assigned on line 903 could be null and is dereferenced by call to `setObject:forKeyedSubscript:` at line 906, column 9",HIGH,906,"HUBViewControllerImplementation_configureComponentWrapper:withModel:containerViewSize:","configureComponentWrapper:withModel:containerViewSize:#HUBViewControllerImplementation#instance.d467c463d296cc46306ede1c0ca18acc",sources/HUBViewControllerImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":901,""description"":""start of procedure configureComponentWrapper:withModel:containerViewSize:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBViewControllerImplementation_configureComponentWrapper:withModel:containerViewSize:""},{""tag"":""name_id"",""value"":""configureComponentWrapper:withModel:containerViewSize:#HUBViewControllerImplementation#instance.d467c463d296cc46306ede1c0ca18acc""}]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":903,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":905,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBViewControllerImplementation.m"",""line_number"":906,""description"":""Skipped call: function or method not found"",""node_tags"":[]}]}","132155902","<qualifier_tags><bucket>B2</bucket><line>906</line><assigned_line>903</assigned_line><value>currentModelIdentifier</value><call_procedure>setObject:forKeyedSubscript:</call_procedure></qualifier_tags>","1061452373","6","false",""
PROVER,ERROR,NULL_DEREFERENCE,"pointer `groupIdentifier` last assigned on line 475 could be null and is dereferenced by call to `setObject:forKeyedSubscript:` at line 478, column 17",HIGH,478,"HUBComponentModelBuilderImplementation_copyWithZone:","copyWithZone:#HUBComponentModelBuilderImplementation#instance.8dcf0034569f920b0c402d8c0e1deea8",sources/HUBComponentModelBuilderImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":438,""description"":""start of procedure copyWithZone:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBComponentModelBuilderImplementation_copyWithZone:""},{""tag"":""name_id"",""value"":""copyWithZone:#HUBComponentModelBuilderImplementation#instance.8dcf0034569f920b0c402d8c0e1deea8""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":440,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":441,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":443,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":450,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":451,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":452,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":453,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":454,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":455,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":1,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":576,""description"":""start of procedure setGroupIdentifier:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBComponentModelBuilderImplementation_setGroupIdentifier:""},{""tag"":""name_id"",""value"":""setGroupIdentifier:#HUBComponentModelBuilderImplementation#instance.0b5ad907d204607c5f2ab4466057abb8""}]},{""level"":1,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":581,""description"":"""",""node_tags"":[]},{""level"":1,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":583,""description"":"""",""node_tags"":[]},{""level"":1,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":587,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":1,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":588,""description"":""return from a call to HUBComponentModelBuilderImplementation_setGroupIdentifier:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_end""},{""tag"":""name"",""value"":""HUBComponentModelBuilderImplementation_setGroupIdentifier:""},{""tag"":""name_id"",""value"":""setGroupIdentifier:#HUBComponentModelBuilderImplementation#instance.0b5ad907d204607c5f2ab4466057abb8""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":456,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":457,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":458,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":459,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":460,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":461,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":462,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":463,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":464,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":466,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":467,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":466,""description"":""Condition is false"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""false""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":470,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":471,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":472,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":474,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":475,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":477,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":478,""description"":""Skipped call: function or method not found"",""node_tags"":[]}]}","294327212","<qualifier_tags><bucket>B1</bucket><line>478</line><assigned_line>475</assigned_line><value>groupIdentifier</value><call_procedure>setObject:forKeyedSubscript:</call_procedure></qualifier_tags>","1014769750","7","false",""
PROVER,ERROR,NULL_DEREFERENCE,"pointer `groupIdentifier` last assigned on line 289 could be null and is dereferenced by call to `setObject:forKeyedSubscript:` at line 294, column 13",HIGH,294,"HUBComponentModelBuilderImplementation_removeBuilderForChildWithIdentifier:","removeBuilderForChildWithIdentifier:#HUBComponentModelBuilderImplementation#instance.2a277bcb09c2a1a379a5a3ba25e1df08",sources/HUBComponentModelBuilderImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":282,""description"":""start of procedure removeBuilderForChildWithIdentifier:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBComponentModelBuilderImplementation_removeBuilderForChildWithIdentifier:""},{""tag"":""name_id"",""value"":""removeBuilderForChildWithIdentifier:#HUBComponentModelBuilderImplementation#instance.2a277bcb09c2a1a379a5a3ba25e1df08""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":284,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":285,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":286,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":288,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":288,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":289,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":290,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":291,""description"":""Message removeObject: with receiver nil returns nil."",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":293,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelBuilderImplementation.m"",""line_number"":294,""description"":""Skipped call: function or method not found"",""node_tags"":[]}]}","132155902","<qualifier_tags><bucket>B1</bucket><line>294</line><assigned_line>289</assigned_line><value>groupIdentifier</value><call_procedure>setObject:forKeyedSubscript:</call_procedure></qualifier_tags>","518748604","8","false",""
PROVER,ERROR,NULL_DEREFERENCE,"pointer `groupIdentifier` last assigned on line 139 could be null and is dereferenced by call to `setObject:forKeyedSubscript:` at line 145, column 17",HIGH,145,"HUBComponentModelImplementation_setChildren:","setChildren:#HUBComponentModelImplementation#instance.ff9809bd6ef6d79d050b4dbfa9d2c85f",sources/HUBComponentModelImplementation.m,"{""trace"":[{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":128,""description"":""start of procedure setChildren:"",""node_tags"":[{""tag"":""kind"",""value"":""procedure_start""},{""tag"":""name"",""value"":""HUBComponentModelImplementation_setChildren:""},{""tag"":""name_id"",""value"":""setChildren:#HUBComponentModelImplementation#instance.ff9809bd6ef6d79d050b4dbfa9d2c85f""}]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":130,""description"":"""",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":132,""description"":"""",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":133,""description"":"""",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":135,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":136,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":138,""description"":""Condition is true"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""true""}]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":139,""description"":""Skipped call: function or method not found"",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":140,""description"":"""",""node_tags"":[]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":142,""description"":""Condition is false"",""node_tags"":[{""tag"":""kind"",""value"":""condition""},{""tag"":""branch"",""value"":""false""}]},{""level"":0,""filename"":""sources/HUBComponentModelImplementation.m"",""line_number"":145,""description"":"""",""node_tags"":[]}]}","474590136","<qualifier_tags><bucket>B1</bucket><line>145</line><assigned_line>139</assigned_line><value>groupIdentifier</value><call_procedure>setObject:forKeyedSubscript:</call_procedure></qualifier_tags>","1027148184","9","false",""

```