### PR TITLE
Fix non-portable include path

### DIFF
--- a/tests/HUBViewControllerImplementationTests.m
+++ b/tests/HUBViewControllerImplementationTests.m
@@ -27,7 +27,7 @@
 #import "HUBComponentRegistryImplementation.h"
 #import "HUBComponentReusePoolMock.h"
 #import "HUBIdentifier.h"
-#import "HUBJSONSChemaRegistryImplementation.h"
+#import "HUBJSONSchemaRegistryImplementation.h"
 #import "HUBJSONSchemaImplementation.h"
 #import "HUBConnectivityStateResolverMock.h"
 #import "HUBImageLoaderMock.h"


### PR DESCRIPTION
Xcode seems to be ok with non-portable includes when using headermaps (the xcode default behavior). We have some other tooling that builds without header maps and this code generates a warning because of the misspelling.

@rastersize @cerihughes @8W9aG 