### PR TITLE
Fix simple OCLint warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ Carthage/Build
 fastlane/report.xml
 fastlane/screenshots
 
+# Infer
+infer-out
+
 # Documentation
 documentation/output/
 

--- a/sources/HUBCollectionView.m
+++ b/sources/HUBCollectionView.m
@@ -35,12 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 {
     id<HUBCollectionViewDelegate> const delegate = self.delegate;
     
-    if (delegate != nil) {
-        if (![delegate collectionViewShouldBeginScrolling:self]) {
-            self.panGestureRecognizer.enabled = NO;
-            self.panGestureRecognizer.enabled = YES;
-            return;
-        }
+    if (delegate != nil && ![delegate collectionViewShouldBeginScrolling:self]) {
+        self.panGestureRecognizer.enabled = NO;
+        self.panGestureRecognizer.enabled = YES;
+        return;
     }
     
     [super setContentOffset:contentOffset];

--- a/sources/HUBComponentModelBuilderImplementation.m
+++ b/sources/HUBComponentModelBuilderImplementation.m
@@ -507,7 +507,7 @@ NS_ASSUME_NONNULL_BEGIN
         id<HUBComponentImageData> const imageData = [builder buildWithIdentifier:imageIdentifier type:HUBComponentImageTypeCustom];
         
         if (imageData != nil) {
-            [customImageData setObject:imageData forKey:imageIdentifier];
+            customImageData[imageIdentifier] = imageData;
         }
     }
     

--- a/sources/HUBComponentWrapper.m
+++ b/sources/HUBComponentWrapper.m
@@ -186,12 +186,10 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL const viewLoaded = (self.view != nil);
     UIView * const view = HUBComponentLoadViewIfNeeded(self.component);
     
-    if (!viewLoaded) {
-        if (HUBConformsToProtocol(self.component, @protocol(HUBComponentViewObserver))) {
-            HUBComponentResizeObservingView * const resizeObservingView = [[HUBComponentResizeObservingView alloc] initWithFrame:view.bounds];
-            resizeObservingView.delegate = self;
-            [view addSubview:resizeObservingView];
-        }
+    if (!viewLoaded && HUBConformsToProtocol(self.component, @protocol(HUBComponentViewObserver))) {
+        HUBComponentResizeObservingView * const resizeObservingView = [[HUBComponentResizeObservingView alloc] initWithFrame:view.bounds];
+        resizeObservingView.delegate = self;
+        [view addSubview:resizeObservingView];
     }
 }
 

--- a/sources/HUBDefaultComponentLayoutManager.m
+++ b/sources/HUBDefaultComponentLayoutManager.m
@@ -82,16 +82,16 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if ([layoutTraits containsObject:HUBComponentLayoutTraitFullWidth]) {
         return 0;
-    } else {
-        BOOL const isCentered = [layoutTraits containsObject:HUBComponentLayoutTraitCentered];
-        BOOL const precedingIsCentered = [precedingComponentLayoutTraits containsObject:HUBComponentLayoutTraitCentered];
-        
-        // Centered components are always grouped toghether
-        if (isCentered != precedingIsCentered) {
-            return CGFLOAT_MAX;
-        }
     }
-    
+
+    BOOL const isCentered = [layoutTraits containsObject:HUBComponentLayoutTraitCentered];
+    BOOL const precedingIsCentered = [precedingComponentLayoutTraits containsObject:HUBComponentLayoutTraitCentered];
+
+    // Centered components are always grouped toghether
+    if (isCentered != precedingIsCentered) {
+        return CGFLOAT_MAX;
+    }
+
     return self.margin;
 }
 

