### PR TITLE
Fix accidental global variables

### DIFF
--- a/sources/HUBConfig.m
+++ b/sources/HUBConfig.m
@@ -48,8 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation HUBConfig
-HUBComponentRegistryImplementation * _componentRegistry;
-HUBActionRegistryImplementation *_actionRegistry;
+{
+    HUBComponentRegistryImplementation * _componentRegistry;
+    HUBActionRegistryImplementation *_actionRegistry;
+}
 
 - (instancetype)initWithComponentLayoutManager:(id<HUBComponentLayoutManager>)componentLayoutManager
                       componentFallbackHandler:(id<HUBComponentFallbackHandler>)componentFallbackHandler
@@ -92,8 +94,4 @@ HUBActionRegistryImplementation *_actionRegistry;
 
 @end
 
-
-
-
 NS_ASSUME_NONNULL_END
-


### PR DESCRIPTION
I don’t think this class actually works, but having these global variables shadowing ivars can’t possibly help.

@cerihughes 