### PR TITLE
Suppress iOS 10 SDK deprecation warning

### DIFF
--- a/sources/HUBSelectionAction.m
+++ b/sources/HUBSelectionAction.m
@@ -36,8 +36,11 @@
     if (targetURI == nil) {
         return NO;
     }
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return [[UIApplication sharedApplication] openURL:targetURI];
+#pragma clang diagnostic pop
 }
 
 @end


### PR DESCRIPTION
We don’t want to change the deployment target post-deprecation, but we can avoid the visible warning.