--- a/sources/HUBDefaultConnectivityStateResolver.m
+++ b/sources/HUBDefaultConnectivityStateResolver.m
@@ -115,13 +115,10 @@ void HUBReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkConnectio
 - (SCNetworkReachabilityContext)createReachabilityContext
 {
     __weak __typeof(self) weakSelf = self;
-    
-    SCNetworkReachabilityContext const context = {
+    return (SCNetworkReachabilityContext){
         .version = 0,
         .info = (__bridge void *)weakSelf
     };
-    
-    return context;
 }
 
 - (HUBConnectivityState)connectivityStateFromReachabilityFlags:(SCNetworkReachabilityFlags)flags

--- a/sources/HUBIconImplementation.m
+++ b/sources/HUBIconImplementation.m
@@ -61,9 +61,8 @@
 {
     if (self.isPlaceholder) {
         return [self.imageResolver imageForPlaceholderIconWithIdentifier:self.identifier size:size color:color];
-    } else {
-        return [self.imageResolver imageForComponentIconWithIdentifier:self.identifier size:size color:color];
     }
+    return [self.imageResolver imageForComponentIconWithIdentifier:self.identifier size:size color:color];
 }
 
 @end

--- a/sources/HUBLiveServiceFactory.m
+++ b/sources/HUBLiveServiceFactory.m
@@ -29,9 +29,9 @@
 {
 #if HUB_DEBUG
     return [HUBLiveServiceImplementation new];
-#endif
-
+#else
     return nil;
+#endif
 }
 
 @end

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -973,8 +973,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     CGFloat const statusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame);
     CGFloat const navigationBarWidth = CGRectGetWidth(self.navigationController.navigationBar.frame);
     CGFloat const navigationBarHeight = CGRectGetHeight(self.navigationController.navigationBar.frame);
