### PR TITLE
Documentation enhancements

### DIFF
--- a/documentation/Action programming guide.md
+++ b/documentation/Action programming guide.md
@@ -117,8 +117,8 @@ Here's an example where we perform an action in response to a `UIGestureRecogniz
 ```objective-c
 - (void)handleGestureRecognizer:(UIGestureRecognizer *)recognizer
 {
-    HUBIdentifier *actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"myFeature" name:@"myAction"];
-    [self.actionDelegate component:self performActionWithIdentifier:actionIdentifier customData:nil];
+	HUBIdentifier *actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"myFeature" name:@"myAction"];
+	[self.actionPerformer performActionWithIdentifier:actionIdentifier customData:nil];
 }
 ```
 
@@ -137,8 +137,8 @@ First, the component which performs the action when the delete button is tapped:
 
 - (void)handleDeleteButtonTapped
 {
-    HUBIdentifier *actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"delete" name:@"song"];
-    [self.actionDelegate component:self performActionWithIdentifier:actionIdentifier];
+	HUBIdentifier *actionIdentifier = [[HUBIdentifier alloc] initWithNamespace:@"delete" name:@"song"];
+	[self.actionPerformer performActionWithIdentifier:actionIdentifier customData:nil];
 }
 
 @end

--- a/documentation/Layout programming guide.md
+++ b/documentation/Layout programming guide.md
@@ -20,6 +20,11 @@ Each `HUBComponent` has the ability to declare a set of layout traits. These tra
 
 The Hub Framework ships with a standard library of layout traits, but more can easily be added by applications using the framework (by declaring a new `HUBComponentLayoutTrait` constant). It's recommended to keep layout traits global in an application, to be able to create clearly defined rules around layout.
 
+```objective-c
+// extend HUBComponentLayoutTrait with a custom trait
+static HUBComponentLayoutTrait const HUBComponentLayoutTraitLeftMarginOnly = @"leftMarginOnly";
+```
+
 An example of a layout trait is `HUBComponentLayoutTraitCompactWidth`, which is used for components that should have horizontal margin on each side (and not stretch the entire view). The opposite of this trait is `HUBComponentLayoutTraitFullWidth`, which tells the layout manager that no horizontal margin should be added.
 
 So layout traits are a way do describe layout, rather than specifying hard rules or metrics. The advantage of this approach is that components can be completely unaware of each other, while still being laid out in a predictable way.


### PR DESCRIPTION
Simple edits. The Action Programming Guide had an old method, causing confusion when attempting to implement actions in a step-by-step fashion. Action Programming Guide tells new users to extend HUBComponentLayoutTraits but doesn't show how to do it. Added an example.