### PR TITLE
Remove Xcode 7 CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,6 @@ matrix:
     - osx_image: xcode8.3
       rvm: 2.2.5
       env: LINT=YES  RUN_TESTS=YES  RUN_DANGER=YES  BUILD_DEMO_APP=YES  RUN_UI_TESTS=YES  BUILD_LIVE_CLI=YES  UPDATE_DOCUMENTATION=YES
-    # Compatibility job; makes sure the library is buildable by Xcode 7.3.1. The demo app requires
-    # Xcode 8 to build and link so skip it.
-    - osx_image: xcode7.3
-      rvm: 2.2.5
-      env: LINT=YES  RUN_TESTS=YES  RUN_DANGER=NO   BUILD_DEMO_APP=NO   RUN_UI_TESTS=NO   BUILD_LIVE_CLI=NO   UPDATE_DOCUMENTATION=NO
 
 cache: bundler
 


### PR DESCRIPTION
We don’t officially support building with Xcode 7 anymore.

@spotify/objc-dev 