-    CGFloat const topBarHeight = MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
-    return topBarHeight;
+    return MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
 }
 
 - (BOOL)shouldAutomaticallyManageTopContentInset

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -841,7 +841,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
              completion:(void (^)(void))completionBlock
 {
     __weak __typeof(self) weakSelf = self;
-    void (^renderBlock)() = ^{
+    void (^renderBlock)(void) = ^{
         __strong __typeof(self) strongSelf = weakSelf;
         [strongSelf renderViewModel:viewModel
                     addHeaderMargin:addHeaderMargin
@@ -1252,7 +1252,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 - (void)scrollToRootBodyComponentAtIndex:(NSUInteger)componentIndex
                           scrollPosition:(HUBScrollPosition)scrollPosition
                                 animated:(BOOL)animated
-                              completion:(void (^)())completion
+                              completion:(void (^)(void))completion
 {
     NSParameterAssert(componentIndex <= (NSUInteger)[self.collectionView numberOfItemsInSection:0]);
 
@@ -1295,7 +1295,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
 
     __weak HUBViewControllerExperimentalImplementation *weakSelf = self;
-    void (^stepCompletionHandler)() = ^{
+    void (^stepCompletionHandler)(void) = ^{
         HUBViewControllerExperimentalImplementation *strongSelf = weakSelf;
 
         HUBComponentWrapper *childComponentWrapper = nil;

--- a/sources/HUBViewControllerExperimentalImplementation.m
+++ b/sources/HUBViewControllerExperimentalImplementation.m
@@ -768,10 +768,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                                                             currentContentOffset:scrollView.contentOffset
                                                                            proposedContentOffset:*targetContentOffset];
 
-    if (targetContentOffset->y >= (scrollView.contentSize.height - CGRectGetHeight(scrollView.frame))) {
-        if (!self.viewModelLoader.isLoading) {
-            [self.viewModelLoader loadNextPageForCurrentViewModel];
-        }
+    CGFloat threshold = scrollView.contentSize.height - CGRectGetHeight(scrollView.frame);
+    if (targetContentOffset->y >= threshold && !self.viewModelLoader.isLoading) {
+        [self.viewModelLoader loadNextPageForCurrentViewModel];
     }
 }
 
@@ -1138,10 +1137,8 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
         return;
     }
 
-    if (wrapper.viewHasAppearedSinceLastModelChange) {
-        if (!ignorePreviousAppearance) {
-            return;
-        }
+    if (wrapper.viewHasAppearedSinceLastModelChange && !ignorePreviousAppearance) {
+        return;
     }
 
     [self componentWrapperWillAppear:wrapper];

--- a/sources/HUBViewControllerFactoryImplementation.m
+++ b/sources/HUBViewControllerFactoryImplementation.m
@@ -150,9 +150,8 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL useV2 = [featureRegistration.options[@"HUBViewController"] isEqualToString:@"v2"];
     if (useV2) {
         return [self createExperimentalViewControllerForViewURI:viewURI featureRegistration:featureRegistration];
-    } else {
-        return [self createStandardViewControllerForViewURI:viewURI featureRegistration:featureRegistration];
     }
+    return [self createStandardViewControllerForViewURI:viewURI featureRegistration:featureRegistration];
 }
 
 - (HUBViewController *)createStandardViewControllerForViewURI:(NSURL *)viewURI

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -779,10 +779,9 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
                                                                             currentContentOffset:scrollView.contentOffset
                                                                            proposedContentOffset:*targetContentOffset];
 
-    if (targetContentOffset->y >= (scrollView.contentSize.height - CGRectGetHeight(scrollView.frame))) {
-        if (!self.viewModelLoader.isLoading) {
-            [self.viewModelLoader loadNextPageForCurrentViewModel];
-        }
+    CGFloat threshold = scrollView.contentSize.height - CGRectGetHeight(scrollView.frame);
+    if (targetContentOffset->y >= threshold && !self.viewModelLoader.isLoading) {
+        [self.viewModelLoader loadNextPageForCurrentViewModel];
     }
 }
 
@@ -1103,10 +1102,8 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
         return;
     }
 
-    if (wrapper.viewHasAppearedSinceLastModelChange) {
-        if (!ignorePreviousAppearance) {
-            return;
-        }
+    if (wrapper.viewHasAppearedSinceLastModelChange && !ignorePreviousAppearance) {
+        return;
     }
 
     [self componentWrapperWillAppear:wrapper];

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -938,8 +938,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     CGFloat const statusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame);
     CGFloat const navigationBarWidth = CGRectGetWidth(self.navigationController.navigationBar.frame);
     CGFloat const navigationBarHeight = CGRectGetHeight(self.navigationController.navigationBar.frame);
-    CGFloat const topBarHeight = MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
-    return topBarHeight;
+    return MIN(statusBarWidth, statusBarHeight) + MIN(navigationBarWidth, navigationBarHeight);
 }
 
 - (BOOL)shouldAutomaticallyManageTopContentInset

--- a/sources/HUBViewControllerImplementation.m
+++ b/sources/HUBViewControllerImplementation.m
@@ -1217,7 +1217,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
 - (void)scrollToRootBodyComponentAtIndex:(NSUInteger)componentIndex
                           scrollPosition:(HUBScrollPosition)scrollPosition
                                 animated:(BOOL)animated
-                              completion:(void (^)())completion
+                              completion:(void (^)(void))completion
 {
     NSParameterAssert(componentIndex <= (NSUInteger)[self.collectionView numberOfItemsInSection:0]);
 
@@ -1260,7 +1260,7 @@ willUpdateSelectionState:(HUBComponentSelectionState)selectionState
     }
 
     __weak HUBViewControllerImplementation *weakSelf = self;
-    void (^stepCompletionHandler)() = ^{
+    void (^stepCompletionHandler)(void) = ^{
         HUBViewControllerImplementation *strongSelf = weakSelf;
 
         HUBComponentWrapper *childComponentWrapper = nil;

--- a/sources/HUBViewModelBuilderImplementation.m
+++ b/sources/HUBViewModelBuilderImplementation.m
@@ -275,7 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (value == nil) {
         [customData removeObjectForKey:key];
     } else {
-        [customData setObject:(id)value forKey:key];
+        customData[key] = value;
     }
 
     self.customData = customData;

--- a/sources/HUBViewModelDiff.m
+++ b/sources/HUBViewModelDiff.m
@@ -224,14 +224,11 @@ static inline HUBDiffStepType HUBDiffStepTypeInfer(NSInteger k, NSInteger d, NSI
         return HUBDiffStepTypeInsert;
     } else if (k == d) {
         return HUBDiffStepTypeDelete;
-    } else {
+    } else if (previousX < nextX) {
         // If the next x is greater than the previous, it is a horizontal movement and thus an insertion.
-        if (previousX < nextX) {
-            return HUBDiffStepTypeInsert;
-        } else {
-            return HUBDiffStepTypeDelete;
-        }
+        return HUBDiffStepTypeInsert;
     }
+    return HUBDiffStepTypeDelete;
 }
 
 @interface HUBDiffStep : NSObject
@@ -262,10 +259,10 @@ static inline HUBDiffStepType HUBDiffStepTypeInfer(NSInteger k, NSInteger d, NSI
     // Vertical movement, insertion
     } else if (self.from.y < self.to.y) {
         return HUBDiffStepTypeInsert;
-    // Horizontal movement, insertion
-    } else {
-        return HUBDiffStepTypeDelete;
     }
+
+    // Horizontal movement, insertion
+    return HUBDiffStepTypeDelete;
 }
 
 @end
@@ -433,9 +430,8 @@ static NSArray<HUBDiffStep *> *HUBDiffStepsBetweenViewModels(id<HUBViewModel> fr
         return HUBDiffInsertionTracesFromViewModel(toViewModel);
     } else if (toViewModel.bodyComponentModels.count == 0) {
         return HUBDiffDeletionTracesFromViewModel(fromViewModel);
-    } else {
-        return HUBDiffMyersTracesBetweenViewModels(fromViewModel, toViewModel);
     }
+    return HUBDiffMyersTracesBetweenViewModels(fromViewModel, toViewModel);
 }
 
 HUBViewModelDiff *HUBDiffMyersAlgorithm(id<HUBViewModel> fromViewModel, id<HUBViewModel> toViewModel) {

--- a/sources/HUBViewModelDiff.m
+++ b/sources/HUBViewModelDiff.m
@@ -349,41 +349,43 @@ static NSArray<HUBDiffStep *> *HUBDiffMyersTracesBetweenViewModels(id<HUBViewMod
             }
             
             /// Here the goal is to follow the diagonal line with additional steps to find the longest common sequence
-            if (step.to.x <= fromCount && step.to.y <= toCount) {
-                [steps addObject:step];
+            if (step.to.x > fromCount || step.to.y > toCount) {
+                continue;
+            }
 
-                NSInteger x = step.to.x;
-                NSInteger y = step.to.y;
-                
-                while (x >= 0 && y >= 0 && x < fromCount && y < toCount) {
-                    id<HUBComponentModel> target = toViewModel.bodyComponentModels[(NSUInteger)y];
-                    id<HUBComponentModel> base = fromViewModel.bodyComponentModels[(NSUInteger)x];
+            [steps addObject:step];
 
-                    /**
-                     * Only the element's identity is compared here, as equality is checked later in order to determine
-                     * the location of updates.
-                     */ 
-                    if ([base.identifier isEqual:target.identifier]) {
-                        // A match is found and another step can be taken diagonally.
-                        x += 1;
-                        y += 1;
+            NSInteger x = step.to.x;
+            NSInteger y = step.to.y;
+            
+            while (x >= 0 && y >= 0 && x < fromCount && y < toCount) {
+                id<HUBComponentModel> target = toViewModel.bodyComponentModels[(NSUInteger)y];
+                id<HUBComponentModel> base = fromViewModel.bodyComponentModels[(NSUInteger)x];
 
-                        HUBDiffStep *nextStep = [[HUBDiffStep alloc] initWithFromPoint:HUBDiffPointMake(x - 1, y - 1) toPoint:HUBDiffPointMake(x, y)];
-                        
-                        [steps addObject:nextStep];
-                    } else {
-                        break;
-                    }
+                /**
+                 * Only the element's identity is compared here, as equality is checked later in order to determine
+                 * the location of updates.
+                 */ 
+                if ([base.identifier isEqual:target.identifier]) {
+                    // A match is found and another step can be taken diagonally.
+                    x += 1;
+                    y += 1;
+
+                    HUBDiffStep *nextStep = [[HUBDiffStep alloc] initWithFromPoint:HUBDiffPointMake(x - 1, y - 1) toPoint:HUBDiffPointMake(x, y)];
+                    
+                    [steps addObject:nextStep];
+                } else {
+                    break;
                 }
+            }
 
-                // Only the x-point needs to be stored since y can be inferred with y = x - k
-                endpoints[index] = x;
+            // Only the x-point needs to be stored since y can be inferred with y = x - k
+            endpoints[index] = x;
 
-                // The end of the graph has been reached, and a solution has been found.
-                if (x >= fromCount && y >= toCount) {
-                    free(endpoints);
-                    return steps;
-                }
+            // The end of the graph has been reached, and a solution has been found.
+            if (x >= fromCount && y >= toCount) {
+                free(endpoints);
+                return steps;
             }
         }
     }

--- a/sources/HUBViewModelLoaderImplementation.m
+++ b/sources/HUBViewModelLoaderImplementation.m
@@ -179,13 +179,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self connectivityStateResolverStateDidChange:self.connectivityStateResolver];
     [self.connectivityStateResolver addObserver:self];
 
-    if (self.contentReloadPolicy != nil) {
-        if (self.previouslyLoadedViewModel != nil) {
-            id<HUBViewModel> const previouslyLoadedViewModel = self.previouslyLoadedViewModel;
-            
-            if (![self.contentReloadPolicy shouldReloadContentForViewURI:self.viewURI currentViewModel:previouslyLoadedViewModel]) {
-                return;
-            }
+    if (self.contentReloadPolicy != nil && self.previouslyLoadedViewModel != nil) {
+        id<HUBViewModel> const previouslyLoadedViewModel = self.previouslyLoadedViewModel;
+        
+        if (![self.contentReloadPolicy shouldReloadContentForViewURI:self.viewURI currentViewModel:previouslyLoadedViewModel]) {
+            return;
         }
     }
     

--- a/sources/HUBViewModelRenderer.m
+++ b/sources/HUBViewModelRenderer.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
              completion:(void (^)(void))completionBlock
 {
     __weak __typeof(self) weakSelf = self;
-    void (^renderBlock)() = ^{
+    void (^renderBlock)(void) = ^{
         __strong __typeof(self) strongSelf = weakSelf;
         [strongSelf renderViewModel:viewModel
                    inCollectionView:collectionView
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
      synchronously, or called from either of of the collection view's performBatchUpdates:completion: blocks), I've
      tried to separate that logic out into 2 block methods: layoutBlock and postLayoutBlock.
      */
-    void (^layoutBlock)() = ^{
+    void (^layoutBlock)(void) = ^{
         [layout computeForCollectionViewSize:collectionView.frame.size
                                    viewModel:viewModel
                                         diff:diff
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
     };
 
     __weak __typeof(self) weakSelf = self;
-    void (^postLayoutBlock)() = ^{
+    void (^postLayoutBlock)(void) = ^{
         __strong __typeof(self) strongSelf = weakSelf;
         strongSelf.lastRenderedViewModel = viewModel;
         completionBlock();


### PR DESCRIPTION
[OCLint](http://oclint.org) is another static analysis tool that focuses on reducing complexity, confusion, and redundant code. It has a [ton](http://oclint-docs.readthedocs.io/en/stable/rules/index.html) of rules. This PR knocks out some of the simpler ones.

The tool also handles analyzing [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) and [npath complexity](https://modess.io/npath-complexity-cyclomatic-complexity-explained), which could help identify places that could probably use a refactor or reduction in complexity.

Many of the rules are conventional but could also be useful (method length, line length, class length, etc.)